### PR TITLE
Add region labels to egs_chamber and egs_dose_scoring

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -114,6 +114,12 @@ void EGS_DoseScoring::setApplication(EGS_Application *App) {
     if (!app) {
         return;
     }
+    
+    if(d_regionString.length() > 0 && d_region.size() < 1) {
+        getNumberRegions(d_regionString, d_region);
+        getLabelRegions(d_regionString, d_region);
+    }
+    
     // Get the number of regions in the geometry.
     nreg = app->getnRegions();
     // Get the number of media in the input file
@@ -232,6 +238,15 @@ void EGS_DoseScoring::setApplication(EGS_Application *App) {
     if (d_region.size()) {
         d_region.clear();
     }
+}
+
+void EGS_DoseScoring::getNumberRegions(const string &str, vector<int> &regs) {
+    egsInformation("TEST1a getNumberRegions\n");
+    app->getNumberRegions(str, regs);
+}
+
+void EGS_DoseScoring::getLabelRegions(const string &str, vector<int> &regs) {
+    app->getLabelRegions(str, regs);
 }
 
 void EGS_DoseScoring::reportResults() {
@@ -438,10 +453,11 @@ extern "C" {
         int d_in_region = input->getInput("region dose",allowed_mode,1);
 
         /* get dose regions */
+        string d_regionsString;
         vector <int> d_regions;
         bool using_all_regions=true;
         vector <int> d_start, d_stop;
-        if (!input->getInput("dose regions",d_regions)&& d_regions.size()>0) {
+        if (!input->getInput("dose regions",d_regionsString)&& d_regionsString.length()>0) {
             using_all_regions = false;    // individual regions
         }
         else {
@@ -498,7 +514,11 @@ extern "C" {
             result->setVol(1.0);    // default value if no entry
         }
         if (!using_all_regions) {
-            result->setDoseRegions(d_regions);
+            if(d_regions.size() > 0) {
+                result->setDoseRegions(d_regions);
+            } else {
+                result->setDoseRegions(d_regionsString);
+            }
         }
         if (d_in_medium) {
             result->setMediumScoring(true);

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
@@ -205,6 +205,10 @@ public:
     };
 
     void setApplication(EGS_Application *App);
+    
+    void getNumberRegions(const string &str, vector<int> &regs);
+    
+    void getLabelRegions(const string &str, vector<int> &regs);
 
     void reportResults();
 
@@ -236,6 +240,9 @@ public:
     void setDoseRegions(const vector <int> d_reg) {
         d_region=d_reg;
     };
+    void setDoseRegions(const string d_reg) {
+        d_regionString=d_reg;
+    };
     void setMediumScoring(bool flag) {
         score_medium_dose=flag;
     };
@@ -258,6 +265,7 @@ protected:
     EGS_ScoringArray *doseM;  //!< Scoring dose in each medium
     vector <EGS_Float>  vol_list; // Input list of region volumes
     vector <int> d_region;        // Input list of dose scoring regions  d_reg[i] = ir
+    string d_regionString;
     vector <int> d_reg_index;     // list index for dose scoring regions d_reg_index[ir]= 0..d_reg.size()-1
     vector <EGS_Float>  vol;      // geometrical region volumes
     EGS_Float norm_u;

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -637,6 +637,37 @@ public:
     int  isWhere(EGS_Vector &r) {
         return geometry->isWhere(r);
     }
+    
+    /*! \brief Gets numbers out of \a str and pushes them onto \a regs
+    
+      Finds integer numbers in \a str and pushes them onto the vector \a regs.
+      For an input string containing a mixture of labels and region numbers,
+      this extracts the region numbers.
+      
+      Usually you will do something like:
+      \verbatim
+      string regionString;
+      vector<int> regionVector;
+      int err1 = input->getInput("cavity regions",regionString);
+      geom->getNumberRegions(regionString, regionVector);
+      geom->getLabelRegions(regionString, regionVector);
+      \endverbatim
+     */
+    void getNumberRegions(const string &str, vector<int> &regs) {
+        geometry->getNumberRegions(str, regs);
+    }
+    
+    /*! \brief Gets the regions for the labels in \a str and pushes onto \a regs
+      
+      This function is used after \a getNumberRegions. It looks for labels
+      in \a str, finds the corresponding local region numbers, and pushes those
+      region numbers onto the region number vector \a regs.
+      
+      The \a regs vector is sorted by this function, and duplicates are removed!
+     */
+    void getLabelRegions(const string &str, vector<int> &regs) {
+        geometry->getLabelRegions(str, regs);
+    }
 
     /*! \brief User scoring function for accumulation of results and VRT implementation
 

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -890,16 +890,58 @@ void EGS_BaseGeometry::addBooleanProperty(int bit, int start, int end,
     }
 }
 
-void EGS_BaseGeometry::getLabelRegions(const string &str, vector<int> &regs) {
+// Gets region numbers from a string
+// Pushes the regions onto the array regs
+void EGS_BaseGeometry::getNumberRegions(const string &str, vector<int> &regs) {
+    
+    if(!str.empty()) {
+        
+        // Tokenize the input string
+        vector<string> tokens;
+        const char *ptr = str.c_str();
+        do {
+            const char *begin = ptr;
+            while (*ptr != ' ' && *ptr) {
+                ptr++;
+            }
+            tokens.push_back(string(begin, ptr));
+        }
+        while (*ptr++ != '\0');
 
-    // get all regions lists for this named label
-    for (int i=0; i<labels.size(); i++) {
-        if (labels[i].name.compare(str) == 0) {
-            regs.insert(regs.end(), labels[i].regions.begin(), labels[i].regions.end());
+        for (int i=0; i<tokens.size(); i++) {
+            // Search for tokens that are numbers, not strings
+            // Push the region numbers onto the regions array
+            if(tokens[i].find_first_not_of(" -0123456789") == std::string::npos) {
+                regs.push_back(atoi(tokens[i].c_str()));
+            }
+        }
+    }
+}
+
+void EGS_BaseGeometry::getLabelRegions(const string &str, vector<int> &regs) {
+    
+    // Tokenize the input string - this allows for multiple labels
+    vector<string> tokens;
+    const char *ptr = str.c_str();
+    do {
+        const char *begin = ptr;
+        while (*ptr != ' ' && *ptr) {
+            ptr++;
+        }
+        tokens.push_back(string(begin, ptr));
+    }
+    while (*ptr++ != '\0');
+    
+    // Get all regions lists for this named label
+    for (int j=0; j<tokens.size(); j++) {
+        for (int i=0; i<labels.size(); i++) {
+            if (labels[i].name.compare(tokens[j]) == 0) {
+                regs.insert(regs.end(), labels[i].regions.begin(), labels[i].regions.end());
+            }
         }
     }
 
-    // sort region list and remove duplicates
+    // Sort region list and remove duplicates
     sort(regs.begin(), regs.end());
     regs.erase(unique(regs.begin(), regs.end()), regs.end());
 }

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -623,6 +623,9 @@ public:
     static EGS_Float getBoundaryTolerance() {
         return epsilon;
     };
+    
+    /*! \brief Get a list of all the regions labeled with a number */
+    virtual void getNumberRegions(const string &str, vector<int> &regs);
 
     /*! \brief Get the list of all regions labeled with \a str */
     virtual void getLabelRegions(const string &str, vector<int> &regs);

--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
@@ -1117,12 +1117,15 @@ int EGS_ChamberApplication::initScoring() {
         while( (aux = options->takeInputItem("calculation geometry")) ) {
             string gname;
             int err = aux->getInput("geometry name",gname);
+            
+            string cavString;
             vector<int> cav;
-            int err1 = aux->getInput("cavity regions",cav);
-
+            int err1 = aux->getInput("cavity regions",cavString);
+            
+            string ecut_rString;
             vector<int> ecut_r;
             EGS_Float ecut_v;
-            int err5 = aux->getInput("ECUT regions",ecut_r);	// jwu
+            int err5 = aux->getInput("ECUT regions",ecut_rString);	// jwu
             int err6 = aux->getInput("ECUT",ecut_v);
 
             string cav_gname;
@@ -1133,29 +1136,14 @@ int EGS_ChamberApplication::initScoring() {
                 do_mcav = false;
             }
             int err11, err12;
+            string cs_regString;
             vector<int> cs_reg;
             vector<int> cs_fac;
             if( do_cse ) {
-                err11 = aux->getInput("enhance regions",cs_reg);
+                err11 = aux->getInput("enhance regions",cs_regString);
                 err12 = aux->getInput("enhancement",cs_fac);
             }
             else{ err11 = 1; err12 = 1; }
-
-            if (do_cse && cs_reg[0]<0 && cs_reg[1]<0 && cs_reg.size()==2) {
-                int start = -cs_reg[0];
-                int end   = -cs_reg[1];
-                cs_reg.clear();
-                for (int i=start; i<=end; i++) {
-                    cs_reg.push_back(i);
-                }
-            }
-            if (do_cse && cs_fac[0]<0 && cs_fac.size()==1) {
-                int tmp = -cs_fac[0];
-                cs_fac.clear();
-                for (int i=0; i<cs_reg.size(); i++) {
-                    cs_fac.push_back(tmp);
-                }
-            }
 
             EGS_Float cmass;
             int err2 = aux->getInput("cavity mass",cmass);
@@ -1172,10 +1160,7 @@ int EGS_ChamberApplication::initScoring() {
             if( err12 ) egsWarning("initScoring: missing/wrong 'enhancement' "
                     "input\n");
             int err13 = 0;
-            if( !err11 && !err12 && (cs_reg.size() != cs_fac.size() )){
-                egsWarning("initScoring: number of 'enhance regions' must match 'enhancement'\n");
-                err13 = 1;
-            }
+            
             if( err || err1 ) egsWarning("  --> input ignored\n");
             else {
                 EGS_BaseGeometry::setActiveGeometryList(app_index);
@@ -1186,12 +1171,42 @@ int EGS_ChamberApplication::initScoring() {
                             " input ignored\n",cav_gname.c_str());
                     cg = 0;
                 }
-
+                
                 EGS_BaseGeometry *g = EGS_BaseGeometry::getGeometry(gname);
-                if( !g ) egsWarning("initScoring: no geometry named %s -->"
+                if( !g ) {
+                    egsWarning("initScoring: no geometry named %s -->"
                         " input ignored\n",gname.c_str());
+                } else {
+                    g->getNumberRegions(cavString, cav);
+                    g->getLabelRegions(cavString, cav);
+                    g->getNumberRegions(cs_regString, cs_reg);
+                    g->getLabelRegions(cs_regString, cs_reg);
+                    g->getNumberRegions(ecut_rString, ecut_r);
+                    g->getLabelRegions(ecut_rString, ecut_r);
+                }
+                
+                if (do_cse && cs_reg[0]<0 && cs_reg[1]<0 && cs_reg.size()==2) {
+                    int start = -cs_reg[0];
+                    int end   = -cs_reg[1];
+                    cs_reg.clear();
+                    for (int i=start; i<=end; i++) {
+                        cs_reg.push_back(i);
+                    }
+                }
+                if (do_cse && cs_fac[0]<0 && cs_fac.size()==1) {
+                    int tmp = -cs_fac[0];
+                    cs_fac.clear();
+                    for (int i=0; i<cs_reg.size(); i++) {
+                        cs_fac.push_back(tmp);
+                    }
+                }
+                if( !err11 && !err12 && (cs_reg.size() != cs_fac.size() )){
+                    egsWarning("initScoring: number of 'enhance regions' must match 'enhancement'\n");
+                    err13 = 1;
+                }
 
-                else {
+                if( g ) {
+                    
                     int nreg = g->regions();
                     int *regs = new int [cav.size()];
                     int ncav = 0;
@@ -1277,8 +1292,11 @@ int EGS_ChamberApplication::initScoring() {
                     if ( do_TmpPhsp ){
                         vector<string> subgeom_name;
                         int err777 = aux->getInput("sub geometries",subgeom_name);
+                        string subgeom_regsString;
                         vector<int> subgeom_regs;
-                        int err888 = aux->getInput("subgeom regions",subgeom_regs);
+                        int err888 = aux->getInput("subgeom regions",subgeom_regsString);
+                        cg->getNumberRegions(subgeom_regsString, subgeom_regs);
+                        cg->getLabelRegions(subgeom_regsString, subgeom_regs);
                         if( err777 ){
                             egsWarning("initScoring: missing/wrong 'sub geometries' "
                                     " for geometry '%s'\n", gname.c_str());


### PR DESCRIPTION
Addresses issue #139.

Now you can set labels in geometries in egs_chamber using `set label` within the geometry block. For example:

```
:start geometry:
        ...
        set label = myLabel 3 4 5
:stop geometry:
```

This assigns the local geometry regions 3 4 5 to the label named myLabel. Cavity regions, enhance regions and subgeom regions can then use myLabel in place of the global region numbers. Multiple labels, and mixed global region numbers with labels are both supported.

```
:start scoring options:
    :start calculation geometry:
        geometry name = myGeom
        cavity regions = detectorLabel
        cavity geometry = myGeom
        enhance regions = enhanceLabel
        enhancement = -128
        cavity mass = ...
    :stop calculation geometry:
:stop scoring options:
```

I also added this to `egs_dose_scoring`, so you can use region labels for the `dose regions`.
