### PR TITLE
Fix pulse height scoring in tutor7pp

### DIFF
--- a/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
+++ b/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
@@ -614,7 +614,7 @@ int Tutor7_Application::startNewShower() {
                 int ireg = ph_regions[j];
                 EGS_Float edep = score->currentScore(ireg);
                 if( edep > 0 ) {
-                    int ibin = (int) (edep/(current_weight*ph_de[j]));
+                    int ibin = min( (int)(edep/(current_weight*ph_de[j])), pheight[j]->bins()-1 );
                     if( ibin >= 0 && ibin < pheight[j]->bins() )
                         pheight[j]->score(ibin,1);
 


### PR DESCRIPTION
Events depositing the maximum particle's energy are not scored in the histogram. As a consequence, large differences are observed in those cases if one compares the energy deposited in a given region calculated from the fraction of energy deposited to the sum over all histogram bins. Now when Emax is deposited in a region, it is scored in the last bin.