### PR TITLE
Fix some egs_advanced_application.cpp compiler warnings

### DIFF
--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -262,13 +262,13 @@ public:
         name(Name), type(1), float_input(val) {};
     /* Character string input type = 3 */
     EGS_TransportProperty(const char *Name, int L, char *val) :
-        name(Name), type(3), char_input(val), len(L) {};
+        name(Name), type(3), len(L), char_input(val)  {};
     /* Character string array input type = 4 */
     EGS_TransportProperty(const char *Name,int L,int N,vector<string> *str):
-        name(Name), type(4), str_v(str), len(L), nitem(N) {};
+        name(Name), str_v(str), type(4), len(L), nitem(N) {};
     /* Real array input type = 5 */
     EGS_TransportProperty(const char *Name,int N,vector<EGS_Float> *f):
-        name(Name), type(5), f_v(f), nitem(N) {};
+        name(Name), f_v(f), type(5), nitem(N) {};
     /* Integer input with allowed values => type = 2 */
     void addOption(const char *opt) {
         options.push_back(opt);
@@ -394,7 +394,7 @@ public:
 #endif
 
 EGS_AdvancedApplication::EGS_AdvancedApplication(int argc, char **argv) :
-    EGS_Application(argc,argv), n_rng_buffer(0), final_job(false), nmed(0), io_flag(0) { }
+    EGS_Application(argc,argv), nmed(0), n_rng_buffer(0), final_job(false), io_flag(0) { }
 
 EGS_AdvancedApplication::~EGS_AdvancedApplication() {
     if (n_rng_buffer > 0) {

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1087,12 +1087,12 @@ extern __extc__ void egsHowfar() {
         return;
     }
     int newmed;
-    EGS_Float tsave = the_epcont->ustep;
     int inew = app->howfar(ireg,
                            EGS_Vector(the_stack->x[np],the_stack->y[np],the_stack->z[np]),
                            EGS_Vector(the_stack->u[np],the_stack->v[np],the_stack->w[np]),
                            the_epcont->ustep,&newmed);
 #ifdef GDEBUG
+    EGS_Float tsave = the_epcont->ustep;
     if (steps_n < MAX_STEP) {
         steps_x[steps_n] =
             EGS_Vector(the_stack->x[np],the_stack->y[np],the_stack->z[np]);


### PR DESCRIPTION
This PR just fixes a couple of out-of-order initialization warnings as well as eliminating an unused variable warning for tsave in egsHowFar (since it's only used in the GDEBUG block).