### PR TITLE
Fix beamdp GUI browser bug.

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/beamdp/browser.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamdp/browser.tcl
@@ -155,6 +155,9 @@ proc browse { dir next_proc_name flag labeltext } {
 			if [string match "*egs4phsp*" $i]==1 {
 			    .query.f1.list insert end $i
 			}
+                        if [string match "*IAEAphsp*" $i]==1 {
+                            .query.f1.list insert end $i
+                        }
 		    }
 		}
 	    }


### PR DESCRIPTION
Browser would only show IAEAphsp files if the GUI was
started in the directory containing the files.  Once
you navigated away and back into the directory, these
files were no longer visible.