### PR TITLE
Fix issue #74 (tabulated spectrum)

### DIFF
--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -710,15 +710,17 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
             int err1 = inp->getInput("energies",eners);
             int err2 = inp->getInput("probabilities",probs);
             int err3 = inp->getInput("spectrum mode",mode);      // according to EGSnrc convention
-            if (err3) err3 = inp->getInput("spectrum type",mode);// deprecated
-            if (err3){
+            if (err3) {
+                err3 = inp->getInput("spectrum type",mode);    // deprecated
+            }
+            if (err3) {
                 egsWarning("%s wrong/missing 'mode' input\n",spec_msg1);
                 if (delete_it) {
                     delete inp;
                 }
                 return 0;
             }
-            else{
+            else {
                 if (mode < 0 || mode > 3) {
                     egsWarning("%s unknown spectrum 'mode' %d"
                                " %s\n",spec_msg1,mode,spec_file.c_str());

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -712,7 +712,7 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
             int err3 = inp->getInput("spectrum mode",mode);      // according to EGSnrc convention
             if (err3) err3 = inp->getInput("spectrum type",mode);// deprecated
             if (err3){
-                egsWarning("%s wrong/missing 'type' input\n",spec_msg1);
+                egsWarning("%s wrong/missing 'mode' input\n",spec_msg1);
                 if (delete_it) {
                     delete inp;
                 }
@@ -720,7 +720,7 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
             }
             else{
                 if (mode < 0 || mode > 3) {
-                    egsWarning("%s unknown spectrum type %d in spectrum file"
+                    egsWarning("%s unknown spectrum 'mode' %d"
                                " %s\n",spec_msg1,mode,spec_file.c_str());
                     if (delete_it) {
                         delete inp;
@@ -765,7 +765,7 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
                     for (int j=0; j<nbin1; j++) {
                         x[ibin] = eners[ibin++];// ibin++;
                         f[j] = mode == 0 ? probs[j]/(eners[ibin-1]-eners[ibin-2]) : probs[j];
-                        //egsWarning("%d %d %g\n",j,ibin,x[ibin-1]);
+                        //egsWarning("%d %d %g %g %g\n",j,ibin,x[ibin-1],probs[j],f[j]);
                         if (itype != 0 && ibin > 1) {
                             if (x[ibin-1] <= x[ibin-2]) {
                                 egsWarning("%s energies must be given in "

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -706,11 +706,34 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
         }
         else {
             vector<EGS_Float> eners, probs;
-            int itype=1;
+            int itype=1, mode;
             int err1 = inp->getInput("energies",eners);
             int err2 = inp->getInput("probabilities",probs);
-            int err3 = inp->getInput("spectrum type",itype);
-
+            int err3 = inp->getInput("spectrum mode",mode);      // according to EGSnrc convention
+            if (err3) err3 = inp->getInput("spectrum type",mode);// deprecated
+            if (err3){
+                egsWarning("%s wrong/missing 'type' input\n",spec_msg1);
+                if (delete_it) {
+                    delete inp;
+                }
+                return 0;
+            }
+            else{
+                if (mode < 0 || mode > 3) {
+                    egsWarning("%s unknown spectrum type %d in spectrum file"
+                               " %s\n",spec_msg1,mode,spec_file.c_str());
+                    if (delete_it) {
+                        delete inp;
+                    }
+                    return 0;
+                }
+                if (mode == 2) {
+                    itype = 0;
+                }
+                else if (mode == 3) {
+                    itype = 2;
+                }
+            }
             if (err1 || err2) {
                 if (err1) egsWarning("%s wrong/missing 'energies' input\n",
                                          spec_msg1);
@@ -737,13 +760,12 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
                         ibin = 1;
                         x[0] = eners[0];
                     }
-                    egsWarning("type = %d nbin = %d nbin1 = %d\n",itype,
-                               nbin,nbin1);
+                    //egsWarning("type = %d nbin = %d nbin1 = %d\n",itype,
+                    //           nbin,nbin1);
                     for (int j=0; j<nbin1; j++) {
-                        x[ibin] = eners[ibin];
-                        f[j] = probs[j];
-                        ibin++;
-                        egsWarning("%d %d %g\n",j,ibin,x[ibin-1]);
+                        x[ibin] = eners[ibin++];// ibin++;
+                        f[j] = mode == 0 ? probs[j]/(eners[ibin-1]-eners[ibin-2]) : probs[j];
+                        //egsWarning("%d %d %g\n",j,ibin,x[ibin-1]);
                         if (itype != 0 && ibin > 1) {
                             if (x[ibin-1] <= x[ibin-2]) {
                                 egsWarning("%s energies must be given in "

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -762,11 +762,9 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
                         ibin = 1;
                         x[0] = eners[0];
                     }
-                    //egsWarning("type = %d nbin = %d nbin1 = %d\n",itype,nbin,nbin1);
                     for (int j=0; j<nbin1; j++) {
                         x[ibin] = eners[ibin++];
                         f[j] = mode == 0 ? probs[j]/(eners[ibin-1]-eners[ibin-2]) : probs[j];
-                        //egsWarning("%d %d %g %g %g\n",j,ibin,x[ibin-1],probs[j],f[j]);
                         if (itype != 0 && ibin > 1) {
                             if (x[ibin-1] <= x[ibin-2]) {
                                 egsWarning("%s energies must be given in "

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -711,10 +711,10 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
             int err2 = inp->getInput("probabilities",probs);
             int err3 = inp->getInput("spectrum mode",mode);      // according to EGSnrc convention
             if (err3) {
-                err3 = inp->getInput("spectrum type",mode);    // deprecated
+                err3 = inp->getInput("spectrum type",mode);      // deprecated
             }
             if (err3) {
-                egsWarning("%s wrong/missing 'mode' input\n",spec_msg1);
+                egsWarning("%s wrong/missing 'spectrum mode' input\n",spec_msg1);
                 if (delete_it) {
                     delete inp;
                 }
@@ -762,10 +762,9 @@ EGS_BaseSpectrum *EGS_BaseSpectrum::createSpectrum(EGS_Input *input) {
                         ibin = 1;
                         x[0] = eners[0];
                     }
-                    //egsWarning("type = %d nbin = %d nbin1 = %d\n",itype,
-                    //           nbin,nbin1);
+                    //egsWarning("type = %d nbin = %d nbin1 = %d\n",itype,nbin,nbin1);
                     for (int j=0; j<nbin1; j++) {
-                        x[ibin] = eners[ibin++];// ibin++;
+                        x[ibin] = eners[ibin++];
                         f[j] = mode == 0 ? probs[j]/(eners[ibin-1]-eners[ibin-2]) : probs[j];
                         //egsWarning("%d %d %g %g %g\n",j,ibin,x[ibin-1],probs[j],f[j]);
                         if (itype != 0 && ibin > 1) {


### PR DESCRIPTION
Following the proposed solution in issue #74 here is the actual fix:

- Introduced input key `spectrum mode` for intrinsic definition of a
tabulated spectrum which has the same meaning as the `mode` flag 
in `EGSnrc` spectrum files.
- The input key `spectrum type` is still valid although considered
_deprecated_ from now on.
- Type 3 in EGS_AliasTable has been left untouched, although it 
does _exactly_ the same as type 2. This avoids breaking any
user implementation relying on the existence of type 3.
- Although the documentation was already pointing at an equivalence 
between the `mode` of spectrum files and the `type` of intrinsically 
defined spectra, an update is required to reflect the use of `spectrum mode`
rather than `spectrum type`