### PR TITLE
Fix exposed path in pirs898 file list

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/Doxyfile
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/Doxyfile
@@ -125,7 +125,7 @@ INLINE_INHERITED_MEMB  = NO
 # path before files name in the file list and in the header files. If set
 # to NO the shortest path that makes the file name unique will be used.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # If the FULL_PATH_NAMES tag is set to YES then the STRIP_FROM_PATH tag
 # can be used to strip a user-defined part of the path. Stripping is


### PR DESCRIPTION
Change Doxyfile `FULL_PATH_NAMES = NO` to hide exposed paths. This removes all paths from the file list so the user can't tell where to find the file, but maybe that is OK.

An alternative would be to use `STRIP_FROM_PATH` to get rid of the start of the path, but then we are providing this path in the Doxyfile itself.
