### PR TITLE
Fix #175: Fix two bugs in dosxyz_gui

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/load_input2_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/load_input2_nrc.tcl
@@ -518,7 +518,7 @@ proc read_input {} {
 
       set data [get_val $data arr 0]
       set imuphspout $arr(0)
-      if {$imuphspout>1 || $imusphspout<0} { set imuphspout 0 }
+      if {$imuphspout>1 || $imuphspout<0} { set imuphspout 0 }
  	  #now get the actual settings
       for {set i 1} {$i<=$numsets} {incr i} {
 	  gets $fileid data

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/reset_parameters_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/reset_parameters_nrc.tcl
@@ -177,6 +177,7 @@ proc reset_parameters { } {
     set the_beam_code {}
     set the_input_file {}
     set the_pegs_file {}
+    set the_vcu_code {}
 
     set values(21) {}
     set nbit1 {}


### PR DESCRIPTION
1. Error caused by variable, the_vcu_code, not defined
2. Typo: "imusphspout" instead of "imuphspout"
