### PR TITLE
Fix 67: Fix inconsistent search paths for density correction file.

### DIFF
--- a/HEN_HOUSE/gui/egs_gui/pegs_page.cpp
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.cpp
@@ -48,6 +48,7 @@
 #include "egs_gui_widget.h"
 #include "egs_config_reader.h"
 #include "pegs_runoutput.h"
+#include <iostream>
 
 // #define PP_DEBUG
 
@@ -181,7 +182,7 @@ void EGS_PegsPage::init()
   connect(cancel_button,SIGNAL(clicked()),this,SLOT(stopPegs()));
 
   new_data_file->setChecked(true); cancel_button->setEnabled(false);
-
+  frt_err=false;
   pegs_process = new QProcess;
   connect(pegs_process,SIGNAL(readyReadStandardOutput()),this,SLOT(readPegsStdout()));
   connect(pegs_process,SIGNAL(readyReadStandardError()),this,SLOT(readPegsStderr()));
@@ -297,7 +298,8 @@ void EGS_PegsPage::getDensityFile() {
     composition_table->setItem(j,0,new QTableWidgetItem(QString::fromStdString(element_data[iz-1].symbol)));
     composition_table->setItem(j,1,new QTableWidgetItem(QString("%1").arg(frac)));
   }
-  dc_file->setText(fi.completeBaseName());// same as baseName(true) in Qt3 -- EMH
+  //dc_file->setText(fi.completeBaseName());// same as baseName(true) in Qt3 -- EMH
+   dc_file->setText(fi.absoluteFilePath());
 }
 
 void EGS_PegsPage::newDataFileChecked(bool b) {
@@ -368,8 +370,17 @@ void EGS_PegsPage::startPegs() {
   if( append_to_datafile->isChecked() )
     args << "-a";//pegs_process->addArgument("-a");
   if( dc_icru_check->isChecked() ) {
+    QFileInfo dfi(dc_file->text());
+    if( !dfi.exists() ) {
+      QMessageBox::critical(this,"Error",
+              QString("Density correction file %1 does not exist ?").arg(dc_file->text()),QMessageBox::Ok,0);
+      return;
+    }
     args << "-d";//pegs_process->addArgument("-d");
-    args << dc_file->text();//pegs_process->addArgument();
+    if(dc_file->text().endsWith(".density")) 
+    args << dc_file->text().remove(dc_file->text().lastIndexOf(".density"),8);//pegs_process->addArgument();
+    else 
+    args << dc_file->text();
   }
   //QStringList list = pegs_process->arguments();
 #ifdef PP_DEBUG
@@ -465,6 +476,7 @@ void EGS_PegsPage::readPegsStderr() {
   qDebug("In EGS_PegsPage::readPegsStderr()");
 #endif
   QString tmp = pegs_process->readAllStandardError();
+  frt_err=tmp.contains(QString("Fortran runtime error"));
   run_output->insertText(tmp);
 }
 
@@ -472,7 +484,11 @@ void EGS_PegsPage::pegsFinished() {
 #ifdef PP_DEBUG
   qDebug("In EGS_PegsPage::pegsFinished()");
 #endif
-  if( pegs_process->exitStatus() == 0 ) // QProcess::NormalExit = 0
+  if(frt_err)
+    QMessageBox::critical(this,"Error",
+     QString("PEGS failed with runtime error."),
+      QMessageBox::Ok,0);
+  else if( pegs_process->exitStatus() == 0 ) // QProcess::NormalExit = 0
     QMessageBox::information(this,"PEGS finished","PEGS finished successfuly",
        QMessageBox::Ok);
   else                                  // QProcess::CrashExit = 1

--- a/HEN_HOUSE/gui/egs_gui/pegs_page.h
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.h
@@ -127,5 +127,6 @@ private:
     EGS_ConfigReader *config_reader;
     bool checkFields();
     bool frt_err;
+    bool gasp_err;
 };
 #endif // PEGS_PAGE_H

--- a/HEN_HOUSE/gui/egs_gui/pegs_page.h
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.h
@@ -126,5 +126,6 @@ private:
     int nelem;
     EGS_ConfigReader *config_reader;
     bool checkFields();
+    bool frt_err;
 };
 #endif // PEGS_PAGE_H

--- a/HEN_HOUSE/gui/egs_gui/pegs_runoutput.cpp
+++ b/HEN_HOUSE/gui/egs_gui/pegs_runoutput.cpp
@@ -32,7 +32,7 @@
 #include "pegs_runoutput.h"
 #include <QTextEdit>
 
-#define RO_DEBUG
+//#define RO_DEBUG
 
 void PEGS_RunOutput::hideWindow()
 {

--- a/HEN_HOUSE/pegs4/pegs4.mortran
+++ b/HEN_HOUSE/pegs4/pegs4.mortran
@@ -5647,18 +5647,6 @@ DO i=1,narg-1 [
            open(20,file=fn,status='old'); have_arg = .true.;
            goto :found_density_file:;
        ]
-       fn = $HEN-HOUSE // 'pegs4/density_corrections/elements/' // arg;
-       inquire(file=fn,exist=is_there);
-       IF( is_there ) [
-           open(20,file=fn,status='old'); have_arg = .true.;
-           goto :found_density_file:;
-       ]
-       fn = $HEN-HOUSE // 'pegs4/density_corrections/compounds/' // arg;
-       inquire(file=fn,exist=is_there);
-       IF( is_there ) [
-           open(20,file=fn,status='old'); have_arg = .true.;
-           goto :found_density_file:;
-       ]
        fn = $EGS_HOME // 'pegs4/density_corrections/' // arg;
        inquire(file=fn,exist=is_there);
        IF( is_there ) [
@@ -5672,6 +5660,18 @@ DO i=1,narg-1 [
            goto :found_density_file:;
        ]
        fn = $EGS_HOME // 'pegs4/density_corrections/compounds/' // arg;
+       inquire(file=fn,exist=is_there);
+       IF( is_there ) [
+           open(20,file=fn,status='old'); have_arg = .true.;
+           goto :found_density_file:;
+       ]
+       fn = $HEN-HOUSE // 'pegs4/density_corrections/elements/' // arg;
+       inquire(file=fn,exist=is_there);
+       IF( is_there ) [
+           open(20,file=fn,status='old'); have_arg = .true.;
+           goto :found_density_file:;
+       ]
+       fn = $HEN-HOUSE // 'pegs4/density_corrections/compounds/' // arg;
        inquire(file=fn,exist=is_there);
        IF( is_there ) [
            open(20,file=fn,status='old'); have_arg = .true.;

--- a/HEN_HOUSE/src/get_media_inputs.mortran
+++ b/HEN_HOUSE/src/get_media_inputs.mortran
@@ -1334,65 +1334,51 @@ DO i=1,NMED[
               $WRITE_MEDERR(' cannot be found.');
        ]
     ]
-    ELSE[
+    ELSE [
        density_file=$cstring(density_file)//'.density';
+       "first look in $EGS_HOME/pegs4/density_corrections"
+       tmp_string=$cstring(egs_home) // 'pegs4' // $file_sep //
+                  'density_corrections' // $file_sep // density_file;
+       inquire(file=tmp_string,exist=ex);
+       IF(ex) goto :density_file_found:;
+       tmp_string=$cstring(egs_home) // 'pegs4' // $file_sep //
+                  'density_corrections' // $file_sep // 'elements' //
+                    $file_sep // density_file;
+       inquire(file=tmp_string,exist=ex);
+       IF(ex) goto :density_file_found:;
+       tmp_string=$cstring(egs_home) // 'pegs4' // $file_sep //
+                  'density_corrections' // $file_sep // 'compounds' //
+                    $file_sep // density_file;
+       inquire(file=tmp_string,exist=ex);
+       IF(ex) goto :density_file_found:;
+       "now look in $EGS_HOME/pegs4/density in case directory still there"
        tmp_string=$cstring(egs_home) // 'pegs4' // $file_sep //
                   'density' // $file_sep // density_file;
        inquire(file=tmp_string,exist=ex);
-       IF (~ex) [
-            IF (elements_specified)[
-                "know which directory to look in based on no. of elements"
-                IF (nne_tmp=1) [
-                    tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
-                        'density_corrections' // $file_sep // 'elements' //
-                        $file_sep // density_file;
-                    inquire(file=tmp_string,exist=ex);
-                    IF (~ex) [
-                        $WRITE_MEDERR(' Error: Density correction file',
-                                        density_file);
-                        $WRITE_MEDERR(
-        ' does not exist in $HEN_HOUSE/pegs4/density_corrections/elements',
-        ' or in $EGS_HOME/pegs4/density');
-                    ]
-                ]
-                ELSE [
-                    tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
-                        'density_corrections' // $file_sep // 'compounds' //
-                        $file_sep // density_file;
-                    inquire(file=tmp_string,exist=ex);
-                    IF (~ex) [
-                        $WRITE_MEDERR(' Error: Density correction file',
-                                        density_file);
-                        $WRITE_MEDERR(
-        ' does not exist in $HEN_HOUSE/pegs4/density_corrections/compounds',
-        ' or in $EGS_HOME/pegs4/density');
-                    ]
-                ]
-            ]
-            ELSE [                      "we have to look in both directories"
-                                        "first, look in elements"
-                tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
+       IF(ex) goto :density_file_found:;
+       "now look through $HEN_HOUSE/pegs4/density_corrections"
+       tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
                     'density_corrections' // $file_sep // 'elements' //
                     $file_sep // density_file;
-                inquire(file=tmp_string,exist=ex);
-                IF (~ex) [              "second, look in compounds"
-                    tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
-                        'density_corrections' // $file_sep // 'compounds' //
-                        $file_sep // density_file;
-                    inquire(file=tmp_string,exist=ex);
-                ]
-                IF (~ex) [
-                    $WRITE_MEDERR(' Error: Density correction file',
+       inquire(file=tmp_string,exist=ex);
+       IF(ex) goto :density_file_found:;
+       tmp_string=$cstring(hen_house) // 'pegs4' // $file_sep //
+                    'density_corrections' // $file_sep // 'compounds' //
+                    $file_sep // density_file;
+       inquire(file=tmp_string,exist=ex);
+       IF(ex) goto :density_file_found:;
+       $WRITE_MEDERR(' Error: Density correction file',
                         density_file);
-                    $WRITE_MEDERR(' does not exist in')
-                    $WRITE_MEDERR(
+       $WRITE_MEDERR(' does not exist in');
+       $WRITE_MEDERR(' $EGS_HOME/pegs4/density_corrections, ');
+       $WRITE_MEDERR(' $EGS_HOME/pegs4/density_corrections/elements, ');
+       $WRITE_MEDERR(' $EGS_HOME/pegs4/density_corrections/compounds, ');
+       $WRITE_MEDERR(' $EGS_HOME/pegs4/density, ');
+       $WRITE_MEDERR(
         ' $HEN_HOUSE/pegs4/density_corrections/elements or ');
-                    $WRITE_MEDERR(
-        ' $HEN_HOUSE/pegs4/density_corrections/compounds or ');
-                    $WRITE_MEDERR(
-        ' $EGS_HOME/pegs4/density.');
-                ]
-            ]
+       $WRITE_MEDERR(
+        ' $HEN_HOUSE/pegs4/density_corrections/compounds.');
+       :density_file_found:
         ]
      ]
 
@@ -1499,8 +1485,6 @@ DO i=1,NMED[
          "close the density file"
          close(i_density);
        ]
-    ]
-
 
    "okay, now commit this to the media library"
    IF(elements_specified & rho_specified)[


### PR DESCRIPTION
Consistent search paths and order for density correction files between
pegs4 and codes running in pegsless mode.  Also, changed egs_gui so
that it always calls pegs4 with full density correction file name.
Finally, changed egs_gui so that, on executing pegs4, if the density
correction file is not found, an error dialog pops up.  Order of
search for density correction file is:
1. full pathname
2. $EGS_HOME/pegs4/density_corrections/
3. $EGS_HOME/pegs4/density_corrections/elements
4. $EGS_HOME/pegs4/density_corrections/compounds
[5. $EGS_HOME/pegs4/density/ -- for pegsless to preserve compatibility
with past installations where this directory was created]
5[6]. $HEN_HOUSE/pegs4/density_corrections/elements
6[7]. $HEN_HOUSE/pegs4/density_corrections/compounds