### PR TITLE
Uniform zooming in egs_view

### DIFF
--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -92,14 +92,12 @@ public slots:
     virtual void cameraZoom(int dy);
     virtual void thetaRotation(int Theta);
     virtual void phiRotation(int Phi);
-    virtual void changeDfine(int newdfine);
     virtual void changeAmbientLight(int alight);
     virtual void changeTransparency(int t);
     virtual void moveLightChanged(int toggle);
     virtual void setLightPosition();
     virtual void setLookAt();
     virtual void loadTracksDialog();
-    virtual void setProjectionSize();
     virtual void viewAllMaterials();
     virtual void reportViewSettings(int x, int y);
     virtual void quitApplication();
@@ -126,8 +124,8 @@ private:
     QString filename_tracks;
     int nmed;
     QRgb *m_colors;
-    int dfine_home;
-    int dfine;
+    int zoomlevel_home;
+    int zoomlevel;
     EGS_Float a_light;
     EGS_Float s_phi;
     EGS_Float c_phi;
@@ -135,8 +133,6 @@ private:
     EGS_Float s_theta;
     EGS_Float c_theta;
     EGS_Float theta;
-    EGS_Float projection_scale;
-    EGS_Float projection_m;
     EGS_Float distance;
     EGS_Float size;
     EGS_Vector axesmax;


### PR DESCRIPTION
This changeset adjusts the camera zooming behavior of egs_view. Zooming
is now logarithmic, so that each constant change in zoom input (scrollwheel, etc.)
scales the field of view up or down by the same factor, no matter the current zoom
level. (The exception is an outer bound on the zoom level set to the point where the
FOV is ~60 times wider than the target geometry.) The initial zoom level is still within
a percent or so of the previous initial zoom level.

The zoom rate (i.e., how much a pixel shift with the middle mouse button changes the
FOV width) has been arbitrarily set to `2^(1/48)=1.0145`. This is a middle ground
between the slowest prior zoom rate (`1.0060`) and the fastest (`2.5` [although
occasionally `7.0` happens]).

(Why `2^(1/48)`? Then 24 pixels of change yield an exact doubling/halving in FOV
area. Since 24 is divisible by 1,2,3,4,6, and 8, those with scroll wheel increments
as one of these can easily obtain such an scaling. If `2^(1/48)` is too aggressive,
`2^(1/60)` would be a nice alternative.)