### PR TITLE
Fix #111: EGS_PrismT geometry bug when enclosing zero along closed axis

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -190,11 +190,13 @@ public:
         if (!ireg) {  // inside
             EGS_Float tt = 1e30;
             int inew = ireg;
-            if (up > 0) {
+            if (up > boundaryTolerance) {
                 tt = (d2 - d)/up;
             }
-            else {
+            else if(up < -boundaryTolerance) {
                 tt = (d1 - d)/up;
+            } else {
+                tt = 0;
             }
             if (tt <= t) {
                 t = tt;
@@ -220,10 +222,10 @@ public:
         }
         if (d < d1 || d > d2) {
             EGS_Float tt = 1e30;
-            if (d < d1 && up > 0) {
+            if (d < d1 && up > boundaryTolerance) {
                 tt = (d1 - d)/up;
             }
-            else if (d > d2 && up < 0) {
+            else if (d > d2 && up < -boundaryTolerance) {
                 tt = (d2 - d)/up;
             }
             if (tt < t) {


### PR DESCRIPTION
Fix a bug resulting in a crash when a closed prism contained the zero point of the axis along which it is closed. For example, an `EGS_PrismX` with `closed = -1 1` would crash. Transformations to this condition, where zero was enclosed, had the same crash.
