### PR TITLE
Fix egs_alias_table header guard

### DIFF
--- a/HEN_HOUSE/egs++/egs_alias_table.h
+++ b/HEN_HOUSE/egs++/egs_alias_table.h
@@ -35,7 +35,7 @@
  */
 
 #ifndef EGS_ALIAS_TABLE_
-#define EGS_ALIAS_TABLE
+#define EGS_ALIAS_TABLE_
 
 #include "egs_libconfig.h"
 #include "egs_rndm.h"


### PR DESCRIPTION
Unmatched #ifndef / #define header guard pair generates warning on some compilers.