### PR TITLE
Support for slurm queuing system

### DIFF
--- a/HEN_HOUSE/scripts/batch_options.slurm
+++ b/HEN_HOUSE/scripts/batch_options.slurm
@@ -35,7 +35,7 @@
 # The name of the command used to submit jobs to the queue
 batch_command=sbatch
 
-generic_bo="-n 1"
+generic_bo="-n1"
 
 # Flag to specify where the output from this job should go.
 # If it is not empty, the job output will be send to input_file.eo

--- a/HEN_HOUSE/scripts/batch_options.slurm
+++ b/HEN_HOUSE/scripts/batch_options.slurm
@@ -1,0 +1,84 @@
+
+###############################################################################
+#
+#  EGSnrc scheduler options for Slurm
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Marc-Andre Renaud, 2016
+#
+###############################################################################
+#
+#  Various definitions for job sumbission using Slurm. This file gets sourced
+#  from $HEN_HOUSE/scripts/run_user_code_batch if the environment variable
+#  EGS_BATCH_OPTIONS is set to pbs or 'batch=pbs' is passed as argument.
+#
+###############################################################################
+
+
+# The name of the command used to submit jobs to the queue
+batch_command=sbatch
+
+generic_bo="-n 1"
+
+# Flag to specify where the output from this job should go.
+# If it is not empty, the job output will be send to input_file.eo
+# where input_file is the name of the input file or input_file_wX.eo
+# where X is the job number in the case of a parallel run.
+# If there is no such option (e.g. `at'), just leave it empty.
+#
+output_bo="-o"
+
+# Flag to specify how to name the request.
+# Giving the job request a name is handy as it helps us find it in a long
+# list of running or waiting jobs. The job request will be normally
+# named usercode_inputfile where usercode is the name of the user code
+# and input file the name of the input file.
+# If there is no such option (e.g. `at'), just leave it empty.
+#
+rname_bo="-J"
+
+# Should the batch submission script sleep between jobs ?
+# (only relevant for parallel job submission)
+# If the following is left empty, the script will not sleep.
+# Sleeping time > 0 is only necessary for PBS because PBS is
+# extremely fast in sumbitting jobs but gets confused if many
+# jobs are submitted quickly. A sleep time of 1 second is sufficient
+# on out system,
+#
+batch_sleep_time=1
+
+# Some queueing systems (e.g. PBS) have a limitation on the
+# maximum length of a job name (e.g. for PBS this is 15).
+# The following variable specifies such a limit and the
+# job name is truncated to that length if necessary in the
+# job submission script.
+#
+batch_mnl=100
+
+# The 3 PBS queues that we have here at NRC.
+# Change these if you have defined different queues.
+#
+short_queue="-p short"
+long_queue="-p long"
+user1_queue="-p user1"
+user2_queue="-p user2"
+user3_queue="-p user3"
+
+

--- a/HEN_HOUSE/scripts/batch_options.slurm
+++ b/HEN_HOUSE/scripts/batch_options.slurm
@@ -27,7 +27,7 @@
 #
 #  Various definitions for job sumbission using Slurm. This file gets sourced
 #  from $HEN_HOUSE/scripts/run_user_code_batch if the environment variable
-#  EGS_BATCH_OPTIONS is set to pbs or 'batch=pbs' is passed as argument.
+#  EGS_BATCH_OPTIONS is set to slurm or 'batch=slurm' is passed as argument.
 #
 ###############################################################################
 
@@ -72,7 +72,7 @@ batch_sleep_time=1
 #
 batch_mnl=100
 
-# The 3 PBS queues that we have here at NRC.
+# Set the Slurm partition names used in your cluster.
 # Change these if you have defined different queues.
 #
 short_queue="-p short"

--- a/HEN_HOUSE/scripts/run_user_code_batch
+++ b/HEN_HOUSE/scripts/run_user_code_batch
@@ -445,7 +445,18 @@ if test $n_parallel -gt 0; then
         echo "Executing $the_command using $batch_command"
         echo "batch options: $batch_options $queue $other_args"
     else
-        echo "$the_command" | $batch_command $batch_options $queue $other_args
+        if test $egs_batch_system = "slurm"; then
+            ${batch_command} <<EOF
+#!/bin/sh
+#SBATCH ${generic_bo}
+#SBATCH ${output_bo} ${input_file}_w${job}.eo
+#SBATCH ${rname_bo} j${rname}
+#SBATCH ${queue}
+${the_command}
+EOF
+        else
+            echo "$the_command" | $batch_command $batch_options $queue $other_args
+        fi
     fi
     if test "x$batch_sleep_time" != x; then
         sleep $batch_sleep_time
@@ -471,7 +482,18 @@ else
       echo "Executing $command using $batch_command"
       echo "batch options: $batch_options $queue $other_args"
   else
-      echo "$command" | $batch_command $batch_options $queue $other_args
+      if test $egs_batch_system = "slurm"; then
+          ${batch_command} <<EOF
+#!/bin/sh
+#SBATCH ${generic_bo}
+#SBATCH ${output_bo} ${input_file}.eo
+#SBATCH ${rname_bo} j${rname}
+#SBATCH ${queue}
+${command}
+EOF
+      else
+          echo "$command" | $batch_command $batch_options $queue $other_args
+      fi
   fi
 fi
 exit 0


### PR DESCRIPTION
Hi, I've modified run_user_code_batch to allow job submission with the Slurm queuing system as it's becoming more popular in HPC environments. Let me know if this is of any interest.

Unfortunately, the run_user_code_batch script assumes that jobs can be submitted with

```
echo "$command" | $batch_command $batch_options $queue $other_args
```

which doesn't work with slurm because it assumes that you're going to pipe a bash script

```
sbatch: error: This does not look like a batch script.  The first
sbatch: error: line must start with #! followed by the path to an interpreter.
sbatch: error: For instance: #!/bin/sh
```

My bash-fu is not very strong so maybe there's a way to make it work without resorting to what I did in the pull request (have a special case for slurm alone). Maybe a better option would be to handle slurm separately, similarly to how pbsdsh is handled.
