### PR TITLE
Prevent negative distance to exit plane in simple cone

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -390,7 +390,9 @@ public:
                             if (normal) {
                                 *normal = a*(-1);
                             }
-                            t = tt;
+                            // avoid negative distances to the exit plane,
+                            // which may lead to endless loops in CD geometries
+                            t = tt < 0 ? 0 : tt;
                             return -1;
                         }
                     }


### PR DESCRIPTION
Due to floating point errors, the distance to the exit plane of a simple cone can be negative when the particle is: 1) inside the cone; 2) sitting on the exit plane; 3) and leaving the geometry. This leads to endless loops in the howfar of CD geometry, under certain circumstances.