### PR TITLE
Fix egs_polygon_shape number of triangle bugs

### DIFF
--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
@@ -87,7 +87,7 @@ EGS_PolygonShape::EGS_PolygonShape(const vector<EGS_Float> &points,
     }
     EGS_2DPolygon pol(p1);
     int ntr = 0;
-    triangle = new EGS_TriangleShape* [n-3];
+    triangle = new EGS_TriangleShape* [n-2];
     np = n;
     EGS_Float p_tmp[6];
     while (np > 3) {

--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.h
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.h
@@ -122,7 +122,7 @@ public:
                      EGS_ObjectFactory *f=0);
     ~EGS_PolygonShape() {
         if (n > 0) {
-            for (int j=0; j<n; j++) {
+            for (int j=0; j<n-2; j++) {
                 delete triangle[j];
             }
             delete [] triangle;


### PR DESCRIPTION
The number of triangles required to span a regular polygon defined by N points is N-2 not N-3 so not enought memory was being allocated.  This has been corrected and resolves #115.

The destructor was also trying to delete N triangles rather than N - 2 which resolves #114 
