### PR TITLE
Go to application directory for pbsdsh batch mode

### DIFF
--- a/HEN_HOUSE/scripts/run_user_code_batch
+++ b/HEN_HOUSE/scripts/run_user_code_batch
@@ -399,6 +399,7 @@ if test $egs_batch_system = "pbsdsh"; then
     fi
 
     # submit the following stdin script to qsub, which will invoke the run_pbsdsh_task script
+    cd $egs_home/$user_code
     $batch_command $batch_options $queue $other_args <<EOF
 #!/bin/sh
 #PBS -l procs=$n_parallel


### PR DESCRIPTION
Go to the application directory before invoking PBS distributed shell
(pbsdsh) parallel runs, so that they can be launched from any location,
in particular from the home directory when submitting jobs remotely via
ssh.
