### PR TITLE
Fix bug in cshrc additions script

### DIFF
--- a/HEN_HOUSE/scripts/egsnrc_cshrc_additions
+++ b/HEN_HOUSE/scripts/egsnrc_cshrc_additions
@@ -53,7 +53,7 @@ endif
 
 # Set dynamic library path
 #
-setenv LD_LIBRARY_PATH "${HEN_HOUSE}egs++/dso/$my_machine:$LD_LIBRARY_PATH"
+setenv LD_LIBRARY_PATH "${HEN_HOUSE}egs++/dso/${my_machine}:$LD_LIBRARY_PATH"
 
 #  Aliases
 #


### PR DESCRIPTION
Variable expansion with a colon after it treats the letters after the colon as modifiers. Wrap the variable in curly braces to avoid a bad modifier error.