### PR TITLE
Fix #90: Fix -ve ustep warnings with IAEA phsp source

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -11977,10 +11977,8 @@ ELSEIF(ISOURC = 21 | ISOURC=24)["Full phase space for each particle"
      VIN=VINOLD;
      WIN=WINOLD;
      WEIGHT=WEIGHTOLD;
-     IF((ISOURC=24 & (ALPHA24~=0 | BETA24~=0)) | IZSCORE=1)[
-       ICM=INIT_ICMOLD;
-       ZIN=ZINOLD;
-     ]
+     ICM=INIT_ICMOLD;
+     ZIN=ZINOLD;
      IF(I_MUPHSP_IN~=0)[
        "make sure any synchronized CMs do not change BEAM_MU_INDEX by setting"
        "BEAM_MU_INDEX_OLD to something different than BEAM_MU_INDEX"
@@ -12141,10 +12139,8 @@ ELSEIF(ISOURC = 21 | ISOURC=24)["Full phase space for each particle"
       CYCLNUM=1;
       XINOLD=XIN;
       YINOLD=YIN;
-      IF((ISOURC=24 & (ALPHA24~=0 | BETA24 ~=0))| IZSCORE=1)[
-         ZINOLD=ZIN;
-         INIT_ICMOLD=ICM;
-      ]
+      ZINOLD=ZIN;
+      INIT_ICMOLD=ICM;
       UINOLD=UIN;
       VINOLD=VIN;
       WINOLD=WIN;


### PR DESCRIPTION
Warnings were ultimately traced to cases where source particles
were recycled, in which case, unless an angled phase space source
(source no. 24) was used or Z was scored in the phase space
files (IZSCORE=1), the CM on which particles were incident was
not saved in variable INIT_ICMOLD.  The next time the particle
was used, INIT_ICM was set to a nonsense value.

The fix simply involved unconditionally saving INIT_ICM in
INIT_ICMOLD when particles are recycled.

Unsure why this bug has not appeared before.
