### PR TITLE
Implement user-defined boundary tolerance in geometry objects

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -387,7 +387,7 @@ extern "C" void __list_geometries() {
 
 EGS_BaseGeometry::EGS_BaseGeometry(const string &Name) : nreg(0), name(Name),
     med(-1), region_media(0), nref(0), debug(false), is_convex(true),
-    has_rho_scaling(false), rhor(0), bproperty(0), bp_array(0) {
+    boundaryTolerance(1e-10), has_rho_scaling(false), rhor(0), bproperty(0), bp_array(0) {
     if (!egs_geometries.size()) {
         egs_geometries.addList(new EGS_GeometryPrivate);
     }
@@ -634,6 +634,15 @@ void EGS_BaseGeometry::setName(EGS_Input *i) {
             }
         }
     }
+}
+
+void EGS_BaseGeometry::setBoundaryTolerance(EGS_Input *i) {
+    int err = i->getInput("boundary tolerance", boundaryTolerance);
+    delete i;
+    if (err) {
+        egsWarning("EGS_BaseGeometry::setBoundaryTolerance(): error while reading 'boundary tolerance' input\n");
+    }
+
 }
 
 void EGS_BaseGeometry::printInfo() const {

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -274,12 +274,6 @@ static char buf_unique[32];
 
 int EGS_BaseGeometry::error_flag = 0;
 
-#ifdef SINGLE
-    EGS_Float EGS_BaseGeometry::epsilon = 1e-5;
-#else
-    EGS_Float EGS_BaseGeometry::epsilon = 1e-7;
-#endif
-
 #ifndef SKIP_DOXYGEN
 EGS_BaseGeometry *EGS_GeometryPrivate::createSingleGeometry(EGS_Input *i) {
     string libname;
@@ -638,11 +632,9 @@ void EGS_BaseGeometry::setName(EGS_Input *i) {
 
 void EGS_BaseGeometry::setBoundaryTolerance(EGS_Input *i) {
     int err = i->getInput("boundary tolerance", boundaryTolerance);
-    delete i;
-    if (err) {
+    if (err > 0) {
         egsWarning("EGS_BaseGeometry::setBoundaryTolerance(): error while reading 'boundary tolerance' input\n");
     }
-
 }
 
 void EGS_BaseGeometry::printInfo() const {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -520,6 +520,16 @@ public:
      */
     void   setName(EGS_Input *inp);
 
+    /*! \brief Set the value of the boundary tolerance from the input \a inp.
+     
+     This method looks for a key <code>tolerance</code> in the input
+     pointed to by \a inp and sets the boundary tolerance of the geometry
+     to the value of the <code>tolerance</code> key. Derived geometry classes should
+     call this function to set their boundary tolerance from the input provided to
+     the geometry creation function.
+     */
+    void    setBoundaryTolerance(EGS_Input *inp);
+    
     /*! \brief Is the boolean property \a prop set for region \a ireg ?
      */
     virtual bool hasBooleanProperty(int ireg, EGS_BPType prop) const {
@@ -616,12 +626,9 @@ public:
         error_flag = 0;
     };
 
-    static void setBoundaryTolerance(EGS_Float btol) {
-        epsilon = btol;
-    };
-
-    static EGS_Float getBoundaryTolerance() {
-        return epsilon;
+    /*! \brief Get the value of the boundary tolerance */
+    EGS_Float getBoundaryTolerance() {
+        return boundaryTolerance;
     };
 
     /*! \brief Get the list of all regions labeled with \a str */
@@ -732,7 +739,7 @@ protected:
     EGS_BPType   *bp_array;
 
     /*! \brief Boundary tolerance for geometries that need it */
-    static EGS_Float epsilon;
+    EGS_Float boundaryTolerance;
 
     /*! \brief Set to non-zero status if a geometry problem is encountered */
     static int       error_flag;

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -529,6 +529,12 @@ public:
      the geometry creation function.
      */
     void    setBoundaryTolerance(EGS_Input *inp);
+
+    /*! \brief Set the value of the boundary tolerance from argument.
+     */
+    void    setBoundaryTolerance(EGS_Float tol) {
+        boundaryTolerance = tol;
+    }
     
     /*! \brief Is the boolean property \a prop set for region \a ireg ?
      */

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -86,6 +86,7 @@ extern "C" {
         result->setName(input);
         result->setMedia(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -84,9 +84,9 @@ extern "C" {
             delete t;
         }
         result->setName(input);
+        result->setBoundaryTolerance(input);
         result->setMedia(input);
         result->setLabels(input);
-        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -238,8 +238,8 @@ extern "C" {
         EGS_BaseGeometry *result = new EGS_CDGeometry(g,G,"",indexing);
         delete [] G;
         result->setName(input);
-        result->setLabels(input);
         result->setBoundaryTolerance(input);
+        result->setLabels(input);
         return result;
 
     }

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -239,6 +239,7 @@ extern "C" {
         delete [] G;
         result->setName(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
 
     }

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -495,8 +495,8 @@ public:
                 tb = 1e30;
                 int ixnew = howfar(ixold,x,u,tb,0,pn);
                 // Enters geometry and at a boundary or very close to one.
-                //if( ixnew_pos >= 0 && ixnew_neg < 0 && tb_neg <= epsilon && tb_pos <= epsilon) {
-                if (ixnew >= 0 && tb <= epsilon) {                             // (b) is true
+                //if( ixnew_pos >= 0 && ixnew_neg < 0 && tb_neg <= boundaryTolerance && tb_pos <= boundaryTolerance) {
+                if (ixnew >= 0 && tb <= boundaryTolerance) {                             // (b) is true
                     t = 0;
                     if (newmed) *newmed = g[ibase] ? g[ibase]->medium(icd) :
                                               bg->medium(ibase);
@@ -506,7 +506,7 @@ public:
                     }
                     return ixold;
                 }
-                else if (ixnew < 0 && tb <= epsilon) {                         // (a) is true
+                else if (ixnew < 0 && tb <= boundaryTolerance) {                         // (a) is true
                     return ixnew;
                 }
                 //***********************************************************************
@@ -516,7 +516,7 @@ public:
                 EGS_Float t1=1e30, t2 = 1e30;
                 int ibase_n, ic_n=0;
                 ibase_n = bg->howfar(ibase,x,u,t1);
-                if (ibase_n < 0 && t1 < 1e-4) {
+                if (ibase_n < 0 && t1 < boundaryTolerance) {
                     // Yes we do => we assume that it was a roundoff problem
                     // and in reality the particle was outside the base geometry.
                     // We then check if it will enter the base geometry.
@@ -539,7 +539,7 @@ public:
                 // distance.
                 if (g[ibase]) {
                     ic_n = g[ibase]->howfar(icd,x,u,t2);
-                    if (ic_n < 0 && t2 < 1e-4) {
+                    if (ic_n < 0 && t2 < boundaryTolerance) {
                         // Yes we do => we assume that it was a roundoff problem
                         // and in reality the particle was outside the inscribed geometry.
                         // We move to the boundary and check again the base geometry.
@@ -562,7 +562,7 @@ public:
                         goto do_checks;
                     }
                 }
-                if (t1 < 1e-4 && ibase_n >= 0 && g[ibase_n]) {
+                if (t1 < boundaryTolerance && ibase_n >= 0 && g[ibase_n]) {
                     // last resort.
                     EGS_Vector xtmp(x + u*t1);
                     int icdx = g[ibase_n]->isWhere(xtmp);
@@ -574,7 +574,7 @@ public:
                         goto do_checks;
                     }
                 }
-                if (t1 > 1e-3 && t2 > 1e-3) {
+                if (t1 > boundaryTolerance && t2 > boundaryTolerance) {
                     error_flag = 1;
                     egsWarning("EGS_CDGeometry::howfar: ireg<0, but position appears inside\n");
                     egsWarning(" name=%s base name=%s inscribed name=%s\n",name.c_str(),
@@ -677,8 +677,8 @@ do_checks:
             }
             // OK, we are in a new base geometry now, adjust
             // position and path-length so-far and retry.
-            if (tnew < 1e-6) {
-                tnew = 1e-6;
+            if (tnew < boundaryTolerance) {
+                tnew = boundaryTolerance;
             }
             tmp += u*tnew;
             ttot += tnew;

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -133,7 +133,7 @@ void EGS_ConeStack::addLayer(EGS_Float thick, const vector<EGS_Float> &rtop,
         pos[nl] = xo*a;
         Rout = rbottom[this_nr-1];
         Rout2 = Rout*Rout;
-        if (fabs(rtop[this_nr-1]-Rout) > 1e-5) {
+        if (fabs(rtop[this_nr-1]-Rout) > boundaryTolerance) {
             same_Rout = false;
         }
     }
@@ -149,10 +149,10 @@ void EGS_ConeStack::addLayer(EGS_Float thick, const vector<EGS_Float> &rtop,
         cones[nl][ir]->setMedium(med_names[ir]);
         cones[nl][ir]->ref();
         if (ir == this_nr-1) {
-            if (fabs(rbottom[this_nr-1]-Rout) > 1e-5) {
+            if (fabs(rbottom[this_nr-1]-Rout) > boundaryTolerance) {
                 same_Rout = false;
             }
-            if (fabs(Rtop-Rout) > 1e-5) {
+            if (fabs(Rtop-Rout) > boundaryTolerance) {
                 same_Rout = false;
             }
         }
@@ -315,6 +315,7 @@ extern "C" {
 
             g->setName(input);
             g->setLabels(input);
+            g->setBoundaryTolerance(input);
             return g;
         }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -314,8 +314,8 @@ extern "C" {
             }
 
             g->setName(input);
-            g->setLabels(input);
             g->setBoundaryTolerance(input);
+            g->setLabels(input);
             return g;
         }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -149,7 +149,7 @@ public:
         a.normalize();
 
         // avoid round-off problems.
-        if (fabs(Rtop - Rbottom) < 2e-5) {          // flag cylinders to avoid round-off problems
+        if (fabs(Rtop - Rbottom) < boundaryTolerance) {          // flag cylinders to avoid round-off problems
             is_cyl = true;
             xo = Xo;
             Ro = Rtop;
@@ -409,7 +409,7 @@ public:
         EGS_Float tt  = 1e30;
         EGS_Float lam = -1;
 
-        if (fabs(A) < 1e-6) {
+        if (fabs(A) < boundaryTolerance) {
             // moving parallel to the cone surface (A=0, within hard-coded tolerance):
             // solution: t = -C/(2*B), if t>0
 
@@ -468,8 +468,8 @@ public:
             }
 
             lam = aa+b*ttt;                         // (x+t*u)*a >= 0: on "positive" cone
-            if (ttt >= -2e-5 && lam >= 0) {
-                tt = ttt;    // why the hard-coded -2e-5 bound??
+            if (ttt >= -boundaryTolerance && lam >= 0) {
+                tt = ttt;
             }
         }
 
@@ -790,7 +790,7 @@ public:
             EGS_Float lam = -1;
 
             // moving parallel to cone surface
-            if (fabs(A) < 1e-6) {                   // guarding against /0 in general solution
+            if (fabs(A) < boundaryTolerance) {                   // guarding against /0 in general solution
                 EGS_Float ttt = -C/(2*B);           // distance to hit
                 lam = aa+b*ttt;                     // axial position of hit
                 if (ttt >= 0 && lam >= 0) {
@@ -833,7 +833,7 @@ public:
         EGS_Float aa = xp*a, b = u*a, r2 = xp.length2(), c = u*xp;
         EGS_Float A = 1 - b*b*g12, B = c - aa*b*g12, C = r2 - aa*aa*g12;
         EGS_Float to = 1e30, lamo = -1;
-        if (fabs(A) < 1e-6) {  // moving parallel to the cone surface.
+        if (fabs(A) < boundaryTolerance) {  // moving parallel to the cone surface.
             // for the outer cone we only have a solution if a*u < 0.
             // i.e. if we are moving towards the apex.
             if (b < 0) {
@@ -1109,7 +1109,7 @@ public:
             //        "C = %g\n",gam12,A,B,C);
             EGS_Float tt = -1, lam;
             bool hit = false;
-            if (fabs(A) < 1e-6) {
+            if (fabs(A) < boundaryTolerance) {
                 if ((ireg < nc && b > 0) || (ireg >= nc && b < 0)) {
                     tt = -C/(2*B);
                 }
@@ -1166,7 +1166,7 @@ public:
         EGS_Float gam12 = ireg < nc ? g12[ireg] : g12[2*nc-ireg];
         EGS_Float A=1-b*b*gam12, B=c-aa*b*gam12, C=r2-aa*aa*gam12;
         EGS_Float tt=-1;
-        if (fabs(A) < 1e-6) {
+        if (fabs(A) < boundaryTolerance) {
             if ((ireg < nc && b < 0) || (ireg > nc && b > 0)) {
                 tt = -C/(2*B);
             }
@@ -1529,11 +1529,11 @@ public:
                 // this isWhere call is using the tmp position and the LOCAL ir region number in
                 // layer 0 of the ConeStack, so it is not inconsistent if x is outside and ir>=0.
                 // BUT indeed we may be glancing on a "corner" of the ConeStack, so we should still
-                // check if a subsequent call to howfar(ir,tmp,...) takes us outside within epsilon.
+                // check if a subsequent call to howfar(ir,tmp,...) takes us outside within boundaryTolerance.
                 // It that case we are not really entering the geometry.
                 EGS_Float tb = 1e30;
                 int inew_g = howfar(ir,tmp,u,tb,0,normal);
-                if (inew_g < 0 && tb <= epsilon) {
+                if (inew_g < 0 && tb <= boundaryTolerance) {
                     return ireg;    // exits geometry
                 }
                 //***************************************************************
@@ -1572,11 +1572,11 @@ public:
                 // this isWhere call is using the tmp position and the LOCAL ir region number in
                 // layer il of the ConeStack, so it is not inconsistent if x is outside and ir>=0.
                 // BUT indeed we may be glancing on a "corner" of the ConeStack, so we should still
-                // check if a subsequent call to howfar(il*nmax+ir) takes us outside within epsilon.
+                // check if a subsequent call to howfar(il*nmax+ir) takes us outside within boundaryTolerance.
                 // It that case we are not really entering the geometry.
                 EGS_Float tb = 1e30;
                 int inew_g = howfar(il*nmax+ir,tmp,u,tb,0,normal);
-                if (inew_g < 0 && tb <= epsilon) {
+                if (inew_g < 0 && tb <= boundaryTolerance) {
                     return ireg;    // exits geometry
                 }
                 //***************************************************************
@@ -1620,14 +1620,14 @@ public:
                 // the howfar call above does not work because it uses irnow for the call to
                 // SimpleCone->howfar: SimpleCone regions can only be 0 (inside) or -1 (outside).
                 // If we find the inconsistent condition irnow >= 0 (inside, but call from outside),
-                // then we are on a boundary. We see if howfar takes us out within epsilon.
+                // then we are on a boundary. We see if howfar takes us out within boundaryTolerance.
                 // If so, then we are not really entering the geometry.
 
                 // fp inconsistency: irnow >= 0 (inside) but called with ireg = -1 (outside)
                 if (irnow >= 0) {
                     EGS_Float tb = 1e30;
                     int inew_g = howfar(irnow,x,u,tb,0,&tmp_normal);
-                    if (inew_g < 0 && tb <= epsilon) {
+                    if (inew_g < 0 && tb <= boundaryTolerance) {
                         return ireg;    // exits geometry
                     }
                 }
@@ -1675,7 +1675,7 @@ public:
                     dir = -1;
                     tp = (pos[il] - xp)/up;
                 }
-                if (tp < epsilon) {
+                if (tp < boundaryTolerance) {
                     il += dir;
                     if (il < 0 || il >= nl) {
                         return ireg;
@@ -1686,7 +1686,7 @@ public:
                 if (isc) {
                     EGS_Float tc = 1e30;
                     int isc_new = cones[il][nr[il]-1]->howfar(0,x,u,tc);
-                    if (!(isc_new < 0 && tc < epsilon)) {
+                    if (!(isc_new < 0 && tc < boundaryTolerance)) {
                         egsWarning("EGS_ConeStack::howfar: called from the outside"
                                    " but I find x=(%g,%g,%g) to be inside\n", x.x,x.y,x.z);
                         egsWarning("layer=%d distance to planes=%g\n",il,tp);

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
@@ -132,6 +132,7 @@ extern "C" {
 
         g->setName(input);
         g->setMedia(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 }

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
@@ -131,8 +131,8 @@ extern "C" {
         }
 
         g->setName(input);
-        g->setMedia(input);
         g->setBoundaryTolerance(input);
+        g->setMedia(input);
         return g;
     }
 }

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -104,6 +104,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -102,9 +102,9 @@ extern "C" {
                                   Projector(EGS_Vector(a[0],a[1],a[2])));
         }
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
@@ -309,7 +309,7 @@ public:
                         egsWarning("t=%g d=%g\n",last_t,last_d);
 #endif
                     }
-                    d = 1e-16;
+                    d = boundaryTolerance;
                 }
             }
 
@@ -353,7 +353,7 @@ public:
                         if (C < -1e-2) egsWarning("EGS_CylindersT::howfar(): "
                                                       "the particle may not be in the region we think it "
                                                       "is as Cin = %g\n",C);
-                        d = 1e-16;
+                        d = boundaryTolerance;
                     }
                 }
             }
@@ -377,7 +377,7 @@ public:
                             egsWarning("  ireg=%d x=(%g,%g,%g) u=(%g,%g,%g)\n",
                                        ireg,x.x,x.y,x.z,u.x,u.y,u.z);
                         }
-                        d = 1e-16;
+                        d = boundaryTolerance;
                     }
                 }
             }

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
@@ -120,6 +120,7 @@ extern "C" {
         }
         g->setName(input);
         g->setMedia(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
@@ -119,8 +119,8 @@ extern "C" {
                                           EGS_Projector(EGS_Vector(ay[0],ay[1],ay[2]),""));
         }
         g->setName(input);
-        g->setMedia(input);
         g->setBoundaryTolerance(input);
+        g->setMedia(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
@@ -179,7 +179,7 @@ public:
                 ay[i]=y_rad[i];
                 ayi[i] = 1/ay[i];
                 EGS_Float z = ay[i]/ax[i];
-                if (fabs(z-1) > 1e-4) {
+                if (fabs(z-1) > boundaryTolerance) {
                     sx[i] = 1/(z*z-1)/ax[i];
                     sy[i] = z*sx[i];
                     is_cyl[i] = false;
@@ -214,7 +214,7 @@ public:
                 ay[i]=y_rad[i];
                 ayi[i] = 1/ay[i];
                 EGS_Float z = ay[i]/ax[i];
-                if (fabs(z-1) > 1e-4) {
+                if (fabs(z-1) > boundaryTolerance) {
                     sx[i] = 1/(z*z-1)/ax[i];
                     sy[i] = z*sx[i];
                     is_cyl[i] = false;
@@ -400,7 +400,7 @@ private:
             }
             double vox = vo*x1, uox = uo + x1, xm1 = 1 - x1*x1;
             double f = vox*vox - uox*uox*xm1;
-            if (fabs(f) < 1e-7) {
+            if (fabs(f) < boundaryTolerance) {
                 break;
             }
             double fs = 2*(vox*vo + uox*(x1*uox-xm1));

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -387,6 +387,7 @@ extern "C" {
         if (fgeoms.size() > 0) {
             EGS_BaseGeometry *result = new EGS_FastEnvelope(g,fgeoms,"",indexing);
             result->setName(input);
+            result->setBoundaryTolerance(input);
             for (int j=0; j<fgeoms.size(); j++) {
                 delete fgeoms[j];
             }

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -128,6 +128,7 @@ extern "C" {
         EGS_BaseGeometry *result = new EGS_StackGeometry(geoms,tol);
         result->setName(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -125,8 +125,8 @@ extern "C" {
         }
         EGS_BaseGeometry *result = new EGS_StackGeometry(geoms);
         result->setName(input);
-        result->setLabels(input);
         result->setBoundaryTolerance(input);
+        result->setLabels(input);
         EGS_Float tol = 1e-10;
         err = input->getInput("tolerance",tol);
         if (!err) {

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -42,7 +42,7 @@
 string EGS_StackGeometry::type = "EGS_StackGeometry";
 
 EGS_StackGeometry::EGS_StackGeometry(const vector<EGS_BaseGeometry *> &geoms,
-                                     EGS_Float Tol, const string &Name) : EGS_BaseGeometry(Name), eps(Tol) {
+                                     const string &Name) : EGS_BaseGeometry(Name) {
     if (geoms.size() < 2) egsFatal("EGS_StackGeometry::EGS_StackGeometry: "
                                        " less than 2 geometries is not mermitted\n");
     ng = geoms.size();
@@ -123,12 +123,15 @@ extern "C" {
             egsWarning("createGeometry(stack): must have at least 2 geometries\n");
             return 0;
         }
-        EGS_Float tol = 1e-4;
-        err = input->getInput("tolerance",tol);
-        EGS_BaseGeometry *result = new EGS_StackGeometry(geoms,tol);
+        EGS_BaseGeometry *result = new EGS_StackGeometry(geoms);
         result->setName(input);
         result->setLabels(input);
         result->setBoundaryTolerance(input);
+        EGS_Float tol = 1e-10;
+        err = input->getInput("tolerance",tol);
+        if (!err) {
+            result->setBoundaryTolerance(tol);
+        }
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.h
@@ -102,11 +102,14 @@ library = egs_gstack
 geometries = list of names of previously defined geometries
 tolerance = small floating number
 \endverbatim
-The tolerance key defines a small floating point number \f$\epsilon\f$.
+The tolerance key defines a small floating point number \f$\boundaryTolerance\f$.
 Each time a particle exits a geometry, its position is moved by
-\f$\epsilon\f$ along its direction of motion. This is needed to avoid
+\f$\boundaryTolerance\f$ along its direction of motion. This is needed to avoid
 numericall roundoff problems that may result in the particle not having
 entered the next geometry in the stack and therefore being discarded.
+ 
+The \f$\tolerance\f$ key duplicates the functionality of the
+\f$\boundary tolerance\f$ key for backwards compatibility.
 */
 class EGS_StackGeometry : public EGS_BaseGeometry {
 
@@ -115,8 +118,7 @@ public:
     /*! \brief Construct a geometry stack from the vector of geometries
     \a geom.
     */
-    EGS_StackGeometry(const vector<EGS_BaseGeometry *> &geoms,
-                      EGS_Float Tol=1e-4, const string &Name = "");
+    EGS_StackGeometry(const vector<EGS_BaseGeometry *> &geoms, const string &Name = "");
 
     ~EGS_StackGeometry();
 
@@ -171,9 +173,9 @@ public:
                 return jg*nmax + inew;
             }
             // inew < 0 implies that we have exited jg.
-            // to prevent roundoff problems, we add eps to the path-length
+            // to prevent roundoff problems, we add boundaryTolerance to the path-length
             // to the boundary of jg.
-            t += eps;
+            t += boundaryTolerance;
             if (jg > 0) {
                 // check if we enter the jg-1'th geometry in the stack.
                 inew = g[jg-1]->howfar(-1,x,u,t,newmed,normal);
@@ -190,7 +192,7 @@ public:
             }
             // if here, we don't enter either of the "stack neighbours"
             // => we exit the geometry.
-            t -= eps;
+            t -= boundaryTolerance;
             return -1;
         }
         int i1 = g[0]->howfar(-1,x,u,t,newmed,normal);
@@ -260,7 +262,6 @@ protected:
     int ng;
     int nmax;
     EGS_BaseGeometry **g;
-    EGS_Float  eps;
     static string    type;
 
     void setMedia(EGS_Input *,int,const int *);

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -101,6 +101,7 @@ extern "C" {
         }
         result->setName(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
 
     }

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -100,8 +100,8 @@ extern "C" {
             delete t;
         }
         result->setName(input);
-        result->setLabels(input);
         result->setBoundaryTolerance(input);
+        result->setLabels(input);
         return result;
 
     }

--- a/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
@@ -315,6 +315,7 @@ extern "C" {
             }
             result->setRLabels(input);
             result->setLabels(input);
+            result->setBoundaryTolerance(input);
             return result;
         }
 
@@ -370,6 +371,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
@@ -308,6 +308,7 @@ extern "C" {
             }
             EGS_RadialRepeater *result = new EGS_RadialRepeater(xo,a,np,g,phi_o);
             result->setName(input);
+            result->setBoundaryTolerance(input);
             string medium;
             err = input->getInput("medium",medium);
             if (!err) {
@@ -315,7 +316,6 @@ extern "C" {
             }
             result->setRLabels(input);
             result->setLabels(input);
-            result->setBoundaryTolerance(input);
             return result;
         }
 
@@ -369,9 +369,9 @@ extern "C" {
         EGS_BaseGeometry *g = new EGS_IPlanes(xo,a,angles.size(),ang,"",is_degree);
         delete [] ang;
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -716,7 +716,7 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
             result->setMedium(j,j,imed[i]);
             if (rho_def[i] > 0) {
                 EGS_Float rrho = rho[j]/rho_def[i];
-                if (fabs(rrho-1) > 1e-4) {
+                if (fabs(rrho-1) > boundaryTolerance) {
                     result->setRelativeRho(j,j,rrho);
                 }
             }
@@ -1091,6 +1091,7 @@ extern "C" {
             }
             result->setXYZLabels(input);
             result->setLabels(input);
+            result->setBoundaryTolerance(input);
             return result;
         }
         else if (!is_xyz && input->compare("EGS_XYZGeometry",type)) {
@@ -1123,6 +1124,7 @@ extern "C" {
                 EGS_XYZGeometry *result =
                     EGS_XYZGeometry::constructGeometry(dens_file.c_str(),ramp_file.c_str(),dens_or_egsphant_or_interfile);
                 result->setName(input);
+                result->setBoundaryTolerance(input);
                 return result;
             }
             vector<EGS_Float> xpos, ypos, zpos, xslab, yslab, zslab;
@@ -1223,6 +1225,7 @@ extern "C" {
                 egsWarning("**********************************************\n");
                 EGS_BaseGeometry *g = result;
                 result->setName(input);
+                result->setBoundaryTolerance(input);
                 g->setMedia(input);
                 result->voxelizeGeometry(input);
 
@@ -1310,6 +1313,7 @@ extern "C" {
         result->setName(input);
         result->setMedia(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -716,7 +716,7 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
             result->setMedium(j,j,imed[i]);
             if (rho_def[i] > 0) {
                 EGS_Float rrho = rho[j]/rho_def[i];
-                if (fabs(rrho-1) > boundaryTolerance) {
+                if (fabs(rrho-1) > 1e-10) {
                     result->setRelativeRho(j,j,rrho);
                 }
             }
@@ -1086,12 +1086,12 @@ extern "C" {
             EGS_XYZRepeater *result =
                 new EGS_XYZRepeater(xmin,xmax,ymin,ymax,zmin,zmax,nx,ny,nz,g);
             result->setName(input);
+            result->setBoundaryTolerance(input);
             if (!err5) {
                 result->setMedium(medium);
             }
             result->setXYZLabels(input);
             result->setLabels(input);
-            result->setBoundaryTolerance(input);
             return result;
         }
         else if (!is_xyz && input->compare("EGS_XYZGeometry",type)) {
@@ -1311,9 +1311,9 @@ extern "C" {
             result = new EGS_NDGeometry(dims);
         }
         result->setName(input);
+        result->setBoundaryTolerance(input);
         result->setMedia(input);
         result->setLabels(input);
-        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -1112,9 +1112,9 @@ protected:
                 iz = zp->isWhere(tmp);
                 if (iz >= 0) {
                     int inew =  ix + iy*nx + iz*nxy;
-                    if (t1 < epsilon) {
+                    if (t1 < boundaryTolerance) {
                         int itest = howfar(inew, tmp, u, t1);
-                        if (itest == -1 && t1 < epsilon) {
+                        if (itest == -1 && t1 < boundaryTolerance) {
                             return -1;
                         }
                     }
@@ -1143,9 +1143,9 @@ protected:
                 iz = zp->isWhere(tmp);
                 if (iz >= 0) {
                     int inew =  ix + iy*nx + iz*nxy;
-                    if (t1 < epsilon) {
+                    if (t1 < boundaryTolerance) {
                         int itest = howfar(inew, tmp, u, t1);
-                        if (itest == -1 && t1 < epsilon) {
+                        if (itest == -1 && t1 < boundaryTolerance) {
                             return -1;
                         }
                     }
@@ -1174,9 +1174,9 @@ protected:
                 iy = yp->isWhere(tmp);
                 if (iy >= 0) {
                     int inew =  ix + iy*nx + iz*nxy;
-                    if (t1 < epsilon) {
+                    if (t1 < boundaryTolerance) {
                         int itest = howfar(inew, tmp, u, t1);
-                        if (itest == -1 && t1 < epsilon) {
+                        if (itest == -1 && t1 < boundaryTolerance) {
                             return -1;
                         }
                     }

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -326,8 +326,8 @@ extern "C" {
         // create the octree geometry
         EGS_Octree *octree = new EGS_Octree(vBox, pruneTree, g);
         octree->setName(input);
-        octree->setLabels(input);
         octree->setBoundaryTolerance(input);
+        octree->setLabels(input);
         octree->printInfo();
 
         if (discardChild) {

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -327,6 +327,7 @@ extern "C" {
         EGS_Octree *octree = new EGS_Octree(vBox, pruneTree, g);
         octree->setName(input);
         octree->setLabels(input);
+        octree->setBoundaryTolerance(input);
         octree->printInfo();
 
         if (discardChild) {

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -173,6 +173,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -171,9 +171,9 @@ extern "C" {
             return 0;
         }
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
@@ -143,7 +143,7 @@ protected:
         dp = p[1] - p[0];
         for (int j=1; j<nreg; j++) {
             EGS_Float dpj = p[j+1] - p[j];
-            if (fabs(dpj/dp-1) > 2e-5) {
+            if (fabs(dpj/dp-1) > boundaryTolerance) {
                 is_uniform = false;
                 break;
             }
@@ -360,11 +360,11 @@ public:
             // we think we are outside but we are inside.
             // hopefully a truncation problem with a particle
             // backscattered at a boundary
-            if (xp-p[0] < 3e-5 && up > 0) {
+            if (xp-p[0] < boundaryTolerance && up > 0) {
                 d = 0;
                 res = 0;
             }
-            else if (p_last-xp < 3e-5 && up < 0) {
+            else if (p_last-xp < boundaryTolerance && up < 0) {
                 d = 0;
                 res = nreg-1;
             }

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -125,7 +125,7 @@ extern "C" {
                 points.push_back(EGS_Vector(p[3*j],p[3*j+1],p[3*j+2]));
             }
             EGS_Vector aux(points[np-1]-points[0]);
-            if (aux.length2() > boundaryTolerance) {
+            if (aux.length2() > 1e-10) {
                 points.push_back(points[0]);
             }
             np = points.size();
@@ -135,7 +135,7 @@ extern "C" {
                 for (int j=0; j<np; j++) {
                     p2.push_back(pro.getProjection(points[j]));
                     EGS_Float d = pro.distance(points[j]);
-                    if (fabs(d) > boundaryTolerance) {
+                    if (fabs(d) > 1e-10) {
                         egsWarning("createGeometry(prism): "
                                    "points are not on a plane\n");
                         return 0;
@@ -150,9 +150,9 @@ extern "C" {
             }
         }
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -125,7 +125,7 @@ extern "C" {
                 points.push_back(EGS_Vector(p[3*j],p[3*j+1],p[3*j+2]));
             }
             EGS_Vector aux(points[np-1]-points[0]);
-            if (aux.length2() > 1e-6) {
+            if (aux.length2() > boundaryTolerance) {
                 points.push_back(points[0]);
             }
             np = points.size();
@@ -135,7 +135,7 @@ extern "C" {
                 for (int j=0; j<np; j++) {
                     p2.push_back(pro.getProjection(points[j]));
                     EGS_Float d = pro.distance(points[j]);
-                    if (fabs(d) > 1e-6) {
+                    if (fabs(d) > boundaryTolerance) {
                         egsWarning("createGeometry(prism): "
                                    "points are not on a plane\n");
                         return 0;
@@ -152,6 +152,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -53,7 +53,7 @@ EGS_PyramidT<T>::EGS_PyramidT(T *P, const EGS_Vector &Xo, bool O,
     nreg = 1;
     d = p->distance(xo);
     xop = p->getProjection(xo);
-    if (fabs(d) < 1e-7) egsFatal("%s: the tip is too close to"
+    if (fabs(d) < boundaryTolerance) egsFatal("%s: the tip is too close to"
                                      " the base (%g)\n",getType().c_str(),fabs(d));
     if (d < 0) {
         a *= (-1);
@@ -163,7 +163,7 @@ extern "C" {
                 points.push_back(EGS_Vector(p[3*j],p[3*j+1],p[3*j+2]));
             }
             EGS_Vector aux(points[np-1]-points[0]);
-            if (aux.length2() > 1e-6) {
+            if (aux.length2() > boundaryTolerance) {
                 points.push_back(points[0]);
             }
             np = points.size();
@@ -173,7 +173,7 @@ extern "C" {
                 for (int j=0; j<np; j++) {
                     p2.push_back(pro.getProjection(points[j]));
                     EGS_Float d = pro.distance(points[j]);
-                    if (fabs(d) > 1e-6) {
+                    if (fabs(d) > boundaryTolerance) {
                         egsWarning("createGeometry(pyramid): "
                                    "points are not on a plane\n");
                         return 0;
@@ -186,6 +186,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -163,7 +163,7 @@ extern "C" {
                 points.push_back(EGS_Vector(p[3*j],p[3*j+1],p[3*j+2]));
             }
             EGS_Vector aux(points[np-1]-points[0]);
-            if (aux.length2() > boundaryTolerance) {
+            if (aux.length2() > 1e-10) {
                 points.push_back(points[0]);
             }
             np = points.size();
@@ -173,7 +173,7 @@ extern "C" {
                 for (int j=0; j<np; j++) {
                     p2.push_back(pro.getProjection(points[j]));
                     EGS_Float d = pro.distance(points[j]);
-                    if (fabs(d) > boundaryTolerance) {
+                    if (fabs(d) > 1e-10) {
                         egsWarning("createGeometry(pyramid): "
                                    "points are not on a plane\n");
                         return 0;
@@ -184,9 +184,9 @@ extern "C" {
                                 EGS_Vector(tip[0],tip[1],tip[2]),o);
         }
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -307,8 +307,8 @@ extern "C" {
         }
         EGS_BaseGeometry *result = new EGS_SmartEnvelope(g,fgeoms,"");
         result->setName(input);
-        result->setLabels(input);
         result->setBoundaryTolerance(input);
+        result->setLabels(input);
         for (int j=0; j<fgeoms.size(); j++) {
             delete fgeoms[j];
         }

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -308,6 +308,7 @@ extern "C" {
         EGS_BaseGeometry *result = new EGS_SmartEnvelope(g,fgeoms,"");
         result->setName(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         for (int j=0; j<fgeoms.size(); j++) {
             delete fgeoms[j];
         }

--- a/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
@@ -44,9 +44,9 @@ extern "C" {
     EGS_SPACE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         EGS_Space *g = new EGS_Space("");
         g->setName(input);
+        g->setBoundaryTolerance(input);
         g->setMedia(input);
         g->setLabels(input);
-        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
@@ -46,6 +46,7 @@ extern "C" {
         g->setName(input);
         g->setMedia(input);
         g->setLabels(input);
+        g->setBoundaryTolerance(input);
         return g;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -341,9 +341,9 @@ extern "C" {
         }
         EGS_BaseGeometry *result = new EGS_cSpheres(radii.size(),r,xo);
         result->setName(input);
+        result->setBoundaryTolerance(input);
         result->setMedia(input);
         result->setLabels(input);
-        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -172,7 +172,7 @@ int EGS_cSpheres::howfar(int ireg, const EGS_Vector &x,
              */
             R2b2 = R2[ireg] - bb2;
             if (R2b2 <= 0 && aa > 0) {
-                d = 1e-15;    // hopefully a truncation problem
+                d = boundaryTolerance;    // hopefully a truncation problem
             }
             else {
                 tmp = aa2 + R2b2;
@@ -247,7 +247,7 @@ int EGS_cSpheres::howfar(int ireg, const EGS_Vector &x,
         egsWarning("\nGot nan\n");
     }
 
-    if (d < -1e-4) {
+    if (d < -boundaryTolerance) {
         egsWarning("\nNegative step?: %g\n",d);
         egsWarning("ireg=%d inew=%d aa=%g bb2=%g\n",ireg,direction_flag,aa,bb2);
         //exit(1);
@@ -343,6 +343,7 @@ extern "C" {
         result->setName(input);
         result->setMedia(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -181,8 +181,8 @@ extern "C" {
         }
         EGS_BaseGeometry *result = new EGS_UnionGeometry(geoms,p);
         result->setName(input);
-        result->setLabels(input);
         result->setBoundaryTolerance(input);
+        result->setLabels(input);
         if (p) {
             delete [] p;
         }

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -182,6 +182,7 @@ extern "C" {
         EGS_BaseGeometry *result = new EGS_UnionGeometry(geoms,p);
         result->setName(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         if (p) {
             delete [] p;
         }

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -714,6 +714,7 @@ extern "C" {
                     tb_med,bm_med,micro_data.c_str());
             result->setName(input);
             result->setLabels(input);
+            result->setBoundaryTolerance(input);
             return result;
         }
         string phantom, media;
@@ -743,6 +744,7 @@ extern "C" {
         result->setName(input);
         result->setMicros(input);
         result->setLabels(input);
+        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -713,8 +713,8 @@ extern "C" {
             EGS_TestMicro *result = new EGS_TestMicro(vs[0],vs[1],vs[2],bsc_t,
                     tb_med,bm_med,micro_data.c_str());
             result->setName(input);
-            result->setLabels(input);
             result->setBoundaryTolerance(input);
+            result->setLabels(input);
             return result;
         }
         string phantom, media;
@@ -742,9 +742,9 @@ extern "C" {
             return 0;
         }
         result->setName(input);
+        result->setBoundaryTolerance(input);
         result->setMicros(input);
         result->setLabels(input);
-        result->setBoundaryTolerance(input);
         return result;
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
@@ -1381,14 +1381,14 @@ public:
             // in macro matrix
             int inew = vg->howfar(ireg,x,u,t,normal);
             if (t < 0) {
-                if (t < -1e-5) {
+                if (t < -boundaryTolerance) {
                     egsWarning("negative step %g in macro voxel\n",t);
                     egsWarning("x=(%g,%g,%g) u=(%g,%g,%g)\n",x.x,x.y,x.z,
                                u.x,u.y,u.z);
                     egsWarning("ix=%d iy=%d iz=%d\n",vg->ix,vg->iy,vg->iz);
                     egsFatal("quitting\n");
                 }
-                t = 1e-15;
+                t = boundaryTolerance;
             }
             if (inew < 0 || inew == ireg) {
                 return inew;
@@ -1457,7 +1457,7 @@ public:
             EGS_Vector x1(x - EGS_Vector(vg->dx*lax,vg->dy*lay,vg->dz*laz));
             int inew = micro->vg->howfarIn(ilocal,ix,iy,iz,x1,u,t,normal);
             if (t < 0) {
-                if (t < -1e-5) {
+                if (t < -boundaryTolerance) {
                     egsWarning("negative step %g in micro matrix\n",t);
                     egsWarning("x=(%g,%g,%g) u=(%g,%g,%g)\n",x.x,x.y,x.z,
                                u.x,u.y,u.z);


### PR DESCRIPTION
This is an attempt at resolving issue #86. Feel free to simply close if you'd prefer using a different approach than I did.

My goal in this pull request is to have a user-defined `boundaryTolerance` variable that is used to check for floating point errors in geometries. The `boundaryTolerance` variable is a protected member of `EGS_BaseGeometry` and has a default value of 1e-10. Being non-static, this allows the user to set a different value of `boundaryTolerance` in any geometry. The tolerance can be set with the input key `boundary tolerance`.

`EGS_StackGeometry` already has a `tolerance` variable that serves the same purpose. For backwards compatibility, the `tolerance` key is preserved and simply duplicates the functionality of the `boundary tolerance` key.