### PR TITLE
Improve CD geometry's howfar

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -508,7 +508,7 @@ public:
                 }
 				// Skip for concave geometries: particles can reenter the CD geometry after leaving.
 				// Check 2. below will catch these cases.
-                else if ((ixnew < 0 && tb <= epsilon) && (bg->isConvex() && g[ibase]->isConvex())) {                         // (a) is true
+                else if ((ixnew < 0 && tb <= epsilon) && (bg->isConvex() && (g[ibase] && g[ibase]->isConvex()))) {                         // (a) is true
                     return ixnew;
                 }
 				// If a particle approaching the geometry sits on a boundary, we look back to see


### PR DESCRIPTION
Two cases are mishandled by the howfar method:

1) A particle is approaching the geometry, but due to round off, ends
up sitting exactly on the boundary. At that point, it will be considered
inside the CD geometry which causes a mismatch with its global region
number. The problem is that the check for condition (b) in the code
fails to catch this case. When the particle sits on the boundary, the
howfar call will set 'tb' to the distance to the next boundary, which
can be much larger than 'epsilon' (and it can also return ixnew < 0
if there is no other CD geometry region along the direction of 'u' 
between the particle and the outside of the CD geometry.) Solution:
call howfar, but in the opposite direction, which should set 'tb' to 0 if
sitting on the boundary.

2) A particle has just left the geometry but is still sitting exactly
on the boundary. This corresponds to condition (a) in the code. The
problem arises with concave geometries. If the particle is sitting on
the boundary and pointing away from the CD geometry, the howfar call
will set 'tb' to 0. But for CD geometries made of concave geometries,
the particle may re-enter the CD geometry on its next step, so we should
instead go to checks 1. and 2.