### PR TITLE
Fix #167: Unmatched quotes in compilation script

### DIFF
--- a/HEN_HOUSE/scripts/compile_user_code
+++ b/HEN_HOUSE/scripts/compile_user_code
@@ -40,18 +40,14 @@ if test $# -lt 1; then
     cat >&2 <<EOF
 Usage: $my_name m|f|mf user_code [a] [opt|noopt|debug] [config=xxx]
 
-$my_name compiles the EGSnrc user code 'user_code'.
-The arguments `f' and `mf' are equivalent, `m' results in a
-mortan compilation only.
-The argument 'a' is here for historical reasons to provide
-compatibility with the typical invocation of EGS compilations in
-previous versions (e.g. 'mf user_code a opt2'). It is ignored if present.
-The optional argumens 'opt' or 'noopt' or 'debug' set optimization
-or no optimization or debug compilation flags for the Fortran compiler.
-'opt' is the default. The 'config=xxx' option lets you overwrite
-the EGSnrc configuration to be used, which is otherwise specified by
-the EGS_CONFIG environment variable. Note that 'xxx' MUST
-be an absolute path to a EGSnrc configuration file.
+$my_name compiles the EGSnrc user code 'user_code'. The arguments 'f' and 'mf'
+are equivalent: 'm' results in a mortan compilation only. The argument 'a' is
+here for historical reasons and is now ignored. The optional arguments 'opt' or
+'noopt' or 'debug' respectively sets optimization, turns off optimization or
+sets the debug compilation flags for the Fortran compiler ('opt' is the
+default). The 'config=xxx' option lets you overwrite the EGSnrc configuration
+to be used, which is otherwise specified by the EGS_CONFIG environment variable.
+Note that 'xxx' MUST be an absolute path to a EGSnrc configuration file.
 
 EOF
     exit 1


### PR DESCRIPTION
Remove back quotes from the usage message, which were interpreted as
command substitution by the shell and caused the script to fail. Also
update the usage message and fix a couple typos.
