### PR TITLE
Add missing nrs initializer to egs_isotropic_source constructor

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -290,9 +290,11 @@ void EGS_DoseScoring::reportResults() {
         vector<EGS_Float> massM(nmedia,0);
         int imed = 0;
         for (int ir=0; ir<nreg; ir++) {
+          if(app->isRealRegion(ir)) {
             imed = app->getMedium(ir);
             EGS_Float volume = vol.size() > 1 ? vol[ir]:vol[0];
             massM[imed] += app->getMediumRho(imed)*volume;
+          }
         }
         if (normE==1) {
             egsInformation("\n\n==> Summary of media dosimetry (per particle)\n");

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -40,7 +40,7 @@
 
 EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f), shape(0), geom(0),
-    regions(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
+    regions(0), nrs(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
     gc(IncludeAll) {
     vector<EGS_Float> pos;
     EGS_Input *ishape = input->takeInputItem("shape");

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
@@ -859,7 +859,8 @@ Use `showrgb' for a list of colours available on your system." -font $helvfont -
 }
 
 proc init_pegsless_variables {} {
-global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
+global is_pegsless matfilename nmatmed ninpmed warnnum2 
+global pegsless_on_inp ae ue ap up
 #just initialize a couple of required global variables
 
    set is_pegsless 0
@@ -872,7 +873,6 @@ global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
    set ninpmed 0
    set matfilename {}
 
-   set warnnum1 0
    set warnnum2 0
 
 }


### PR DESCRIPTION
Without the initializer the destructor will access an uninitialized `nrs` variable at line 138 in egs_isotropic_source.h