### PR TITLE
Fix pegsless elements lowercase input

### DIFF
--- a/HEN_HOUSE/src/get_media_inputs.mortran
+++ b/HEN_HOUSE/src/get_media_inputs.mortran
@@ -681,6 +681,8 @@ $LOGICAL  iunrst_specified,stern_specified,iaprim_specified,
           df_if_rho_mismatch($MXMED);
 $LOGICAL  ex;
 
+$INTEGER CURSOR,Kconvert;
+
 "maybe we do not need to keep ZTBL REAL4, since it is only used here"
 $REAL4 ZTBL;
 
@@ -931,7 +933,10 @@ DO i=1,NMED[
    nmin=ival_elements;nmax=ival_elements;
    CALL GET_INPUT;
    IF(error_flags(ival_elements)=0)[
-   "now get fraction of each element"
+    DO j=1,nvalue(ival_elements)[
+        $CONVERT char_value(ival_elements,j) TO UPPER CASE;
+    ]
+    "now get fraction of each element"
     ival=ival+1;
     ival_pz=ival;
     nne_tmp=nvalue(ival_elements);


### PR DESCRIPTION
Change the elements to be automatically changed to upper case for pegsless input. This fixes a crash that occurs when the elements are not found due to the case mismatch.

For example, now you can use the following input:

```
:start glass:
    elements = O, Na, Si, Ca
    ...
```

where previously you were required to use:

```
:start glass:
    elements = O, NA, SI, CA
    ...
```
