### PR TITLE
Fix #201: Fix bug in addphsp adding to existing IAEA phsp files.

### DIFF
--- a/HEN_HOUSE/omega/progs/addphsp/addphsp.mortran
+++ b/HEN_HOUSE/omega/progs/addphsp/addphsp.mortran
@@ -204,7 +204,12 @@ ELSE[
 
 append=.false.;
 "first, see if the output file already exists"
-inquire(file=outfile,exist=ex);
+IF(i_iaea_in=1)[
+   inquire(file=$cstring(outfile)//'.IAEAphsp',exist=ex);
+]
+ELSE[
+   inquire(file=outfile,exist=ex);
+]
 IF(ex)[
    OUTPUT $cstring(outfile);
     (/' Output file ',A,' exists.'/


### PR DESCRIPTION
Bug was caused by addphsp not including the .IAEAphsp extension
when initially searching to see if the output phase space file
already existed.  As a result, it was impossible to add data
to an existing IAEA phsp file.