### PR TITLE
Simple format specifier fix for the number of computed histories.

### DIFF
--- a/HEN_HOUSE/egs++/egs_scoring.cpp
+++ b/HEN_HOUSE/egs++/egs_scoring.cpp
@@ -70,7 +70,7 @@ void EGS_ScoringArray::setHistory(EGS_I64 ncase) {
 
 void EGS_ScoringArray::reportResults(double norm, const char *title,
                                      bool relative_error, const char *format) {
-    if (title) egsInformation("\n\n%s for %d particles:\n\n",title,
+    if (title) egsInformation("\n\n%s for %lli particles:\n\n",title,
                                   current_ncase);
     if (current_ncase < 2) {
         egsWarning("EGS_ScoringArray::reportResults: you must run more than 2 "


### PR DESCRIPTION
I believe it is only a problem with the print out of this number and not with the internal format used in the code.