### PR TITLE
Remove unnecessary warnings in egs_isotropic_source

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -290,9 +290,11 @@ void EGS_DoseScoring::reportResults() {
         vector<EGS_Float> massM(nmedia,0);
         int imed = 0;
         for (int ir=0; ir<nreg; ir++) {
+          if(app->isRealRegion(ir)) {
             imed = app->getMedium(ir);
             EGS_Float volume = vol.size() > 1 ? vol[ir]:vol[0];
             massM[imed] += app->getMediumRho(imed)*volume;
+          }
         }
         if (normE==1) {
             egsInformation("\n\n==> Summary of media dosimetry (per particle)\n");

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -45,7 +45,6 @@ EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
     vector<EGS_Float> pos;
     EGS_Input *ishape = input->takeInputItem("shape");
     if (ishape) {
-        egsWarning("EGS_IsotropicSource: trying to construct the shape\n");
         shape = EGS_BaseShape::createShape(ishape);
         delete ishape;
     }

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -128,7 +128,6 @@ public:
     */
     EGS_IsotropicSource(EGS_Input *, EGS_ObjectFactory *f=0);
     ~EGS_IsotropicSource() {
-        egsWarning("destructing point source\n");
         EGS_Object::deleteObject(shape);
         if (geom) {
             if (!geom->deref()) {

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
@@ -859,7 +859,8 @@ Use `showrgb' for a list of colours available on your system." -font $helvfont -
 }
 
 proc init_pegsless_variables {} {
-global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
+global is_pegsless matfilename nmatmed ninpmed warnnum2 
+global pegsless_on_inp ae ue ap up
 #just initialize a couple of required global variables
 
    set is_pegsless 0
@@ -872,7 +873,6 @@ global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
    set ninpmed 0
    set matfilename {}
 
-   set warnnum1 0
    set warnnum2 0
 
 }


### PR DESCRIPTION
egs_isotropic_source gives warnings when a source is created or destructed. No other source (as far as I can tell) outputs such warnings. I suggest removing them.