### PR TITLE
Use EGS_SimpleAliasTable instead of EGS_AliasTable where appropriate

### DIFF
--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
@@ -48,12 +48,12 @@ EGS_ShapeCollection::EGS_ShapeCollection(const vector<EGS_BaseShape *> &Shapes,
     }
     nshape = n1;
     shapes = new EGS_BaseShape* [nshape];
-    EGS_Float *dum = new EGS_Float [nshape], *p = new EGS_Float [nshape];
+    EGS_Float *p = new EGS_Float [nshape];
     for(int j=0; j<nshape; j++) {
-        shapes[j] = Shapes[j]; shapes[j]->ref(); p[j] = Probs[j]; dum[j] = 1;
+        shapes[j] = Shapes[j]; shapes[j]->ref(); p[j] = Probs[j];
     }
-    table = new EGS_AliasTable(nshape,dum,p,0);
-    delete [] dum; delete [] p;
+    table = new EGS_SimpleAliasTable(nshape,p);
+    delete [] p;
 }
 
 extern "C" {

--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.h
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.h
@@ -106,7 +106,7 @@ public:
         }
     };
     EGS_Vector getPoint(EGS_RandomGenerator *rndm) {
-        int j = table->sampleBin(rndm);
+        int j = table->sample(rndm);
         return shapes[j]->getPoint(rndm);
     };
 
@@ -126,7 +126,7 @@ public:
     void getPointSourceDirection(const EGS_Vector &Xo,
             EGS_RandomGenerator *rndm, EGS_Vector &u, EGS_Float &wt) {
         EGS_Vector xo = T ? Xo*(*T) : Xo;
-        int j = table->sampleBin(rndm);
+        int j = table->sample(rndm);
         shapes[j]->getPointSourceDirection(xo,rndm,u,wt);
         if( T ) T->rotate(u);
     };
@@ -135,7 +135,7 @@ protected:
 
     int            nshape;
     EGS_BaseShape  **shapes;
-    EGS_AliasTable *table;
+    EGS_SimpleAliasTable *table;
 
 };
 

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
@@ -84,7 +84,7 @@ void EGS_SourceCollection::setUp(const vector<EGS_BaseSource *> &S,
     if( prob.size() < nsource ) nsource = prob.size();
     description = "Invalid source collection";
     if( isValid() ) {
-        p = new EGS_Float [nsource]; EGS_Float *dum = new EGS_Float [nsource];
+        p = new EGS_Float [nsource];
         sources = new EGS_BaseSource* [nsource];
         Emax = 0;
         for(int j=0; j<nsource; j++) {
@@ -93,16 +93,15 @@ void EGS_SourceCollection::setUp(const vector<EGS_BaseSource *> &S,
                 if( p[j] < 0 ) egsWarning("EGS_SourceCollection: input "
                      "probability p[%d]=%g is less than zero.\n",j,p[j]);
                 else egsWarning("EGS_SourceCollection: source %d is null\n",j);
-                delete [] p; delete [] dum;
+                delete [] p;
                 for(int i=0; i<j; j++) EGS_Object::deleteObject(sources[i]);
                 delete [] sources; nsource = 0; return;
             }
-            dum[j] = 1; sources[j]->ref();
+            sources[j]->ref();
             EGS_Float e = sources[j]->getEmax();
             if( e > Emax ) Emax = e;
         }
-        table = new EGS_AliasTable(nsource,dum,p,0);
-        delete [] dum;
+        table = new EGS_SimpleAliasTable(nsource,p);
         description = "Source collection";
         last_cases = new EGS_I64 [ nsource ];
         for(int i=0; i<nsource; i++) last_cases[i] = 0;

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
@@ -112,7 +112,7 @@ public:
     EGS_I64 getNextParticle(EGS_RandomGenerator *rndm,
             int &q, int &latch, EGS_Float &E, EGS_Float &wt,
             EGS_Vector &x, EGS_Vector &u) {
-        int j = table->sampleBin(rndm);
+        int j = table->sample(rndm);
         EGS_I64 this_case = sources[j]->getNextParticle(rndm,q,latch,E,wt,x,u);
         count += this_case - last_cases[j];
         last_cases[j] = this_case;
@@ -167,7 +167,7 @@ protected:
 
     int nsource;
     EGS_BaseSource **sources;  //!< The sources in the collection
-    EGS_AliasTable *table;     //!< Alias table for randomly picking a source
+    EGS_SimpleAliasTable *table;     //!< Alias table for randomly picking a source
     EGS_I64        *last_cases;//!< Last case returned from each source
     EGS_Float      *p;         //!< The probabilities
     EGS_Float Emax;            //!< Maximum energy (max of s[j]->getEmax()).


### PR DESCRIPTION
EGS_ShapeCollection and EGS_SourceCollection can both use the simpler and more efficient EGS_SimpleAliasTable instead of EGS_AliasTable.