### PR TITLE
Fix #152: Fix input bug in beamdp/beamdp_gui for option 11.

### DIFF
--- a/HEN_HOUSE/omega/progs/beamdp/beamdp.mortran
+++ b/HEN_HOUSE/omega/progs/beamdp/beamdp.mortran
@@ -1190,16 +1190,21 @@ IF(CHOICE1=11)[
     IF ~EGSPERT[ CALL HELP_MESSAGE(19); ]
     :LB2:
     OUTPUT;
-    (/' Number(default=100), IQ(-1,0,1,2,3) =?'/' ',$);
+    (/' From particle no. (default=1), to particle no. (default=100),'
+      ' IQ(-1,0,1,2,3) =?'/' ',$);
     READ(5,'(3I12)',ERR=:LB1:)NUMBERST,NUMBERP,IQSMFP(1);
     GOTO :LB3:;
     :LB1:
       CALL HELP_MESSAGE(19);
       GOTO :LB2:;
     :LB3:
+    IF (NUMBERST<1)[
+        NUMBERST=1;
+        OUTPUT;(/' First particle no. defaults to 1!'); 
+        ]
     IF (NUMBERP<1)[
         NUMBERP=100;
-        OUTPUT;(/' Number defaults to 100!');
+        OUTPUT;(/' Last particle no. defaults to 100!');
         ]
     IF(IQSMFP(1)<-1)|(IQSMFP(1)>3)[
         IQSMFP(1)=2;"defaults to all the particles"
@@ -5250,6 +5255,7 @@ IF(i_iaea_in=1)[
   IF(IMUIDX1~=0)[
     OUTPUT;(' Fractional MU index also scored in phase space data. '/);
   ]
+  NINC=LPARANINC;
 ]
 ELSE[
 

--- a/HEN_HOUSE/omega/progs/gui/beamdp/beamdp_gui.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamdp/beamdp_gui.tcl
@@ -667,7 +667,8 @@ You can use bits 1 to 23 for these filters.  For more information, \
 	    # get number of particles, iq.
 	    set w5 $w.opt11
 	    frame $w5
-	    textfield $w5.f1 "Number of particles to be listed (default 100)" fpar(1)
+            textfield $w5.f0 "Start at particle no. (defaults to 1)" fpar(0)
+	    textfield $w5.f1 "End at particle no. (default 100)" fpar(1)
 	    set text1(1) "Particle type"
 
 	    frame $w5.inp1
@@ -1447,13 +1448,14 @@ proc create_script {} {
 	}
 	if $ichoice==11 {
 	    # Put numberp,charge
+            if { [catch {expr $fpar(0)}]==1 } { set fpar(0) 1 }
 	    if { [catch {expr $fpar(1)}]==1 } { set fpar(1) 100 }
 	    if $charge==100 {
 		tk_dialog .failed "Failed" "The charge is not \
 			specified.  Specify and try again." error 0 OK
 		return 0
 	    }
-	    puts $id "$fpar(1), $charge"
+	    puts $id "$fpar(0), $fpar(1), $charge"
 	}
 
 	if { $ichoice>0 && $ichoice<10 || $ichoice==11} {


### PR DESCRIPTION
Previously, beamdp_gui only allowed the user to input no.
of particles for which to output parameters.  This did
not reflect inputs actually required by beamdp: the range
of particles for which to list parameters.  Confusion was
exacerbated by the command line description of this input
from beamdp, itself, which also indicated only the no.
of particles for which to output data.  This has been
fixed as well.  Also, fixed a serious bug resulting in
erroneous data output for all options when IAEA phase space
data was analyzed.
