### PR TITLE
Fix uninitialized values/compiler errors in cones

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -101,7 +101,7 @@ void EGS_ConeStack::addLayer(EGS_Float thick, const vector<EGS_Float> &rtop,
         egsWarning("  --> ignoring layer\n");
         return;
     }
-    if (med_names.size() != this_nr) {
+    if ((int)med_names.size() != this_nr) {
         egsWarning("EGS_ConeStack::addLayer: number of cone radii (%d) is"
                    " different from number of media (%d)\n",this_nr,med_names.size());
         egsWarning("  --> ignoting layer\n");
@@ -306,7 +306,7 @@ extern "C" {
 
             // adjust lable region numbering in each layer
             int count=0;
-            for (int i=0; i<layerLabels.size(); i++) {
+            for (size_t i=0; i<layerLabels.size(); i++) {
                 for (int j=0; j<layerLabels[i]; j++) {
                     g->shiftLabelRegions(count,i);
                     count++;
@@ -436,7 +436,7 @@ extern "C" {
                 int nc=1;
                 if (!err && d.size() > 0) {
                     dist = new EGS_Float [d.size()];
-                    for (int j=0; j<d.size(); j++) {
+                    for (size_t j=0; j<d.size(); j++) {
                         dist[j] = d[j];
                     }
                     nc = 1 + d.size();

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -872,7 +872,7 @@ public:
 
     // hownear
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tc;
+        EGS_Float tc = 1E30;
         if (ireg < 0 || ireg < nc-1) {
             EGS_Vector xp;
             if (ireg < 0) {
@@ -1213,7 +1213,7 @@ public:
     }
 
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tc;
+        EGS_Float tc = 1E30;
         EGS_Vector xp(x-xo);
         EGS_Float aa = xp*a, r2 = xp.length2(), ag;
         //egsWarning("hownear: ireg = %d x = (%g,%g,%g) aa = %g r2 = %g\n",
@@ -1336,8 +1336,8 @@ public:
 
     // constructor (empty cone stack)
     EGS_ConeStack(const EGS_Vector &Xo, const EGS_Vector &A, const string &Name)
-        : xo(Xo), a(A), nl(0), nltot(0), nmax(0), same_Rout(true), Rout(0), Rout2(0),
-          EGS_BaseGeometry(Name) {
+        : EGS_BaseGeometry(Name), xo(Xo), a(A), nl(0), nltot(0), nmax(0), same_Rout(true), Rout(0),
+          Rout2(0) {
         a.normalize();
     }
 
@@ -1667,6 +1667,7 @@ public:
                 // we think we are outside but we just found we are inside.
                 // Hopefully a roundoff problem.
                 EGS_Float tp = 1e30;
+
                 if (up > 0) {
                     dir = 1;
                     tp = (pos[il+1] - xp)/up;
@@ -1674,6 +1675,11 @@ public:
                 else if (up < 0) {
                     dir = -1;
                     tp = (pos[il] - xp)/up;
+                }else{
+                    // prevent compiler from complaining about use of
+                    // uninitialized value of dir (even though tp will
+                    // always be greater than epsilon in this case).
+                    dir = 0;
                 }
                 if (tp < epsilon) {
                     il += dir;
@@ -1815,7 +1821,7 @@ public:
 
     // shiftLabels
     void shiftLabelRegions(const int i, const int index) {
-        for (int k=0; k<labels[i].regions.size(); k++) {
+        for (size_t k=0; k<labels[i].regions.size(); k++) {
             labels[i].regions[k] += index*nmax;
         }
     }


### PR DESCRIPTION
This patch resolves a number of compiler warnings for the egs_cones
geometry.  Most importantly is the change in EGS_ConeSet::hownear to
properly initialize the tc variable. If hownear is called with ireg=0 or
ireg=2*nc then `tc` never gets set and the tco < tc comparison in the
last line of the function will produce undetermined results.