### PR TITLE
Allow negative z-axis vector as a rotation vector

### DIFF
--- a/HEN_HOUSE/egs++/egs_transformations.h
+++ b/HEN_HOUSE/egs++/egs_transformations.h
@@ -159,6 +159,11 @@ public:
             register EGS_Float sint = -sinz/norm;
             *this = rotY(cost,sint)*rotZ(cphi,sphi);
         }
+        else if (v.z < 0.) {
+            // v along negative z is degenerate: a rotation of pi around any axis in the
+            // xy plane satisfies the condition; we pick the x axis
+            *this = rotX(M_PI);
+        }
         else { // v is along the z-axis => matrix is the unit transformation
             rxx = 1;
             rxy = 0;


### PR DESCRIPTION
The description of the 'rotation vector' input of affine transforms
specifies that it "defines a rotation which, when applied to the 3D
vector defined by the input, transforms it into a vector along the
positive z-axis". Thus, it's natural to input:

'rotation vector = 0, 0, -1'

in order to flip an object 180 degrees along the z-axis (i.e., by
rotating 180 degrees around the x-axis or around the y-axis.)

This commit defines a rotation of 180 degrees around the x-axis when
a vector pointing along the negative z-axis is input as the 'rotation
vector'.