### PR TITLE
Fix typo in comment in PYRAMIDS_cm

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/CMs/PYRAMIDS_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/PYRAMIDS_cm.mortran
@@ -301,7 +301,7 @@
 " so evaluate DIST, distance to region boundary along current trajectory.  USTEP
 " must not exceed DIST.
 "
-"   There are 4xISCM local regions see above graph:
+"   There are 3xISCM local regions see above graph:
 "
 "      local                    absolute                   description
 "   ------------  ------------------------------------   ---------------


### PR DESCRIPTION
Trivial change, really. The number of local regions is 3 times the number of pyramid blocks since the inner and outer air regions are actually the same numbered region. Change is to the comment only, for clarity.
