### PR TITLE
Set is_convex to false for concave conestacks

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -135,6 +135,7 @@ void EGS_ConeStack::addLayer(EGS_Float thick, const vector<EGS_Float> &rtop,
         Rout2 = Rout*Rout;
         if (fabs(rtop[this_nr-1]-Rout) > 1e-5) {
             same_Rout = false;
+            is_convex = false;
         }
     }
 
@@ -151,9 +152,11 @@ void EGS_ConeStack::addLayer(EGS_Float thick, const vector<EGS_Float> &rtop,
         if (ir == this_nr-1) {
             if (fabs(rbottom[this_nr-1]-Rout) > 1e-5) {
                 same_Rout = false;
+                is_convex = false;
             }
             if (fabs(Rtop-Rout) > 1e-5) {
                 same_Rout = false;
+                is_convex = false;
             }
         }
     }


### PR DESCRIPTION
Conestacks with multiple layers whose outer radii are different are concave geometries. To reduce geometry errors when conestacks are inscribed in CD geometries, the is_convex flag should be explicitly set to 'false' when appropriate.

Along with pull request #87, this fixes all non-overlapping cases of issues #28 and #31. The issue was not a particle near a corner, as an inspection in egs_view revealed. Instead, when a particle exited, then re-entered the conestack in one step, errors were prone to occur. See screenshot below, along with a screenshot after the fixes (this one and #87) are applied.
![conestack_inscribed_in_cd](https://cloud.githubusercontent.com/assets/1675666/15524984/3e4db124-21f4-11e6-800d-750f731fce25.png)
![fixed](https://cloud.githubusercontent.com/assets/1675666/15524985/42a1ea24-21f4-11e6-90cf-33ff280bf2ae.png)

 