### PR TITLE
Fix #101: Fix negative energies output after Moller

### DIFF
--- a/HEN_HOUSE/src/nrcaux.mortran
+++ b/HEN_HOUSE/src/nrcaux.mortran
@@ -209,7 +209,7 @@ ELSEIF(IARG = 9)[
      DO IP=NPold,NP[
         KE = E(IP) - ABS(IQ(NP))*RM;
         IF(IP=NPold)[$CNTOUT(IP);(T11,'Resulting electrons',T36,':');]
-        ELSE[$CNTOUT(IP);(T36,':');]
+        ELSEIF(IQ(IP)=-1)[$CNTOUT(IP);(T36,':');]
      ]
   ]
 ]


### PR DESCRIPTION
Fixed SUBROUTINE WATCH so that fluorescent photons resulting from EII
processes after Moller do not get listed as "Resulting electrons"
with negative energies when IWATCH is being used.  Note: This is
an output bug only; it does not affect results!