### PR TITLE
Add space between value and units in output

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -290,9 +290,11 @@ void EGS_DoseScoring::reportResults() {
         vector<EGS_Float> massM(nmedia,0);
         int imed = 0;
         for (int ir=0; ir<nreg; ir++) {
+          if(app->isRealRegion(ir)) {
             imed = app->getMedium(ir);
             EGS_Float volume = vol.size() > 1 ? vol[ir]:vol[0];
             massM[imed] += app->getMediumRho(imed)*volume;
+          }
         }
         if (normE==1) {
             egsInformation("\n\n==> Summary of media dosimetry (per particle)\n");

--- a/HEN_HOUSE/egs++/egs_run_control.cpp
+++ b/HEN_HOUSE/egs++/egs_run_control.cpp
@@ -667,7 +667,7 @@ int EGS_RunControl::finishSimulation() {
     //egsInformation("Total cpu time for this run: %g seconds (%g hours)\n\n",
     //        cpu_time, cpu_time/3600);
     if (previous_cpu_time > 0)
-        egsInformation("%-40s%.2f (sec.) %.4f(hours)\n",
+        egsInformation("%-40s%.2f (sec.) %.4f (hours)\n",
                        "CPU time including previous runs:",cpu_time+previous_cpu_time,
                        (cpu_time+previous_cpu_time)/3600);
     egsInformation("%-40s%-14g\n","Histories per hour:",3600.*ndone/

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/pegsless_egsnrc.tcl
@@ -859,7 +859,8 @@ Use `showrgb' for a list of colours available on your system." -font $helvfont -
 }
 
 proc init_pegsless_variables {} {
-global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
+global is_pegsless matfilename nmatmed ninpmed warnnum2 
+global pegsless_on_inp ae ue ap up
 #just initialize a couple of required global variables
 
    set is_pegsless 0
@@ -872,7 +873,6 @@ global is_pegsless matfilename nmatmed ninpmed warnnum1 warnnum2
    set ninpmed 0
    set matfilename {}
 
-   set warnnum1 0
    set warnnum2 0
 
 }


### PR DESCRIPTION
A space is missing between the cpu time in hours and its units.