### PR TITLE
Fix #8: update transport parameter description

### DIFF
--- a/HEN_HOUSE/doc/src/pirs701-egsnrc/inputs/transport_parameters.tex
+++ b/HEN_HOUSE/doc/src/pirs701-egsnrc/inputs/transport_parameters.tex
@@ -28,14 +28,14 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 
-\index{ECUT} 
+\index{ECUT}
 \begin{verbatim}
        Global ECUT=     Global (in all regions) electron transport cut
                         off energy (in MeV). If this imput is missing,
                         AE(medium) will be used.
                         [ ECUT ]
 \end{verbatim}
-\index{PCUT} 
+\index{PCUT}
 \begin{verbatim}
        Global PCUT=     Global (in all regions) photon transport cut
                         off energy (in MeV). If this imput is missing,
@@ -62,7 +62,7 @@
                         the defualt is 0.25 (25%).
                         [ ESTEPE ]
 \end{verbatim}
-\index{XImax} 
+\index{XImax}
 \begin{verbatim}
        XImax=           Maximum first elastic scattering moment per step.
                         Default is 0.5, NEVER use value greater than 1 as
@@ -122,17 +122,17 @@
                         Turns off/on spin effects for electron elastic
                         scattering. Spin On is ABSOLUTELY necessary for
                         good backscattering calculations. Will make a
-                        difference even in `well conditioned' situations 
-                        (e.g. depth dose curves for RTP energy range 
+                        difference even in `well conditioned' situations
+                        (e.g. depth dose curves for RTP energy range
                         electrons).
                         [ spin_effects ]
 \end{verbatim}
 \index{brems angular sampling}
 \index{IBRDST}
 \begin{verbatim}
-       Brems angular sampling= Simple, KM, default is KM 
+       Brems angular sampling= Simple, KM, default is KM
                         If Simple, use only the leading term of the Koch-Motz
-                        distribution to determine the emission angle of 
+                        distribution to determine the emission angle of
                         bremsstrahlung photons. If On, complete
                         modified Koch-Motz 2BS is used (modifications
                         concern proper handling of kinematics at low energies,
@@ -146,7 +146,7 @@
                         If BH is selected, the Bethe-Heitler bremsstrahlung
                         cross sections (Coulomb corrected above 50 MeV)
                         will be used. If NIST is selected, the NIST brems
-                        cross section data base (which is the basis for 
+                        cross section data base (which is the basis for
                         the ICRU radiative stopping powers) will be employed.
                         Differences are negligible for E > ,say, 10 MeV,
                         but significant in the keV energy range. If NRC is
@@ -154,8 +154,8 @@
                         be used, which is a version of the NIST data base
                         with corrected electron-electron brems contributions
                         (corrections to the NIST data is typically only
-                        significant for low values of the atomic number Z 
-                        and for k/T < 0.005). 
+                        significant for low values of the atomic number Z
+                        and for k/T < 0.005).
                         [ ibr_nist ]
 \end{verbatim}
 \index{triplet production}
@@ -170,13 +170,15 @@
 \index{bound Compton scattering}
 \index{IBCMP}
 \begin{verbatim}
-       Bound Compton scattering=  On (default), Off or Simple
+       Bound Compton scattering=  On, Off, Simple or norej (default)
                         If Off, Compton scattering will be treated with
                         Klein-Nishina, with On Compton scattering is
-                        treated in the Impulse approximation. 
-                        With Simple, the impulse approximation incoherent 
+                        treated in the Impulse approximation.
+                        With Simple, the impulse approximation incoherent
                         scattering function will be used (i.e., no Doppler
-                        broadenning). 
+                        broadenning). With norej the actual total bound
+                        Compton cross section is used and there are no
+                        rejections at run time.
                         Make sure to turn on for low energy applications,
                         not necessary above, say, 1 MeV.
                         [ IBCMP ]
@@ -189,8 +191,8 @@
                         Equations are based on original Brown & Feynman
                         equations (Phys. Rev. 85, p 231--1952).  Requires
                         a change to the user codes Makefile to include
-                        $(EGS_SOURCEDIR)rad_compton1.mortran in the 
-                        SOURCES (just before 
+                        $(EGS_SOURCEDIR)rad_compton1.mortran in the
+                        SOURCES (just before
                         $(EGS_SOURCEDIR)get_inputs.mortran).
                         [ radc_flag ]
 \end{verbatim}
@@ -198,13 +200,18 @@
 \index{eii\_flag}
 \begin{verbatim}
        Electron Impact Ionization= Off (default), On, casnati, kolbenstvedt,
-                        gryzinski.  If set to On, then use Kawrakow's theory
-                        to derive EII cross-sections.  If set to casnati, then
-                        use the cross-sections of Casnati (contained in the
-                        file ($HEN_HOUSE/data/eii_casnati.data).  Similar for
-                        kolbenstvedt and gryzinski. This is only of interest 
-                        in keV X-ray calculations.
-                        [ eii_flag ]
+                        gryzinski or penelope.  If set to On or ik, then
+                        use Kawrakow's theory to derive EII cross-sections.
+                        If set to casnati, then use the cross-sections of
+                        Casnati (from file $HEN_HOUSE/data/eii_casnati.data).
+                        Similar for kolbenstvedt, gryzinski and penelope.
+                        This is only of interest in kV X-ray calculations.
+                        Note that the user can supply their own EII
+                        cross-section data as well. The requirement is that
+                        the file eii_suffix.data exists in the $HEN_HOUSE/data
+                        directory, where suffix is the name specified.
+                        Entry is case-sensitive except for Off, On or ik.
+                        [ eii_flag, eii_xfile ]
 \end{verbatim}
 \index{pair angular sampling}
 \index{IPRDST}
@@ -217,7 +224,7 @@
                         (this is sufficient for most applications),
                         KM (comes from Koch and Motz) turns on using 2BS
                         from the article by Koch and Motz.  Uniform
-                        Default is Simple, make sure you always use 
+                        Default is Simple, make sure you always use
                         Simple or KM
                         [ IPRDST ]
 \end{verbatim}
@@ -230,25 +237,26 @@
                         (in file $HEN_HOUSE/data/pair_nrc1.data).  Only
                         of interest at low energies, where the NRC cross-
                         sections take into account the assymmetry in the
-                        positron-electron energy distribution. 
+                        positron-electron energy distribution.
                         [ pair_nrc ]
 \end{verbatim}
 \index{photon cross sections}
 \index{photon\_xsections}
 \begin{verbatim}
-       Photon cross sections= Photon cross-section data.  Current options are 
+       Photon cross sections= Photon cross-section data.  Current options are
                         si (Storm-Israel--the default), epdl (Evaluated Photon
                         Data Library), and xcom.  Allows the user to use photon
                         cross-sections other than the default PEGS4 (Storm-
-                        Israel) values.  Note that the user can supply their 
-                        own cross-section data as well.  The requirement is 
-                        that the files 
-                        photon_xsections_photo.data, 
+                        Israel) values.  Note that the user can supply their
+                        own cross-section data as well.  The requirement is
+                        that the files
+                        photon_xsections_photo.data,
                         photon_xsections_pair.data,
-                        photon_xsections_triplet.data, and 
+                        photon_xsections_triplet.data, and
                         photon_xsections_rayleigh.data exist in the
                         $HEN_HOUSE/data directory, where photon_xsections
                         is the name specified.
+                        Entry is case-sensitive except for the pegs4 option.
                         [ photon_xsections ]
 \end{verbatim}
 \index{photon cross sections!output}
@@ -257,7 +265,7 @@
        Photon cross-sections output= Off (default) or On.  If On, then
                         a file $EGS_HOME/user_code/inputfile.xsections is
                         output containing photon cross-section data used.
-                        [ xsec_out ] 
+                        [ xsec_out ]
 \end{verbatim}
 \index{compton cross sections}
 \index{comp\_xsections}
@@ -272,9 +280,23 @@
                         of any user-supplied data) is compton_sigma.data.
                         [ comp_xsections ]
 \end{verbatim}
+\index{Rayleigh scattering}
+\index{Rayleigh scattering!custom form factors}
+\index{IRAYLR}
+\begin{verbatim}
+       Rayleigh scattering= Off, On, custom
+                        If On, turned on coherent (Rayleigh) scattering.
+                        Default is Off. Should be turned on for low energy
+                        applications. If custom, user must provide media names
+                        and form factor files for each desired medium. The
+                        rest of the media use the default atomic form factors.
+                        Not set to On by default for historical reasons since
+                        a PEGS4 data set is not required anymore.
+                        [ IRAYLR ]
+\end{verbatim}
 \index{iray\_ff\_media}
 \begin{verbatim}
-       ff media names = A list of media names (must match media found in 
+       ff media names = A list of media names (must match media found in
                         PEGS4 data file) for which the user is going to
                         provide custom Rayleigh form factor data.
                         [ iray_ff_media($MXMED) ]
@@ -283,12 +305,12 @@
 \begin{verbatim}
        ff file names = A list of names of files containing the Rayleigh
                        form factor data for the media specified by
-                       the ff media names = input above.  Full directory 
+                       the ff media names = input above.  Full directory
                        paths must be given for all files, and for each medium
-                       specified, iray_ff_media(i), there must be a 
+                       specified, iray_ff_media(i), there must be a
                        corresponding file name, iray_ff_file(i).  For
-                       example files, see the directory 
-                       $HEN_HOUSE/data/molecular_form_factors. 
+                       example files, see the directory
+                       $HEN_HOUSE/data/molecular_form_factors.
                        [ iray_ff_file($MXMED) ]
 \end{verbatim}
 \index{photoelectron angular sampling}
@@ -309,17 +331,6 @@
                         Default is On
                         [ IPHTER ]
 \end{verbatim}
-\index{Rayleigh scattering}
-\index{Rayleigh scattering!custom form factors}
-\index{IRAYLR}
-\begin{verbatim}
-       Rayleigh scattering= Off, On, custom
-                        If On, turned on coherent (Rayleigh) scattering.
-                        Default is Off. Should be turned on for low energy
-                        applications. Not set to On by default because 
-                        On requires a special PEGS4 data set
-                        [ IRAYLR ]
-\end{verbatim}
 \index{atomic relaxations}
 \index{IEDGFL}
 \begin{verbatim}
@@ -338,8 +349,8 @@
 \end{verbatim}
 
 \noindent
-Atomic relaxations, Rayleigh scattering, Photoelectron angular sampling 
-and Bound Compton scattering can also be turned On/Off on a 
+Atomic relaxations, Rayleigh scattering, Photoelectron angular sampling
+and Bound Compton scattering can also be turned On/Off on a
 region-by-region basis. An example for Atomic relaxations on a region-
 by-region basis is:
 
@@ -363,7 +374,7 @@ Then define the regions in which you want the feature to be turned on:
        PE sampling start region=
        PE sampling stop region=
 \end{verbatim}
-each followed by a list of one or more start and stop regions 
+each followed by a list of one or more start and stop regions
 separated by commas. Example:
 \begin{verbatim}
         Atomic relaxations= On in Regions
@@ -377,14 +388,14 @@ region number and ignored if
 \verb+start region < 1+ or \verb+stop_region > $MXREG+ or
 \verb+start region > stop region+.
 
-\verb+ECUT+, \verb+PCUT+ and \verb+SMAX+ can also be set on a 
+\verb+ECUT+, \verb+PCUT+ and \verb+SMAX+ can also be set on a
 region-by-region basis. To do so, include in the input file
 \begin{verbatim}
          Set XXXX=              f_value1, f_value2, ...
          Set XXXX start region= i_value1, i_value2, ...
          Set XXXX stop region=  j_value1, j_value2, ...
 \end{verbatim}
-where \verb+XXXX+ is \verb+ECUT+, \verb+PCUT+ or \verb+SMAX+, 
-\verb+f_value1+, \verb+f_value2+,... 
-are the desired values for \verb+XXXX+ and \verb+i_value_i+ and 
+where \verb+XXXX+ is \verb+ECUT+, \verb+PCUT+ or \verb+SMAX+,
+\verb+f_value1+, \verb+f_value2+,...
+are the desired values for \verb+XXXX+ and \verb+i_value_i+ and
 \verb+j_value_i+ are the start and stop regions.

--- a/HEN_HOUSE/doc/src/pirs702-egsnrc-codes/inputs/transport_parameters.tex
+++ b/HEN_HOUSE/doc/src/pirs702-egsnrc-codes/inputs/transport_parameters.tex
@@ -193,7 +193,7 @@
                         equations (Phys. Rev. 85, p 231--1952).  Requires
                         a change to the user codes Makefile to include
                         $(EGS_SOURCEDIR)rad_compton1.mortran in the
-                        SOURCES (just before 
+                        SOURCES (just before
                         $(EGS_SOURCEDIR)get_inputs.mortran).
                         [ radc_flag ]
 \end{verbatim}
@@ -205,7 +205,7 @@
                         gryzinski or penelope.  If set to On or ik, then
                         use Kawrakow's theory to derive EII cross-sections.
                         If set to casnati, then use the cross-sections of
-                        Casnati (from file ($HEN_HOUSE/data/eii_casnati.data).
+                        Casnati (from file $HEN_HOUSE/data/eii_casnati.data).
                         Similar for kolbenstvedt, gryzinski and penelope.
                         This is only of interest in kV X-ray calculations.
                         Note that the user can supply their own EII


### PR DESCRIPTION
@mchamberland pointed out that the pirs701 file `transport_parameters.tex` had not been updated to reflect the change of the Bound Compton scattering default value to `norej`. Update the file in this regard, and update a couple of other bits according the pirs702 version of `transport_parameters.tex`.