### PR TITLE
Add egs++ volume calculation

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/geometry.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/geometry.doxy
@@ -317,6 +317,51 @@ developing new geometries and has helped to find numerous bugs
 in the initial implementations of the various geometry classes
 provided with \c egspp.
 
+\section volume_calculation Calculating volumes
+
+The volumes of regions or media in your geometry can be calculated via
+Monte Carlo sampling using the built in volume calculation. To perform the
+volume calculation, you define a box within which test points will be generated.
+Make sure that the box encloses your entire volume(s) of interest.
+
+The volumes of each region and medium are automatically printed as output.
+The user may also specify regions to calculate the volume in using labels.
+After setting labels in geometries of interest, list the labels under
+the \c labels input. For each label, the sum of the region volumes is output.
+
+To turn on <tt>volume calculation</tt>, include a new control block in your input
+file:
+\verbatim
+:start volume calculation:
+    passes = the number of recursion passes to create the octree
+    samples = the number samples to perform per node per pass
+    box min = 0 0 0
+    box max = 100 100 100
+    labels = labels you have added to your geometry using `set label`
+:stop volume calculation:
+\endverbatim
+
+For example:
+\verbatim
+:start volume calculation:
+    passes = 20
+    samples = 1e7
+    box min = 0 0 0
+    box max = 100 100 100
+    labels = detector
+:stop volume calculation:
+\endverbatim
+
+For the volume calculation, the sampling box is divided into progressively
+smaller voxels as the geometry is analyzed.
+Voxels are created in an \em octree, to provide higher sampling resolution in
+areas with a greater density of geometry regions.
+
+As the volume calculation progresses, the number of samplings in each region is
+adjusted according to the uncertainty on its volume. On each pass, regions
+with a higher uncertainty are sampled more often, while regions with lower
+uncertainty are sampled less often.
+
 \section geometry_view The geometry viewer: egs_view
 
 The geometry package comes with a viewer that can be used

--- a/HEN_HOUSE/doc/src/pirs898-egs++/geometry.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/geometry.doxy
@@ -42,13 +42,14 @@
 
   \anchor geometry_anchor
 
-\ref geometry_general <br>
-\ref geometry_design <br>
-\ref geometry_common <br>
-\ref geometry_media <br>
-\ref geometry_implementing <br>
-\ref geometry_view <br>
-\ref geometry_examples <br>
+\ref geometry_general<br>
+\ref geometry_design<br>
+\ref geometry_common<br>
+\ref geometry_media<br>
+\ref geometry_implementing<br>
+\ref volume_calculation<br>
+\ref geometry_view<br>
+\ref geometry_examples<br>
 
 \section geometry_general General discussion
 
@@ -329,14 +330,14 @@ The user may also specify regions to calculate the volume in using labels.
 After setting labels in geometries of interest, list the labels under
 the \c labels input. For each label, the sum of the region volumes is output.
 
-To turn on <tt>volume calculation</tt>, include a new control block in your input
-file:
+To turn on <tt>volume calculation</tt>, include a new control block in your
+input file:
 \verbatim
 :start volume calculation:
     passes = the number of recursion passes to create the octree
     samples = the number samples to perform per node per pass
-    box min = 0 0 0
-    box max = 100 100 100
+    box min = minX minY minZ
+    box max = maxX maxY maxZ
     labels = labels you have added to your geometry using `set label`
 :stop volume calculation:
 \endverbatim
@@ -346,21 +347,22 @@ For example:
 :start volume calculation:
     passes = 20
     samples = 1e7
-    box min = 0 0 0
+    box min = -100 -100 -100
     box max = 100 100 100
     labels = detector
 :stop volume calculation:
 \endverbatim
 
 For the volume calculation, the sampling box is divided into progressively
-smaller voxels as the geometry is analyzed.
-Voxels are created in an \em octree, to provide higher sampling resolution in
-areas with a greater density of geometry regions.
+smaller voxels as the geometry is analyzed on each pass. The algorithm follows
+the creation of an \em octree. Areas with a greater density of geometry
+regions end up with a higher density of voxels and thus are sampled more often
+in the volume calculation.
 
-As the volume calculation progresses, the number of samplings in each region is
-adjusted according to the uncertainty on its volume. On each pass, regions
-with a higher uncertainty are sampled more often, while regions with lower
-uncertainty are sampled less often.
+As the volume calculation progresses, the number of samplings in each octree
+node is also adjusted. On each pass, regions with a higher uncertainty
+on the volume are sampled more often, while regions with lower uncertainty
+are sampled less often.
 
 \section geometry_view The geometry viewer: egs_view
 

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -690,6 +690,11 @@ int EGS_Application::initGeometry() {
     }
     geometry->ref();
     geometry->setApplication(this);
+
+    if(rndm) {
+        geometry->printVolumes(input,rndm);
+    }
+
     return 0;
 }
 
@@ -749,9 +754,17 @@ int EGS_Application::initRNG() {
 
 int EGS_Application::initSimulation() {
     //if( !input ) { egsWarning("%s no input\n",__egs_app_msg2); return -1; }
-    egsInformation("In EGS_Application::initSimulation()\n");
+
+    egsInformation("\n================================================================================\n");
+    egsInformation("EGS_Application::initSimulation()\n");
+    egsInformation("Initializing simulation...\n\n");
     int err;
     bool ok = true;
+    err = initRNG();
+    if (err) {
+        egsWarning("\n\n%s RNG initialization failed\n",__egs_app_msg2);
+        ok = false;
+    }
     err = initGeometry();
     if (err) {
         egsWarning("\n\n%s geometry initialization failed\n",__egs_app_msg2);
@@ -760,11 +773,6 @@ int EGS_Application::initSimulation() {
     err = initSource();
     if (err) {
         egsWarning("\n\n%s source initialization failed\n",__egs_app_msg2);
-        ok = false;
-    }
-    err = initRNG();
-    if (err) {
-        egsWarning("\n\n%s RNG initialization failed\n",__egs_app_msg2);
         ok = false;
     }
     err = initRunControl();

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -43,6 +43,7 @@
 #define EGS_BASE_GEOMETRY_
 
 #include "egs_vector.h"
+#include "egs_rndm.h"
 
 #include <string>
 #include <vector>
@@ -730,6 +731,9 @@ public:
 
     /*! \brief Set the labels from an input string */
     int setLabels(const string &inp);
+    
+    /*! \brief Calculate the volumes of regions in the geometry */
+    void printVolumes(EGS_Input *input, EGS_RandomGenerator *rndm);
 
 protected:
 
@@ -1336,5 +1340,201 @@ struct EGS_GeometryIntersections {
   and the complete implementation:
 */
 
+class Volume_Info {
+public:
+    EGS_Vector          min, max;
+    EGS_BaseGeometry    *g;
+    EGS_RandomGenerator *rng;
+
+    // constructor
+    Volume_Info(EGS_Vector &bbmin, EGS_Vector &bbmax, EGS_BaseGeometry *geom, EGS_RandomGenerator *generator) {
+        min  = bbmin;
+        max  = bbmax;
+        g    = geom;
+        rng  = generator;
+    }
+};
+
+class Volume_Node {
+public:
+    double          ntry;
+    vector <double> nhit;
+    int             ix, iy, iz;             ///< octree indices, representing the binary location code of the node in x, y, z;
+    int             region;                 ///< region number of the node
+    unsigned short  level;                  ///< depth of the node (root node is level 0)
+    Volume_Node     *parent;                ///< pointer to the parent node (only root node can have parent set to NULL)
+    Volume_Node     **child;                ///< pointer to children nodes, NULL is there are no children
+
+    // constructor
+    Volume_Node(Volume_Info *v, Volume_Node *p, int index) {
+
+        // init child
+        child = NULL;
+
+        // set parent
+        parent = NULL;
+        if (p != NULL) parent = p;
+
+        // set level
+        if (parent != NULL) {
+            level = parent->level + 1;
+            ix = (parent->ix << 1) | (index>>0 & 0x1);
+            iy = (parent->iy << 1) | (index>>1 & 0x1);
+            iz = (parent->iz << 1) | (index>>2 & 0x1);
+        }
+        else {
+            level = 0;
+            ix = iy = iz = 0;
+        }
+
+        // set region number of the node
+        setRegion(v);
+
+        // allocate array of region hits
+        int nreg = v->g->regions();
+        for (int i=0; i<nreg; i++) {
+            nhit.push_back(0);
+        }
+        ntry = 0;
+    }
+    
+    ~Volume_Node() {
+        deleteChildren();
+    }
+
+    // setRegion
+    void setRegion (Volume_Info *v) {
+        EGS_Vector d  = (v->max - v->min) * (1.0/(double)(1<<level));
+        EGS_Vector r0 = v->min;
+        r0.x += (ix+0.5)*d.x;
+        r0.y += (iy+0.5)*d.y;
+        r0.z += (iz+0.5)*d.z;
+        region = v->g->isWhere(r0);
+    }
+
+    // create children nodes
+    void createChildren(Volume_Info *v) {                     // create children to the this node
+        if (!child) {                                           // ensure there are no children already
+            child = new Volume_Node* [8];                       // allocate memory for 8 new children nodes
+            for (int i=0; i<8; i++) {
+                child[i] = new Volume_Node(v, this, i);
+            }
+        }
+    }
+
+    // delete children (recursively)
+    void deleteChildren() {                                     // delete children of this node
+        if (child) {                                            // if this node has children, delete them
+            for (int i=0; i<8; i++) {
+                child[i]->deleteChildren();                     // recursive calls to delete all children branches
+                delete child[i];
+            }
+            delete [] child;                                    // free the memory allocated for the 8 children
+            child = NULL;                                       // set children pointer to NULL to indicate that there are no children anymore
+        }
+    }
+
+    // count the number of octree leaves
+    int countLeaves() {
+        int count = 1;
+        if (child) {
+            count -= 1;
+            for (int i=0; i<8; i++) {
+                count += child[i]->countLeaves();
+            }
+        }
+        return count;
+    }
+
+    // count memory
+    double countMem() {
+        int count = 1;
+        if (child) {
+            for (int i=0; i<8; i++) {
+                count += child[i]->countLeaves();
+            }
+        }
+        return (double)count*sizeof(Volume_Node)/1024.0/1024.0;
+    }
+
+    // sample region volumes
+    void sampleVolumes(Volume_Info *v, int nsample, vector<double> sigma, double avgSigma) {
+
+        if (child) {
+            for (int i=0; i<8; i++) {
+                child[i]->sampleVolumes(v, nsample, sigma, avgSigma);
+            }
+        }
+        else {
+            EGS_Vector d = (v->max - v->min) * (1.0/(double)(1<<level));
+            double minx = v->min.x + ix*d.x;
+            double miny = v->min.y + iy*d.y;
+            double minz = v->min.z + iz*d.z;
+            int nreg = v->g->regions();
+            int nsampleAdjusted;
+            if(avgSigma > 0) {
+                // Adjust the number sampled by this leaf using the
+                // deviation of the uncertainty from the average
+                // This increases the number of samples in regions with
+                // higher uncertainty
+                // The efficiency improvement is a factor of about 3.8
+                nsampleAdjusted = int(double(nsample) * sigma[region]*sigma[region] / (avgSigma*avgSigma));
+                //nsampleAdjusted = int(double(nsample) * sigma[region] / avgSigma);
+                //nsampleAdjusted = nsample;
+            } else {
+                nsampleAdjusted = nsample;
+            }
+            
+            for (long long i=0; i<nsampleAdjusted; i++) {
+                EGS_Vector r;
+                double rx = v->rng->getUniform();
+                double ry = v->rng->getUniform();
+                double rz = v->rng->getUniform();
+                r.x = minx + (d.x*rx);
+                r.y = miny + (d.y*ry);
+                r.z = minz + (d.z*rz);
+                int ireg = v->g->isWhere(r);
+                if (level < 8 && ireg != region) {
+                    createChildren(v);
+                    break;
+                }
+                else if (ireg >= 0 && ireg < nreg) {
+                    nhit[ireg]++;
+                }
+                ntry++;
+            }
+        }
+    }
+
+    // calculate region volumes
+    void calculateVolumes(Volume_Info *v, vector<double> &volume, vector<double> &sigma, int nreg, double &ntot, vector<double> &regionHits, vector<double> &regionTrys) {
+
+        if (child) {
+            for (int i=0; i<8; i++) {
+                child[i]->calculateVolumes(v, volume, sigma, nreg, ntot, regionHits, regionTrys);
+            }
+        }
+        else {
+            EGS_Vector d = (v->max - v->min) * (1.0/(double)(1<<level));
+            double vol = d.x*d.y*d.z;
+            if (region >= 0 && nhit[region] == ntry) {
+                volume[region] += vol;
+                regionHits[region] += nhit[region];
+                regionTrys[region] += ntry;
+            }
+            else if (ntry > 0) {
+                for (int i=0; i<nreg; i++) {
+                    double ave = nhit[i]/ntry;
+                    double var = (ave-ave*ave)/ntry;
+                    volume[i] += ave*vol;
+                    sigma[i]  += var*vol*vol;
+                    regionHits[i] += nhit[i];
+                    regionTrys[i] += ntry;
+                }
+            }
+            ntot += ntry;
+        }
+    }
+};
 
 #endif


### PR DESCRIPTION
Add a Monte Carlo volume calculation to `egs++`, originally designed by @ftessier. It can be turned on using `:start volume calculation:` in any input file. The recursive algorithm builds an octree with higher resolution in geometries with more regions. A user specified box is used as the boundary for sampling.

For example:

```
:start volume calculation:
    passes = the number of recursion passes to create the octree
    samples = the number samples to perform per node per pass
    box min = minX minY minZ
    box max = maxX maxY maxZ
    labels = labels you have added to your geometry using `set label`
:stop volume calculation:
```

For the volume calculation, the sampling box is divided into progressively smaller voxels as the geometry is analyzed on each pass. The algorithm follows the creation of an `octree`. Areas with a greater density of geometry  regions end up with a higher density of voxels and thus are sampled more often in the volume calculation.

As the volume calculation progresses, the number of samplings in each octree node is also adjusted. On each pass, regions with a higher uncertainty  on the volume are sampled more often, while regions with lower uncertainty are sampled less often.

_I'm open to suggestions on this implementation!_ Is is bad practice to add the `Volume_Node` and `Volume_Info` classes to `egs_base_geometry.h`? Maybe these should go in a separate file. Is there additional or alternative functionality we would like?
