### PR TITLE
Fix various issues with egs_inprz

### DIFF
--- a/HEN_HOUSE/gui/egs_inprz/include/tooltips.h
+++ b/HEN_HOUSE/gui/egs_inprz/include/tooltips.h
@@ -568,10 +568,11 @@ static const char* sources[] = {
                     "\n be deleted from the list."
 
 #define DENSITY_FILE "specify a density correction file which, when applied to calculated cross-sections,"\
-                     "\nresults in agreement with stopping powers published in ICRU37.  The browser"\
-                     "\nstarts in the $HEN_HOUSE/pegs4/density_corrections parent directory and allows"\
-                     "\nyou to enter either the 'compounds' or 'elements' subdirectory."\
-                     "\nOmit the directory path and '.density' extension from the filename."
+                     "\nresults in agreement with stopping powers published in ICRU37.  You can start"\
+                     "\nthe browser in $EGS_HOME/pegs4/density_corrections (the default) or in"\
+                     "\n$HEN_HOUSE/pegs4/density_corrections from either of which you can"\
+                     "\nenter either the 'compounds' or 'elements' subdirectory."\
+                     "\nNote that the file name includes the full directory path."
 
 #define STERNCID "The Sternheimer-Seltzer-Berger ID for the medium.  If this matches the ID in"\
                  "\nan internal lookup table, pre-calculated density effect parameters are applied"\

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
@@ -1114,6 +1114,8 @@ void inputRZImpl::update_MCInputs( const MMCInputs* EGSmc )
       else {
          openErrors += QString(WARNING_KERMA) + "\n";
       }
+      if ( (ifullComboBox->currentText()).toLower() == "pulse height distribution")
+               phdGroupBox->setEnabled( true );
    }
    else if ( usercode != flurznrc ) {// PHOTON REGENERATION
       if ( EGSmc->photreg.toLower() == "yes" ){
@@ -1360,6 +1362,7 @@ void inputRZImpl::update_PEGSLESSParam( const PEGSLESSInputs* EGSpgls)
 
  //set some defaults in the input window for material specified in .egsinp file
  pzRadioButton->setChecked(true);
+ df_egs_homeRadioButton->setChecked(true);
  //qt3to4 -- BW
  //pz_or_rhozTable->horizontalHeader()->setLabel(1,"no. of atoms");
  pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("no. of atoms"));
@@ -1441,6 +1444,7 @@ void inputRZImpl::inpmediumSave( const QString& str)
 {
 
   int ind=inpmediumComboBox->currentIndex();
+  Ppgls->inpmedind=ind;
   if(inpmediumComboBox->currentText()!="define new medium"){
     //note: above allows blanks in medium name...probably not a good idea
     if(ind==Ppgls->ninpmedia) {
@@ -2675,9 +2679,6 @@ void inputRZImpl::update_usercode()
        outoptComboBox->addItem( tr( "long" ) );
 
        outputTip->setTips( out_dos, sizeof out_dos / sizeof(char *));
-
-       if ( (ifullComboBox->currentText()).toLower() == "pulse height distribution")
-	       phdGroupBox->setEnabled( true );
 
        //Q3WhatsThis::add( CSEnhancementGroupBox, CS_ENHANCEMENT_DOSRZNRC  );
        CSEnhancementGroupBox->setWhatsThis(CS_ENHANCEMENT_DOSRZNRC  );

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
@@ -773,7 +773,10 @@ void inputRZImpl::GetDFfile()
    //char s = QDir::separator();
    char s = QDir::separator().toAscii();
    //browse from HEN_HOUSE/pegs4/density_corrections
+   if(df_hen_houseRadioButton->isChecked())
    tmpDir = ironIt(HEN_HOUSE + s + "pegs4" + s + "density_corrections" + s);
+   else
+   tmpDir = ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s);
    QDir d(tmpDir);
    //qt3to4 -- BW
    //QString f = Q3FileDialog::getOpenFileName( this,"",tmpDir, "density correction file (*.density);; all files (*)");
@@ -783,11 +786,14 @@ void inputRZImpl::GetDFfile()
       //HEN_HOUSE/pegs4/data/compounds directories
       if ( (f.indexOf(tmpDir + "elements",0) >=0  || f.indexOf(tmpDir + "compounds",0) >=0 ) &&
            f.indexOf(".density",1)>=0) {
+         //keep entire filename
          //remove directory name
-         f.remove( 0, f.lastIndexOf(s,-1)+1);
+         //f.remove( 0, f.lastIndexOf(s,-1)+1);
          //remove ".density" extension
-         f.remove(f.indexOf(".density",1),8);
+         //f.remove(f.indexOf(".density",1),8);
       }
+      int ind=inpmediumComboBox->currentIndex();
+      Ppgls->inpmedind=ind;
       Ppgls->dffile[Ppgls->inpmedind] = f;
       DFEdit->setText(Ppgls->dffile[Ppgls->inpmedind]);
    }

--- a/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
@@ -40,6 +40,8 @@
 //qt3to4 -- BW
 #include <QTextStream>
 
+#include <qmessagebox>
+
 PEGSLESSInputs::PEGSLESSInputs()
 {
 
@@ -142,7 +144,6 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
        //define defaults
 
        rPEGSLESS->elements[tempint].push_back("");
-       rPEGSLESS->pz_or_rhoz[tempint].push_back("");
        rPEGSLESS->spec_by_pz[tempint]=true;
        rPEGSLESS->isgas[tempint]=false;
 
@@ -151,13 +152,15 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
        if(rPEGSLESS->elements[tempint][0]!="") {
         //see if composition defined
          rPEGSLESS->nelements[tempint]=rPEGSLESS->elements[tempint].size();
+         //initialize composition with blanks
+         for(int i=0; i<rPEGSLESS->nelements[tempint]; i++) rPEGSLESS->pz_or_rhoz[tempint].push_back("");
          rPEGSLESS->pz_or_rhoz[tempint]=getThemAll( codes1[1] , rPEGSLESS->pz_or_rhoz[tempint], rPEGSLESS->errors, p1 );
          if(rPEGSLESS->pz_or_rhoz[tempint][0]=="") {
            rPEGSLESS->pz_or_rhoz[tempint]=getThemAll( codes1[2] , rPEGSLESS->pz_or_rhoz[tempint], rPEGSLESS->errors, p1 );
            if(rPEGSLESS->pz_or_rhoz[tempint][0]!="") rPEGSLESS->spec_by_pz[tempint]=false;
          }
        }
-
+    
        rPEGSLESS->rho[tempint]=getIt( codes1[3] , "", rPEGSLESS->errors, p1 );
        rPEGSLESS->spr[tempint]=getIt( codes1[4] , "restricted total", rPEGSLESS->errors, p1 );
        rPEGSLESS->bc[tempint]=getIt( codes1[5] , "KM", rPEGSLESS->errors, p1 );
@@ -251,7 +254,20 @@ QTextStream & operator << ( QTextStream & t, PEGSLESSInputs * rPEGSLESS )
         if(!rPEGSLESS->spec_by_pz[i]) t << "mass fractions= ";
         else t << "no. of atoms= ";
        }
-       t << rPEGSLESS->pz_or_rhoz[i][j];
+       QString qs_pz_or_rhoz=QString::fromStdString(rPEGSLESS->pz_or_rhoz[i][j]);
+       float fl_pz_or_rhoz=qs_pz_or_rhoz.toFloat();
+       int i_pz_or_rhoz=(int)fl_pz_or_rhoz;
+       if(rPEGSLESS->spec_by_pz[i]){
+           if (fl_pz_or_rhoz-i_pz_or_rhoz>0) {
+             QString error = "Composition of med " + QString::number(i+1) +
+                             " specified by no. of atoms but" +
+                             " non-integer no. input.  Number will" +
+                             " be truncated in .egsinp file.";
+             QMessageBox::warning(0,"Warning",error,1,0,0);
+          }
+          t << i_pz_or_rhoz;
+       }
+       else t << fl_pz_or_rhoz; 
        if(j<rPEGSLESS->nelements[i]-1) t << ",";
        else t << "\n";
      }

--- a/HEN_HOUSE/gui/egs_inprz/ui/inputRZ.ui
+++ b/HEN_HOUSE/gui/egs_inprz/ui/inputRZ.ui
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><ui version="4.0"><comment>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <comment>
 ###############################################################################
 #
 #  EGSnrc user interface for egs_inprz
@@ -28,7 +30,7 @@
 #
 ###############################################################################
 </comment>
-<class>InputRZForm</class>
+ <class>InputRZForm</class>
  <widget class="QWidget" name="InputRZForm">
   <property name="geometry">
    <rect>
@@ -112,6 +114,219 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_17">
+     <item>
+      <widget class="QGroupBox" name="ButtonGroup4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string/>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_15">
+          <item>
+           <widget class="QPushButton" name="ExecuteButton">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>Only enabled if user code compiled, no input errors found and proper pegs data used.</string>
+            </property>
+            <property name="whatsThis">
+             <string>Only enabled if user code compiled, no input errors found and proper pegs data used.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Execute</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+E</string>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="PreviewRZButton">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>preview geometry of an existing input file</string>
+            </property>
+            <property name="whatsThis">
+             <string>preview geometry of an existing input file</string>
+            </property>
+            <property name="text">
+             <string>Pre&amp;viewRZ</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+V</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="PrintButton">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="toolTip">
+             <string>print input file</string>
+            </property>
+            <property name="whatsThis">
+             <string>print input file</string>
+            </property>
+            <property name="text">
+             <string>&amp;Print</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+P</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="compileButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="toolTip">
+             <string>Compile user code</string>
+            </property>
+            <property name="whatsThis">
+             <string>Compile user code</string>
+            </property>
+            <property name="text">
+             <string>&amp;Compile</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+C</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="ConfirmButtonGroup">
+       <property name="title">
+        <string/>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_31">
+        <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_16">
+          <item>
+           <widget class="QPushButton" name="ApplyButton">
+            <property name="toolTip">
+             <string>save to/modify file !</string>
+            </property>
+            <property name="whatsThis">
+             <string>save to/modify file !</string>
+            </property>
+            <property name="text">
+             <string>&amp;Save</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+S</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="CancelButton">
+            <property name="toolTip">
+             <string>close application without saving.</string>
+            </property>
+            <property name="whatsThis">
+             <string>close application without saving.</string>
+            </property>
+            <property name="text">
+             <string>&amp;Exit</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+E</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="HelpButton">
+            <property name="toolTip">
+             <string>shows the user manual with Netscape or Konqueror</string>
+            </property>
+            <property name="whatsThis">
+             <string>shows the user manual with Netscape or Konqueror</string>
+            </property>
+            <property name="text">
+             <string>&amp;Help</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+H</string>
+            </property>
+            <property name="autoDefault">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QPushButton" name="AboutButton">
+            <property name="text">
+             <string>&amp;About</string>
+            </property>
+            <property name="shortcut">
+             <string>Alt+A</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="1" column="0">
     <widget class="QTabWidget" name="TabWidgetRZ">
      <property name="enabled">
@@ -153,7 +368,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>5</number>
      </property>
      <property name="iconSize">
       <size>
@@ -5671,13 +5886,13 @@
        <widget class="QWidget" name="layoutWidget11">
         <property name="geometry">
          <rect>
-          <x>16</x>
-          <y>34</y>
+          <x>18</x>
+          <y>36</y>
           <width>848</width>
-          <height>348</height>
+          <height>353</height>
          </rect>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_19">
+        <layout class="QHBoxLayout" name="horizontalLayout_28">
          <item>
           <layout class="QVBoxLayout" name="verticalLayout_9">
            <item>
@@ -6054,7 +6269,7 @@
           </layout>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_10">
+          <layout class="QVBoxLayout" name="verticalLayout_37">
            <item>
             <spacer name="verticalSpacer_6">
              <property name="orientation">
@@ -6063,7 +6278,7 @@
              <property name="sizeHint" stdset="0">
               <size>
                <width>448</width>
-               <height>32</height>
+               <height>18</height>
               </size>
              </property>
             </spacer>
@@ -6196,16 +6411,66 @@
             </layout>
            </item>
            <item>
-            <layout class="QVBoxLayout">
+            <layout class="QVBoxLayout" name="verticalLayout_35">
              <item>
-              <widget class="QLabel" name="DFLabel">
-               <property name="text">
-                <string>density correction file:</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
+              <layout class="QHBoxLayout" name="horizontalLayout_24">
+               <item>
+                <widget class="QLabel" name="DFLabel">
+                 <property name="text">
+                  <string>density correction file:</string>
+                 </property>
+                 <property name="wordWrap">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="df_searchButtonGroup">
+                 <property name="title">
+                  <string>search in:</string>
+                 </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_10">
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_19">
+                    <item>
+                     <widget class="QRadioButton" name="df_egs_homeRadioButton">
+                      <property name="text">
+                       <string>EGS_HOME</string>
+                      </property>
+                      <attribute name="buttonGroup">
+                       <string notr="true">buttonGroup</string>
+                      </attribute>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="df_hen_houseRadioButton">
+                      <property name="text">
+                       <string>HEN_HOUSE</string>
+                      </property>
+                      <attribute name="buttonGroup">
+                       <string notr="true">buttonGroup</string>
+                      </attribute>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+              </layout>
              </item>
              <item>
               <layout class="QHBoxLayout">
@@ -6313,7 +6578,7 @@
              <property name="sizeHint" stdset="0">
               <size>
                <width>448</width>
-               <height>52</height>
+               <height>18</height>
               </size>
              </property>
             </spacer>
@@ -11246,219 +11511,6 @@
      </widget>
     </widget>
    </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_17">
-     <item>
-      <widget class="QGroupBox" name="ButtonGroup4">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="title">
-        <string/>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_15">
-          <item>
-           <widget class="QPushButton" name="ExecuteButton">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="toolTip">
-             <string>Only enabled if user code compiled, no input errors found and proper pegs data used.</string>
-            </property>
-            <property name="whatsThis">
-             <string>Only enabled if user code compiled, no input errors found and proper pegs data used.</string>
-            </property>
-            <property name="text">
-             <string>&amp;Execute</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+E</string>
-            </property>
-            <property name="checked">
-             <bool>false</bool>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="PreviewRZButton">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>preview geometry of an existing input file</string>
-            </property>
-            <property name="whatsThis">
-             <string>preview geometry of an existing input file</string>
-            </property>
-            <property name="text">
-             <string>Pre&amp;viewRZ</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+V</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="PrintButton">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="toolTip">
-             <string>print input file</string>
-            </property>
-            <property name="whatsThis">
-             <string>print input file</string>
-            </property>
-            <property name="text">
-             <string>&amp;Print</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+P</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="compileButton">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="toolTip">
-             <string>Compile user code</string>
-            </property>
-            <property name="whatsThis">
-             <string>Compile user code</string>
-            </property>
-            <property name="text">
-             <string>&amp;Compile</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+C</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QGroupBox" name="ConfirmButtonGroup">
-       <property name="title">
-        <string/>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_31">
-        <item>
-         <layout class="QHBoxLayout" name="horizontalLayout_16">
-          <item>
-           <widget class="QPushButton" name="ApplyButton">
-            <property name="toolTip">
-             <string>save to/modify file !</string>
-            </property>
-            <property name="whatsThis">
-             <string>save to/modify file !</string>
-            </property>
-            <property name="text">
-             <string>&amp;Save</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+S</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="CancelButton">
-            <property name="toolTip">
-             <string>close application without saving.</string>
-            </property>
-            <property name="whatsThis">
-             <string>close application without saving.</string>
-            </property>
-            <property name="text">
-             <string>&amp;Exit</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+E</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="HelpButton">
-            <property name="toolTip">
-             <string>shows the user manual with Netscape or Konqueror</string>
-            </property>
-            <property name="whatsThis">
-             <string>shows the user manual with Netscape or Konqueror</string>
-            </property>
-            <property name="text">
-             <string>&amp;Help</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+H</string>
-            </property>
-            <property name="autoDefault">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QPushButton" name="AboutButton">
-            <property name="text">
-             <string>&amp;About</string>
-            </property>
-            <property name="shortcut">
-             <string>Alt+A</string>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
@@ -12844,4 +12896,7 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
Fixes included:
1. Elimination of segmentation fault when browsing density
   correction files in pegless media def.
2. Truncation of float values to int when saving no. of
   atoms in pegsless media def.
3. Proper enabling of energy table when dosrznrc .egsinp file
   specifies a pulse height distribution calculation
4. Ability to browse from EGS_HOME and HEN_HOUSE for
   density correction files in pegsless media def.