### PR TITLE
Fix for clean_after_parallel not properly working

### DIFF
--- a/HEN_HOUSE/scripts/clean_after_parallel
+++ b/HEN_HOUSE/scripts/clean_after_parallel
@@ -135,7 +135,7 @@ then
             p4=1
           fi
 	  #$HEN_HOUSE/pprocess/addphsp $p1 $p2 $p3 $p4
-	  addphsp $p1 $p2 $p3 $p4
+	  addphsp $1 $p1 $p2 $p3 $p4
 	fi
       fi
       ls -l $1_w* |cut -c1-10,15-23,33-120


### PR DESCRIPTION
My suggested attempt to fix issue #72. The script `clean_after_parallel` calls `addphsp` with `addphsp`'s expected inputs and order. Tested using defaults and redefined inputs. 