### PR TITLE
Fix egs inprz and egs gui gasp input

### DIFF
--- a/HEN_HOUSE/gui/egs_gui/pegs_page.cpp
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.cpp
@@ -224,6 +224,22 @@ void EGS_PegsPage::densityIcruChanged( bool is_on) {
   dc_group->setEnabled( is_on );
   rho_group->setEnabled( !is_on );
   medtype_cbox->setEnabled( !is_on );
+  is_gas->setEnabled( !is_on );
+  enable_gaspEdit();
+}
+
+void EGS_PegsPage::enable_gaspEdit()
+{
+   if(is_gas->isChecked() && !dc_icru_check->isChecked()) {
+    gaspLabel->setEnabled(true);
+    gaspEdit->setEnabled(true);
+    gaspUnits->setEnabled(true);
+   }
+   else {
+    gaspLabel->setEnabled(false);
+    gaspEdit->setEnabled(false);
+    gaspUnits->setEnabled(false);
+   }
 }
 
 void EGS_PegsPage::medtypeChanged( const QString &s )
@@ -422,7 +438,7 @@ void EGS_PegsPage::startPegs() {
   }
   if( comboBox2->currentText() == "kg/m**3" ) rho *= 0.001;//convert to g/cm**3
   ts << rho;
-  if( is_gas->isChecked() ) ts << ",GASP=1.0";
+  if( is_gas->isChecked() && !dc_icru_check->isChecked() && gaspEdit->text().toFloat()>0.0) ts << ",GASP= " << gaspEdit->text();
   ts << ",EPSTFL=" << dc_icru_check->isChecked() << ",IAPRIM="
      << rad_icru_check->isChecked() << ",IRAYL=" << rayleigh_check->isChecked()
      << " &END\n";

--- a/HEN_HOUSE/gui/egs_gui/pegs_page.h
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.h
@@ -115,6 +115,7 @@ public slots:
     void outputClosed();
     void launchReturned();
     void setConfigReader(EGS_ConfigReader *r);
+    void enable_gaspEdit();
 
 protected:
     void init();

--- a/HEN_HOUSE/gui/egs_gui/pegs_page.ui
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.ui
@@ -1,4 +1,6 @@
-<?xml version="1.0" encoding="UTF-8"?><ui version="4.0"><comment>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <comment>
 ###############################################################################
 #
 #  EGSnrc user interface for egs_gui pegs page
@@ -27,7 +29,7 @@
 #
 ###############################################################################
 </comment>
-<class>EGS_PegsPage</class>
+ <class>EGS_PegsPage</class>
  <widget class="QWidget" name="EGS_PegsPage">
   <property name="enabled">
    <bool>true</bool>
@@ -36,212 +38,261 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>645</width>
-    <height>618</height>
+    <width>1886</width>
+    <height>710</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QGroupBox" name="groupBox6">
-     <property name="minimumSize">
-      <size>
-       <width>261</width>
-       <height>281</height>
-      </size>
-     </property>
-     <property name="title">
-      <string>Medium composition</string>
-     </property>
-     <layout class="QVBoxLayout" name="verticalLayout">
-      <item>
-       <widget class="QTableWidget" name="composition_table">
-        <property name="rowCount">
-         <number>20</number>
-        </property>
-        <property name="columnCount">
-         <number>2</number>
-        </property>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <row/>
-        <column>
-         <property name="text">
-          <string>Element</string>
-         </property>
-        </column>
-        <column>
-         <property name="text">
-          <string>Fraction by weight</string>
-         </property>
-        </column>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <layout class="QVBoxLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_5">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QGroupBox" name="groupBox11">
-       <property name="title">
-        <string>Medium name</string>
+      <widget class="QGroupBox" name="groupBox6">
+       <property name="minimumSize">
+        <size>
+         <width>261</width>
+         <height>281</height>
+        </size>
        </property>
-       <layout class="QHBoxLayout">
+       <property name="title">
+        <string>Medium composition</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
         <item>
-         <widget class="QLineEdit" name="medname_le"/>
+         <widget class="QTableWidget" name="composition_table">
+          <property name="rowCount">
+           <number>20</number>
+          </property>
+          <property name="columnCount">
+           <number>2</number>
+          </property>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <row/>
+          <column>
+           <property name="text">
+            <string>Element</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Fraction by weight</string>
+           </property>
+          </column>
+         </widget>
         </item>
        </layout>
       </widget>
      </item>
      <item>
-      <layout class="QHBoxLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
-        <widget class="QGroupBox" name="groupBox8">
+        <widget class="QGroupBox" name="groupBox11">
          <property name="title">
-          <string>Medium type</string>
+          <string>Medium name</string>
          </property>
          <layout class="QHBoxLayout">
           <item>
-           <widget class="QComboBox" name="medtype_cbox">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <item>
-             <property name="text">
-              <string>Element</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Compound</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Mixture</string>
-             </property>
-            </item>
-           </widget>
+           <widget class="QLineEdit" name="medname_le"/>
           </item>
          </layout>
         </widget>
        </item>
        <item>
-        <widget class="QGroupBox" name="rho_group">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QGroupBox" name="groupBox8">
+           <property name="title">
+            <string>Medium type</string>
+           </property>
+           <layout class="QHBoxLayout">
+            <item>
+             <widget class="QComboBox" name="medtype_cbox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <item>
+               <property name="text">
+                <string>Element</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Compound</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>Mixture</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="rho_group">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="title">
+            <string>Mass density</string>
+           </property>
+           <layout class="QHBoxLayout">
+            <item>
+             <widget class="QLineEdit" name="rho_le"/>
+            </item>
+            <item>
+             <widget class="QComboBox" name="comboBox2">
+              <item>
+               <property name="text">
+                <string>g/cm**3</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>kg/m**3</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupBox3">
          <property name="title">
-          <string>Mass density</string>
+          <string>Options</string>
          </property>
-         <layout class="QHBoxLayout">
+         <layout class="QVBoxLayout" name="verticalLayout_3">
           <item>
-           <widget class="QLineEdit" name="rho_le"/>
-          </item>
-          <item>
-           <widget class="QComboBox" name="comboBox2">
+           <layout class="QVBoxLayout" name="verticalLayout_2">
             <item>
-             <property name="text">
-              <string>g/cm**3</string>
-             </property>
+             <widget class="QCheckBox" name="dc_icru_check">
+              <property name="text">
+               <string>ICRU density correction</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
             </item>
             <item>
-             <property name="text">
-              <string>kg/m**3</string>
-             </property>
+             <widget class="QCheckBox" name="rad_icru_check">
+              <property name="text">
+               <string>ICRU radiative stopping power</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
             </item>
-           </widget>
+            <item>
+             <widget class="QCheckBox" name="rayleigh_check">
+              <property name="text">
+               <string>Include Rayleigh data</string>
+              </property>
+              <property name="checked">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout">
+              <item>
+               <widget class="QCheckBox" name="is_gas">
+                <property name="text">
+                 <string>Medium is a gas</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>9</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item>
+               <widget class="QLabel" name="gaspLabel">
+                <property name="text">
+                 <string>gas pressure</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLineEdit" name="gaspEdit">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QLabel" name="gaspUnits">
+                <property name="text">
+                 <string>atm</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
+       </item>
+       <item>
+        <spacer name="spacer5">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeType">
+          <enum>QSizePolicy::Expanding</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>30</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>
-     <item>
-      <widget class="QGroupBox" name="groupBox3">
-       <property name="title">
-        <string>Options</string>
-       </property>
-       <layout class="QVBoxLayout">
-        <item>
-         <widget class="QCheckBox" name="dc_icru_check">
-          <property name="text">
-           <string>ICRU density correction</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="rad_icru_check">
-          <property name="text">
-           <string>ICRU radiative stopping power</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="rayleigh_check">
-          <property name="text">
-           <string>Include Rayleigh data</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="is_gas">
-          <property name="text">
-           <string>Medium is a gas</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
-     <item>
-      <spacer name="spacer5">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>20</width>
-         <height>30</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item>
     <widget class="QGroupBox" name="dc_group">
      <property name="title">
       <string>Density correction file</string>
@@ -284,7 +335,7 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item>
     <widget class="QGroupBox" name="groupBox5">
      <property name="title">
       <string>Energy range</string>
@@ -427,7 +478,7 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item>
     <widget class="QGroupBox" name="groupBox10">
      <property name="title">
       <string>PEGS Output</string>
@@ -510,7 +561,7 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
+   <item>
     <layout class="QHBoxLayout">
      <item>
       <spacer name="spacer4">
@@ -617,6 +668,22 @@
     <hint type="destinationlabel">
      <x>20</x>
      <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>is_gas</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>EGS_PegsPage</receiver>
+   <slot>enable_gaspEdit()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>1032</x>
+     <y>297</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>942</x>
+     <y>388</y>
     </hint>
    </hints>
   </connection>

--- a/HEN_HOUSE/gui/egs_inprz/include/inputRZImpl.h
+++ b/HEN_HOUSE/gui/egs_inprz/include/inputRZImpl.h
@@ -35,7 +35,6 @@
 
 #include "pegslessinputs.h"
 
-//qt3to4 -- BW
 #include "ui_inputRZ.h"
 
 #include "datainp.h"
@@ -43,39 +42,22 @@
 #include "eventfilter.h"
 #include "comboboxtooltip.h"
 #include "beamsrcdlg.h"
-//#include <q3table.h>
-//#include <q3header.h>
 #include <qtooltip.h>
-//#include <q3listbox.h>
 #include <qdialog.h>
 #include <qpushbutton.h>
 #include <qlayout.h>
-//#include <q3buttongroup.h>
-//Added by qt3to4:
-//qt3to4 -- BW
-//#include <Q3TextStream>
 #include <QLabel>
 
-//qt3to4 -- BW
 #include <QTextStream>
 
-//qt3to4 -- BW
-//class MTable;
-//class Q3Table;
 std::ifstream & operator >> ( std::ifstream & in, MInputRZ * r );
 template <class X>
-//qt3to4 -- BW
-//void get_col_content( const int &col, Q3Table* t, std::vector<X> &result );
 void get_col_content( const int &col, QTableWidget* t, std::vector<X> &result );
 
 template <class X>
-//qt3to4 -- BW
-//void get_col_explicit( const int &col, Q3Table* t, std::vector<X> &result, X def);
 void get_col_explicit( const int &col, QTableWidget* t, std::vector<X> &result, X def);
 
 template <class X>
-//qt3to4 -- BW
-//void update_table( std::vector<X> *v, int ini, int count, Q3Table* t );
 void update_table( std::vector<X> *v, int ini, int count, QTableWidget* t );
 
 template <class X>
@@ -94,8 +76,6 @@ std::vector<X> del_element( std::vector<X> v, X e );
   input blocks for the EGSnrc user codes: DOSRZnrc, CAVRZnrc,
   SPRRZnrc and FLURZnrc.
 */
-//qt3to4 -- BW
-//class inputRZImpl : public InputRZForm
 class inputRZImpl : public QWidget, public Ui::InputRZForm
 {
   Q_OBJECT
@@ -187,9 +167,6 @@ void update_PlotControl( const MPLOTInputs* EGSplot );
 
 void updateConfiguration( const QString & conf );
 
-//qt3to4 -- BW
-//void clear_table( Q3Table* t );
-//void clear_col( Q3Table* t, int col);
 void clear_table( QTableWidget* t );
 void clear_col( QTableWidget* t, int col);
 int  Add_New_Item( const char* ItemName, QComboBox* cb );
@@ -219,20 +196,8 @@ int TotalTextLines( const QString& fname);
 
 void update_mediaTable( const MGEOInputs* EGSgeo );
 void fill_media_table( const MGEOInputs* EGSgeo );
-//qt3to4 -- BW
-//void print_delimeter( const char* boundary , const char* section, Q3TextStream &t );
 void print_delimeter( const char* boundary , const char* section, QTextStream &t );
 void SetInitialDir();
-//qt3to4 -- BW
-/*
-void DeactivateTable( Q3Table* table );
-void InitializeTwoColumnTable( Q3Table* table );
-void InitializeThreeColumnTable( Q3Table* table, const QString& rvalue );
-void InitializeTable( Q3Table* t, const QStringList& s );
-void InitializeTable( Q3Table* t, const QStringList& s, v_float frac );
-void InitializeTable( Q3Table* t, const QString& s0, const QString& s1 );
-void InitializeTable( Q3Table* t, const QString& s0, const QString& s1, const QString& s2 );
-*/
 void DeactivateTable( QTableWidget* table );
 void InitializeTwoColumnTable( QTableWidget* table);
 void InitializeThreeColumnTable( QTableWidget* table, const QString& rvalue);
@@ -270,10 +235,6 @@ void     update_caption( const QString& str );
 
 bool pegs_is_ok( QString fname );
 bool pegsless_is_ok();
-//qt3to4 -- BW
-//bool IsByRegionsEnabled( QComboBox* cb, Q3Table* table );
-//bool IsByRegionsEnabled( QCheckBox* chk, Q3Table* table );
-//bool IsByRegionsEnabled( QRadioButton* rbOn, QRadioButton* rbOff, Q3Table* table );
 bool IsByRegionsEnabled( QComboBox* cb, QTableWidget* table );
 bool IsByRegionsEnabled( QCheckBox* chk, QTableWidget* table );
 bool IsByRegionsEnabled( QRadioButton* rbOn, QRadioButton* rbOff, QTableWidget* table );
@@ -283,13 +244,13 @@ void update_conf_files();
 
 void reset_mediaTable();
 void reset_customFFTable();
+bool GetMedFromDCfile(QString f);
 
 public slots:
     virtual void activate_fluence_table();
     virtual void activate_ff_table();
     virtual void update_source_type();
     virtual void update_usercode();
-//    virtual void update_run_mode();
     virtual void set_cavity();
     virtual void set_group();
     virtual void set_individual();
@@ -299,6 +260,10 @@ public slots:
     virtual void update_MediaInput();
     virtual void mediaTable_clicked(int row, int col);
     virtual void mediaTable_singleclicked(int row, int col);
+    virtual void enableDCfileInput(bool enable);
+    virtual void medTypeChanged(const QString& str);
+    virtual void pz_or_rhozTable_clicked(int row, int col);
+    virtual void pz_or_rhozTable_singleclicked(int row, int col);
     virtual void customFFTable_clicked(int row, int col);
     virtual void customFFTable_singleclicked(int row, int col);
     virtual void UpDateInputRZFile();
@@ -306,6 +271,7 @@ public slots:
     virtual void OpenEGSInpFile();
     virtual void GetMDfile();
     virtual void GetDFfile();
+    virtual void GetDFfileReturn();
     virtual void set_table_header_pbw();
     virtual void set_table_header_noa();
     virtual void enable_gaspEdit();

--- a/HEN_HOUSE/gui/egs_inprz/include/pegslessinputs.h
+++ b/HEN_HOUSE/gui/egs_inprz/include/pegslessinputs.h
@@ -40,12 +40,21 @@
 #define MXEL 14
 
 #include "inputblock.h"
-//Added by qt3to4:
-//qt3to4 -- BW
-//#include <Q3TextStream>
-
-//qt3to4 -- BW
 #include <QTextStream>
+
+struct Element {
+  int   Z;
+  std::string symbol;
+ float  aw;
+ float  Iev;
+ float  rho;
+};
+
+extern QStringList element_list;
+
+extern int n_element;
+
+extern Element element_data[];
 
 class PEGSLESSInputs : public MInputBlock
 {
@@ -73,11 +82,11 @@ class PEGSLESSInputs : public MInputBlock
         QString bc[MXMED];
         QString gasp[MXMED];
         bool isgas[MXMED];
+        bool use_dcfile[MXMED];
         QString dffile[MXMED];
         QString sterncid[MXMED];
+        float rho_scale[MXMED];
 };
 std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs * rPEGSLESS );
-//Q3TextStream   & operator << ( Q3TextStream &    t, PEGSLESSInputs * rPEGSLESS );
-//qt3to4 -- BW
 QTextStream   & operator << ( QTextStream &    t, PEGSLESSInputs * rPEGSLESS );
 #endif

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
@@ -1539,6 +1539,8 @@ void inputRZImpl::enableDCfileInput(bool is_checked) {
    DFgroupBox->setEnabled(is_checked);
    rhoGroupBox->setEnabled(!is_checked);
    medTypeGroupBox->setEnabled(!is_checked);
+   isGasCheckBox->setEnabled(!is_checked);
+   enable_gaspEdit();
 }
 
 enum MedIndex {Elem, Comp, Mixt};

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
@@ -37,6 +37,7 @@
 #include "commandManager.h"
 #include "executiondlgImpl.h"
 #include "eventfilter.h"
+#include "pegslessinputs.h"
 #include <qevent.h>
 #include <qlineedit.h>
 #include <qapplication.h>
@@ -69,7 +70,6 @@
 //#include <qsettings.h>
 //#include <qlibrary.h>
 
-//qt3to4 -- BW
 #include <QProcess>
 
 #define PIRS801 "pirs801.html"
@@ -153,8 +153,6 @@ geoErrors    =  "";
   ListFluTable->setEnabled( false );
 
   //Initialize table defining tops of output bins in MeV
-  //qt3to4 -- BW
-  //sloteFluTable->horizontalHeader()->setLabel(0,"bin top [MeV]");
   sloteFluTable->setHorizontalHeaderItem(0,new QTableWidgetItem("bin top [MeV]"));
 
   //Initialize the stopping power output mode table
@@ -170,7 +168,7 @@ geoErrors    =  "";
   InitializeTable( mediaTable, smed, frmed);
 
   //Initialize the pegsless medium table
-  InitializeTable( pz_or_rhozTable, "element", "no. of atoms" );
+  InitializeTable( pz_or_rhozTable, "Element", "Fraction by weight" );
   //Initialize FF table
   //customFFTable->setValidator(false);
   QStringList sl; sl.append("medium");sl.append("FF file (full path)");
@@ -189,8 +187,6 @@ geoErrors    =  "";
   InitializeTable( cylTable,  s );
 
   //Initialize cavity iformation
-  //qt3to4 -- BW
-  //cavTable->horizontalHeader()->setLabel(0,"region #");
   cavTable->setHorizontalHeaderItem(0,new QTableWidgetItem("region #"));
 
   //Initialize source information
@@ -225,7 +221,6 @@ geoErrors    =  "";
                           list_items(PEGSdir1,"*.pegs4dat")+list_items(PEGSdir2,"*.pegs4dat"),".pegs4dat");
   //get rid of duplicates
   pegsfiles.removeDuplicates();
-  //pegsfiles.prepend(PEGSdir);
   QStringList inpfiles = strip_extension( list_items(inpDir,"*.egsinp" ),
                          ".egsinp" );
   beamDlg = new BeamSourceDlg(this,"beam_source",&beamuc,&inpfiles,&pegsfiles);
@@ -244,18 +239,6 @@ geoErrors    =  "";
               "for info on building a source library)"));
 
   changeTextColor(beamLabel,"red");
-  /*
-  QToolTip::add( beamDlg->get_beam(), BEAM_CODE  );
-  QToolTip::add( beamDlg->get_inp(),  BEAM_INP  );
-  QToolTip::add( beamDlg->get_pegs(), BEAM_PEGS  );
-  QToolTip::add( beamDlg->get_min(), BEAM_MIN_WEIGHT  );
-  QToolTip::add( beamDlg->get_max(), BEAM_MAX_WEIGHT  );
-  QToolTip::add( beamDlg->get_dist(), BEAM_DIST  );
-  QToolTip::add( beamDlg->get_angle(), BEAM_ANGLE  );
-  QToolTip::add( beamDlg->get_zoffset(), BEAM_ZOFFSET  );
-  QToolTip::add( beamDlg->get_xoffset(), BEAM_XOFFSET  );
-  QToolTip::add( beamDlg->get_yoffset(), BEAM_YOFFSET  );
-  */
   beamDlg->get_beam()->setToolTip(BEAM_CODE  );
   beamDlg->get_inp()->setToolTip(BEAM_INP  );
   beamDlg->get_pegs()->setToolTip(BEAM_PEGS  );
@@ -280,38 +263,28 @@ geoErrors    =  "";
   InitializeThreeColumnTable( SMAXTable, "SMAX");
 
 // Tool tips for General Tab
-  //QToolTip::add(  UserCodeAreaButtonGroup, USER_CODE_AREA );
-  //qt3to4 -- BW
-  //Q3WhatsThis::add ( UserCodeAreaButtonGroup, USER_CODE_AREA );
   UserCodeAreaButtonGroup->setWhatsThis(USER_CODE_AREA );
   UserCodeAreaButtonGroup->setToolTip(USER_CODE_AREA );
 
-  //Q3WhatsThis::add ( PEGSDataAreaButtonGroup, PEGS4_AREA );
   PEGSDataAreaButtonGroup->setWhatsThis(PEGS4_AREA );
   PEGSDataAreaButtonGroup->setToolTip(PEGS4_AREA );
 
 
-  //Q3WhatsThis::add(  OpenFileButton, OPEN_INPUT_FILE );
-  //Q3WhatsThis::add(  Pegs4FileButton, OPEN_PEGS_FILE );
   OpenFileButton->setWhatsThis(OPEN_INPUT_FILE );
   Pegs4FileButton->setWhatsThis(OPEN_PEGS_FILE );
   OpenFileButton->setToolTip(OPEN_INPUT_FILE );
   Pegs4FileButton->setToolTip(OPEN_PEGS_FILE );
 
  // Tool tips for I/O Tab
- //Q3WhatsThis::add( DoseRegGroupBox , DOSE_REGIONS );
  DoseRegGroupBox->setWhatsThis(DOSE_REGIONS );
  DoseRegGroupBox->setToolTip(DOSE_REGIONS );
 
- //Q3WhatsThis::add( sloteFluEdit , SLOTE_FLU );
  sloteFluEdit->setWhatsThis(SLOTE_FLU );
  sloteFluEdit->setToolTip(SLOTE_FLU );
 
- //Q3WhatsThis::add( sloteFluLabel , SLOTE_FLU );
  sloteFluLabel->setWhatsThis(SLOTE_FLU );
  sloteFluLabel->setToolTip(SLOTE_FLU );
 
- //Q3WhatsThis::add( sloteFluTable, TOP_BIN_FLU );
  sloteFluTable->setWhatsThis(TOP_BIN_FLU );
  sloteFluTable->setToolTip(TOP_BIN_FLU );
 
@@ -332,105 +305,52 @@ iwatchTip = new ComboBoxToolTip( iwatchComboBox, 0, iwatch,
 
 ifullTip = new ComboBoxToolTip( ifullComboBox, 0, ifull_dos,
                                 sizeof ifull_dos / sizeof(char *) );
-/*
-QToolTip::add( maxCPUEdit, CPU_TIME  );
-QToolTip::add( maxCPULabel, CPU_TIME  );
-
-QToolTip::add( statEdit, ACCURACY  );
-QToolTip::add( statLabel, ACCURACY  );
-
-QToolTip::add( randGroupBox, RND_GEN  );
-
-QToolTip::add( rand1SpinBox, RND_1  );
-QToolTip::add( rand1Label, RND_1  );
-
-QToolTip::add( rand2SpinBox, RND_2  );
-QToolTip::add( rand2Label, RND_2  );
-
-QToolTip::add( SLOTEEdit, SLOTE  );
-QToolTip::add( SLOTELabel, SLOTE  );
-
-QToolTip::add( DELTAEEdit, DELTAE  );
-QToolTip::add( DELTAELabel, DELTAE  );
-
-QToolTip::add( phdTable, QString(SENSITIVE_VOL) + "\n" + QString(BIN_TOP)  +
-               QString(INDEPENDENT));
-
-QToolTip::add( kermaCheckBox, KERMA  );
-
-QToolTip::add( photregCheckBox, REGENERATION );
-*/
-//Q3WhatsThis::add( maxCPUEdit, CPU_TIME  );
-//Q3WhatsThis::add( maxCPULabel, CPU_TIME  );
 maxCPUEdit->setWhatsThis(CPU_TIME  );
  maxCPULabel->setWhatsThis(CPU_TIME  );
 
 maxCPUEdit->setToolTip(CPU_TIME  );
  maxCPULabel->setToolTip(CPU_TIME  );
 
-//Q3WhatsThis::add( statEdit, ACCURACY  );
-//Q3WhatsThis::add( statLabel, ACCURACY  );
 statEdit->setWhatsThis(ACCURACY  );
 statLabel->setWhatsThis(ACCURACY  );
 statEdit->setToolTip(ACCURACY  );
 statLabel->setToolTip(ACCURACY  );
 
-//Q3WhatsThis::add( randGroupBox, RND_GEN  );
 randGroupBox->setWhatsThis(RND_GEN  );
 randGroupBox->setToolTip(RND_GEN  );
 
-//Q3WhatsThis::add( rand1SpinBox, RND_1  );
-//Q3WhatsThis::add( rand1Label, RND_1  );
 rand1SpinBox->setWhatsThis(RND_1  );
 rand1Label->setWhatsThis( RND_1  );
 rand1SpinBox->setToolTip(RND_1  );
 rand1Label->setToolTip( RND_1  );
 
-//Q3WhatsThis::add( rand2SpinBox, RND_2  );
-//Q3WhatsThis::add( rand2Label, RND_2  );
 rand2SpinBox->setWhatsThis(RND_2  );
 rand2Label->setWhatsThis(RND_2  );
 rand2SpinBox->setToolTip(RND_2  );
 rand2Label->setToolTip(RND_2  );
 
-//Q3WhatsThis::add( SLOTEEdit, SLOTE  );
-//Q3WhatsThis::add( SLOTELabel, SLOTE  );
 SLOTEEdit->setWhatsThis(SLOTE  );
 SLOTELabel->setWhatsThis(SLOTE  );
 SLOTEEdit->setToolTip(SLOTE  );
 SLOTELabel->setToolTip(SLOTE  );
 
-//Q3WhatsThis::add( DELTAEEdit, DELTAE  );
-//Q3WhatsThis::add( DELTAELabel, DELTAE  );
 DELTAEEdit->setWhatsThis(DELTAE  );
 DELTAELabel->setWhatsThis( DELTAE  );
 DELTAEEdit->setToolTip(DELTAE  );
 DELTAELabel->setToolTip( DELTAE  );
 
-//Q3WhatsThis::add( phdTable, QString(SENSITIVE_VOL) + "\n" + QString(BIN_TOP)  +
-//                 QString(INDEPENDENT));
 phdTable->setWhatsThis(QString(SENSITIVE_VOL) + "\n" + QString(BIN_TOP)  +
                  QString(INDEPENDENT));
 phdTable->setToolTip(QString(SENSITIVE_VOL) + "\n" + QString(BIN_TOP)  +
                  QString(INDEPENDENT));
 
-//Q3WhatsThis::add( kermaCheckBox, KERMA  );
 kermaCheckBox->setWhatsThis(KERMA  );
 kermaCheckBox->setToolTip(KERMA  );
 
-//Q3WhatsThis::add( photregCheckBox, KERMA  );
 photregCheckBox->setWhatsThis(KERMA  );
 photregCheckBox->setToolTip(KERMA  );
 
  // Tool tips for geometry input Tab
-/*
-QToolTip::add( groupRadioButton, GROUPS  );
-QToolTip::add( individualRadioButton, INDIVIDUAL  );
-QToolTip::add( cavityRadioButton, CAVITY  );
-*/
-//Q3WhatsThis::add( groupRadioButton, GROUPS  );
-//Q3WhatsThis::add( individualRadioButton, INDIVIDUAL  );
-//Q3WhatsThis::add( cavityRadioButton, CAVITY  );
 groupRadioButton->setWhatsThis(GROUPS  );
 individualRadioButton->setWhatsThis(INDIVIDUAL  );
 cavityRadioButton->setWhatsThis(CAVITY  );
@@ -458,70 +378,15 @@ imodeComboBox->hide();
 imodeTip = new ComboBoxToolTip( imodeComboBox, 0,
            imode, sizeof imode / sizeof(char *) );
 
-/*
-QToolTip::add( localRadioButton, RAD_DIS_LOCAL);
-QToolTip::add( externalRadioButton, RAD_DIS_EXTERNAL);
-*/
-
-//Q3WhatsThis::add( localRadioButton, RAD_DIS_LOCAL);
-//Q3WhatsThis::add( externalRadioButton, RAD_DIS_EXTERNAL);
 localRadioButton->setWhatsThis( RAD_DIS_LOCAL);
 externalRadioButton->setWhatsThis(RAD_DIS_EXTERNAL);
 localRadioButton->setToolTip( RAD_DIS_LOCAL);
 externalRadioButton->setToolTip(RAD_DIS_EXTERNAL);
 
-//Q3WhatsThis::add( phasespaceGroupBox, PHSP_FILE );
 phasespaceGroupBox->setWhatsThis(PHSP_FILE );
 phasespaceGroupBox->setToolTip(PHSP_FILE );
 
   // Tool tips for Transport Parameters Tab
-  /*
-  QToolTip::add(  GPCUTGroupBox, GLOBAL_PCUT );
-  QToolTip::add(  GECUTGroupBox, GLOBAL_ECUT );
-  QToolTip::add(  GSMAXGroupBox, GLOBAL_SMAX );
-  QToolTip::add(  ESTEPELabel, ESTEPE_TIP );
-  QToolTip::add(  ESTEPEEdit, ESTEPE_TIP );
-  QToolTip::add(  XImaxEdit, XIMAX_TIP );
-  QToolTip::add(  XImaxLabel, XIMAX_TIP );
-  QToolTip::add(  SkinDepthEdit, SKINDEPTH_TIP );
-  QToolTip::add(  SkinDepthLabel, SKINDEPTH_TIP );
-  QToolTip::add(  SpinCheckBox, SPIN_EFFECTS );
-  QToolTip::add(  BCAGroupBox, BCA_TIP );
-  QToolTip::add(  PairAngSamplingGroupBox, PAIR_ANG_SAMPLING );
-  QToolTip::add(  BremsAngSamplingGroupBox, BREMS_ANG_SAMPLING );
-  QToolTip::add(  BoundComptongroupBox, BOUND_COMPTON );
-  QToolTip::add(  PEgroupBox, PE_ANG_SAMPLING );
-  QToolTip::add(  RayleighgroupBox, RAYLEIGH_SCAT );
-  QToolTip::add(  RelaxationgroupBox, RELAXATION_TIP );
-  QToolTip::add(  estep_algorithmGroupBox, ESTEPE_ALGORITHM );
-  QToolTip::add(  BremsXSectionGroupBox, BREMS_XSECTION );
-  QToolTip::add(  photonXSectiongroupBox, PHOTON_XSECTION );
-  QToolTip::add(  EIIgroupBox, EII_XSECTION );
-  */
-
-  /*
-  Q3WhatsThis::add(  GPCUTGroupBox, GLOBAL_PCUT );
-  Q3WhatsThis::add(  GECUTGroupBox, GLOBAL_ECUT );
-  Q3WhatsThis::add(  GSMAXGroupBox, GLOBAL_SMAX );
-  Q3WhatsThis::add(  ESTEPELabel, ESTEPE_TIP );
-  Q3WhatsThis::add(  ESTEPEEdit, ESTEPE_TIP );
-  Q3WhatsThis::add(  XImaxEdit, XIMAX_TIP );
-  Q3WhatsThis::add(  XImaxLabel, XIMAX_TIP );
-  Q3WhatsThis::add(  SkinDepthEdit, SKINDEPTH_TIP );
-  Q3WhatsThis::add(  SkinDepthLabel, SKINDEPTH_TIP );
-  Q3WhatsThis::add(  SpinCheckBox, SPIN_EFFECTS );
-  Q3WhatsThis::add(  BCAGroupBox, BCA_TIP );
-  Q3WhatsThis::add(  PairAngSamplingGroupBox, PAIR_ANG_SAMPLING );
-  Q3WhatsThis::add(  BremsAngSamplingGroupBox, BREMS_ANG_SAMPLING );
-  Q3WhatsThis::add(  BoundComptongroupBox, BOUND_COMPTON );
-  Q3WhatsThis::add(  PEgroupBox, PE_ANG_SAMPLING );
-  Q3WhatsThis::add(  RayleighgroupBox, RAYLEIGH_SCAT );
-  Q3WhatsThis::add(  RelaxationgroupBox, RELAXATION_TIP );
-  Q3WhatsThis::add(  estep_algorithmGroupBox, ESTEPE_ALGORITHM );
-  Q3WhatsThis::add(  BremsXSectionGroupBox, BREMS_XSECTION );
-  Q3WhatsThis::add(  photonXSectiongroupBox, PHOTON_XSECTION );
-  Q3WhatsThis::add(  EIIgroupBox, EII_XSECTION );
-  */
 
   GPCUTGroupBox->setWhatsThis(GLOBAL_PCUT );
   GECUTGroupBox->setWhatsThis(GLOBAL_ECUT );
@@ -576,53 +441,6 @@ phasespaceGroupBox->setToolTip(PHSP_FILE );
  RelaxationsGroupBox->setWindowTitle( RelaxationsGroupBox->title() );
   //Initialize Variance Reduction
 
-  /*
-  QToolTip::add(  eRangeRejCheckBox, RANGE_REJECTION );
-  QToolTip::add(  ESAVEINEdit, RR_ESAVEIN );
-  QToolTip::add(  ESAVEINLabel, RR_ESAVEIN );
-
-  QToolTip::add(  PhotonForcingCheckBox,  PHOTON_FORCING );
-  QToolTip::add(  StartForcingLabel, START_PHOTON_FORCING );
-  QToolTip::add(  StopForcingLabel, STOP_PHOTON_FORCING );
-  QToolTip::add(  StartForcingSpinBox, START_PHOTON_FORCING );
-  QToolTip::add(  StopForcingSpinBox, STOP_PHOTON_FORCING );
-
-  QToolTip::add(  ExpTrafoCLabel, EXPONENTIAL_TRANSPORT );
-  QToolTip::add(  ExpTrafoCEdit, EXPONENTIAL_TRANSPORT );
-
-  QToolTip::add( photonSplitSpinBox, PHOTON_SPLITTING );
-  QToolTip::add( photonSplitLabel, PHOTON_SPLITTING );
-
-  QToolTip::add(  RRDepthLabel, RUSSIAN_ROULETTE_DEPTH );
-  QToolTip::add(  RRDepthEdit, RUSSIAN_ROULETTE_DEPTH );
-  QToolTip::add(  RRFractionLabel, RUSSIAN_ROULETTE_FRACTION );
-  QToolTip::add(  RRFractionEdit, RUSSIAN_ROULETTE_FRACTION );
-  */
-//  QToolTip::add(  RRGroupBox, RUSSIAN_ROULETTE );
-
-  /*
-  Q3WhatsThis::add(  eRangeRejCheckBox, RANGE_REJECTION );
-  Q3WhatsThis::add(  ESAVEINEdit, RR_ESAVEIN );
-  Q3WhatsThis::add(  ESAVEINLabel, RR_ESAVEIN );
-
-  Q3WhatsThis::add(  PhotonForcingCheckBox,  PHOTON_FORCING );
-  Q3WhatsThis::add(  StartForcingLabel, START_PHOTON_FORCING );
-  Q3WhatsThis::add(  StopForcingLabel, STOP_PHOTON_FORCING );
-  Q3WhatsThis::add(  StartForcingSpinBox, START_PHOTON_FORCING );
-  Q3WhatsThis::add(  StopForcingSpinBox, STOP_PHOTON_FORCING );
-
-  Q3WhatsThis::add(  ExpTrafoCLabel, EXPONENTIAL_TRANSPORT );
-  Q3WhatsThis::add(  ExpTrafoCEdit, EXPONENTIAL_TRANSPORT );
-
-  Q3WhatsThis::add( photonSplitSpinBox, PHOTON_SPLITTING );
-  Q3WhatsThis::add( photonSplitLabel, PHOTON_SPLITTING );
-
-  Q3WhatsThis::add(  RRDepthLabel, RUSSIAN_ROULETTE_DEPTH );
-  Q3WhatsThis::add(  RRDepthEdit, RUSSIAN_ROULETTE_DEPTH );
-  Q3WhatsThis::add(  RRFractionLabel, RUSSIAN_ROULETTE_FRACTION );
-  Q3WhatsThis::add(  RRFractionEdit, RUSSIAN_ROULETTE_FRACTION );
-  */
-
   eRangeRejCheckBox->setWhatsThis(RANGE_REJECTION );
   ESAVEINEdit->setWhatsThis(RR_ESAVEIN );
   ESAVEINLabel->setWhatsThis(RR_ESAVEIN );
@@ -656,27 +474,6 @@ phasespaceGroupBox->setToolTip(PHSP_FILE );
   RRDepthEdit->setToolTip(RUSSIAN_ROULETTE_DEPTH );
   RRFractionLabel->setToolTip(RUSSIAN_ROULETTE_FRACTION );
   RRFractionEdit->setToolTip(RUSSIAN_ROULETTE_FRACTION );
-
-  /*
-  QToolTip::add( CSEnhancementGroupBox, CS_ENHANCEMENT_CAVRZNRC  );
-  QToolTip::add( CSEnhancementSpinBox, CS_ENHANCEMENT_FACTOR  );
-
-  QToolTip::add( BremsSplitCheckBox,  BREMS_SPLITTING );
-  QToolTip::add( BremsSplitSpinBox,  BREMS_SPLITTING_FACTOR );
-  QToolTip::add( BremsSplitTextLabel,  BREMS_SPLITTING_FACTOR );
-  QToolTip::add( ChargedPartRRCheckBox, CHARGED_PARTICLE_RR );
-  */
-
-
-  /*
-  Q3WhatsThis::add( CSEnhancementGroupBox, CS_ENHANCEMENT_CAVRZNRC  );
-  Q3WhatsThis::add( CSEnhancementSpinBox, CS_ENHANCEMENT_FACTOR  );
-
-  Q3WhatsThis::add( BremsSplitCheckBox,  BREMS_SPLITTING );
-  Q3WhatsThis::add( BremsSplitSpinBox,  BREMS_SPLITTING_FACTOR );
-  Q3WhatsThis::add( BremsSplitTextLabel,  BREMS_SPLITTING_FACTOR );
-  Q3WhatsThis::add( ChargedPartRRCheckBox, CHARGED_PARTICLE_RR );
-  */
 
   CSEnhancementGroupBox->setWhatsThis(CS_ENHANCEMENT_CAVRZNRC  );
   CSEnhancementSpinBox->setWhatsThis(CS_ENHANCEMENT_FACTOR  );
@@ -717,19 +514,10 @@ phasespaceGroupBox->setToolTip(PHSP_FILE );
   //Initialize the plot regions table
   InitializeTable( SpecPlotTable, "start", "stop" );
   //Some tool tips for Media Definition tab
-  /*
-  QToolTip::add( MDFEdit, MATERIAL_DATA_FILE);
-  QToolTip::add( inpmediaGroupBox, INPMEDIA_DEF);
-  QToolTip::add( inpmediumComboBox, MEDIUM_NAME);
-  QToolTip::add( DFEdit, DENSITY_FILE);
-  QToolTip::add( sterncidEdit, STERNCID);
-  */
 
   MDFEdit->setToolTip(MATERIAL_DATA_FILE);
   inpmediaGroupBox->setToolTip(INPMEDIA_DEF);
   inpmediumComboBox->setToolTip(MEDIUM_NAME);
-  DFEdit->setToolTip(DENSITY_FILE);
-  sterncidEdit->setToolTip(STERNCID);
 
   //event handler for inpmediumComboBox
   im_events = new ComboEvents(inpmediumComboBox,0);
@@ -1361,15 +1149,13 @@ void inputRZImpl::update_PEGSLESSParam( const PEGSLESSInputs* EGSpgls)
  MDFEdit->setText(EGSpgls->matdatafile);
 
  //set some defaults in the input window for material specified in .egsinp file
- pzRadioButton->setChecked(true);
- df_egs_homeRadioButton->setChecked(true);
- //qt3to4 -- BW
- //pz_or_rhozTable->horizontalHeader()->setLabel(1,"no. of atoms");
- pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("no. of atoms"));
- validate_combo("restricted total","ERROR in stopping power ratio specs",spComboBox);
- validate_combo("KM","ERROR in bremsstrahlung correction specs",bcComboBox);
  isGasCheckBox->setChecked(false);
  enable_gaspEdit();
+ medTypeChanged("Element");
+ DCcheckBox->setChecked(false);
+ enableDCfileInput(false);
+ ICRUradCheckBox->setChecked(false);
+ DFEdit->setText("");
 
  //set public (adjustable) values equal to values passed
  Ppgls = new PEGSLESSInputs;
@@ -1386,47 +1172,54 @@ void inputRZImpl::update_PEGSLESSParam( const PEGSLESSInputs* EGSpgls)
      Ppgls->pz_or_rhoz[i].push_back(EGSpgls->pz_or_rhoz[i][j]);
    }
    Ppgls->rho[i]=EGSpgls->rho[i];
+   Ppgls->rho_scale[i]=EGSpgls->rho_scale[i];
    Ppgls->spr[i]=EGSpgls->spr[i];
    Ppgls->bc[i]=EGSpgls->bc[i];
    Ppgls->gasp[i]=EGSpgls->gasp[i];
    Ppgls->isgas[i]=EGSpgls->isgas[i];
    Ppgls->dffile[i]=EGSpgls->dffile[i];
+   Ppgls->use_dcfile[i]=EGSpgls->use_dcfile[i]; 
    Ppgls->sterncid[i]=EGSpgls->sterncid[i];
  }
+
 
  if(EGSpgls->ninpmedia>0) {
     Ppgls->inpmedind=0; //set input medium index
     inpmediumComboBox->setEditText(EGSpgls->inpmedium[0]);
-    if(!EGSpgls->spec_by_pz[0]) {
-      rhozRadioButton->setChecked(true);
-      //qt3to4 -- BW
-      //pz_or_rhozTable->horizontalHeader()->setLabel(1,"mass fractions");
-      pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("mass fractions"));
-    }
+    if(!GetMedFromDCfile(Ppgls->dffile[0])) {
+       if(Ppgls->use_dcfile[0]) {
+           QString errStr = "Could not read composition from specified density correction file for medium "  + EGSpgls->inpmedium[0];
+           QMessageBox::information( this, " Warning",errStr, QMessageBox::Ok );
+       }
+       DCcheckBox->setChecked(false);
+       enableDCfileInput(false);
+    //fill the table based on previous info
+       if(Ppgls->nelements[0]==1) medTypeChanged("Element");
+       else if(Ppgls->spec_by_pz[0]) medTypeChanged("Compound");
+       else medTypeChanged("Mixture");
 
-    //now populate the table
-    for (int i=0; i<EGSpgls->nelements[0]; i++) {
-      //QString item1 = EGSpgls->elements[0][i];
-      //QString item2 =  EGSpgls->pz_or_rhoz[0][i];
-      //qt3to4 -- BW
-      QString item1 = QString::fromStdString(EGSpgls->elements[0][i]);
-      QString item2 =  QString::fromStdString(EGSpgls->pz_or_rhoz[0][i]);
-      //qt3to4 -- BW
-      //pz_or_rhozTable->setItem(i,0,new Q3TableItem(pz_or_rhozTable,Q3TableItem::OnTyping,item1));
-      //pz_or_rhozTable->setItem(i,1,new Q3TableItem(pz_or_rhozTable,Q3TableItem::OnTyping,item2));
-      pz_or_rhozTable->setItem(i,0,new QTableWidgetItem(item1));
-      pz_or_rhozTable->setItem(i,1,new QTableWidgetItem(item2));
-    }
+    //now populate the element table
+      for (int i=0; i<EGSpgls->nelements[0]; i++) {
+        QString item1 = QString::fromStdString(EGSpgls->elements[0][i]);
+        QString item2 =  QString::fromStdString(EGSpgls->pz_or_rhoz[0][i]);
+        pz_or_rhozTable->setItem(i,0,new QTableWidgetItem(item1));
+        pz_or_rhozTable->setItem(i,1,new QTableWidgetItem(item2));
+      }
 
-    //get the other values
-    rhoEdit->setText(EGSpgls->rho[0]);
-    validate_combo(EGSpgls->spr[0].toLatin1().data(),"ERROR in stopping power ratio specs",spComboBox);
-    validate_combo(EGSpgls->bc[0].toLatin1().data(),"ERROR in bremsstrahlung correction specs",bcComboBox);
+      //get the other values
+      rhoEdit->setText(EGSpgls->rho[0]);
+      DFEdit->setText(EGSpgls->dffile[0]);
+    }
+    else {
+      DCcheckBox->setChecked(true);
+      enableDCfileInput(true);
+    }
+    //get parameters that do not depend on density correction file specified
     gaspEdit->setText(EGSpgls->gasp[0]);
     isGasCheckBox->setChecked(EGSpgls->isgas[0]);
     enable_gaspEdit();
-    DFEdit->setText(EGSpgls->dffile[0]);
-    sterncidEdit->setText(EGSpgls->sterncid[0]);
+    if(EGSpgls->bc[0]=="NRC") ICRUradCheckBox->setChecked(true);
+    else ICRUradCheckBox->setChecked(false);
   }
 
   if(EGSpgls->ninpmedia>0 || EGSpgls->matdatafile!="" ) {
@@ -1455,8 +1248,14 @@ void inputRZImpl::inpmediumSave( const QString& str)
     }
     //save data for current medium
     Ppgls->inpmedium[ind]=inpmediumComboBox->currentText();
-    Ppgls->spec_by_pz[ind]=true;
-    if(rhozRadioButton->isChecked()) Ppgls->spec_by_pz[ind]=false;
+    if(ICRUradCheckBox->isChecked()) Ppgls->bc[ind]="NRC";
+    else Ppgls->bc[ind]="KM";
+    Ppgls->isgas[ind]=isGasCheckBox->isChecked();
+    Ppgls->gasp[ind]=gaspEdit->text();
+    if(Ppgls->isgas[ind] && (Ppgls->gasp[ind]=="" || Ppgls->gasp[ind].toFloat()<=0.0)) Ppgls->gasp[ind]="1.0";
+    gaspEdit->setText(Ppgls->gasp[ind]);
+    Ppgls->spec_by_pz[ind]=false;
+    if(medTypeComboBox->currentText()=="Compound") Ppgls->spec_by_pz[ind]=true;
     //see if any elements are present in the table
     int nrow=0;
     int nelements=0;
@@ -1466,35 +1265,102 @@ void inputRZImpl::inpmediumSave( const QString& str)
          Ppgls->elements[ind].clear();
          Ppgls->pz_or_rhoz[ind].clear();
        }
-       //qt3to4 -- BW
-       //Ppgls->elements[ind].push_back(pz_or_rhozTable->text(nrow,0));
-       //Ppgls->pz_or_rhoz[ind].push_back(pz_or_rhozTable->text(nrow,1));
-       //qt3to4 -- BW
        if(pz_or_rhozTable->item(nrow,0))
             Ppgls->elements[ind].push_back(pz_or_rhozTable->item(nrow,0)->text().toStdString());
        if(pz_or_rhozTable->item(nrow,1))
             Ppgls->pz_or_rhoz[ind].push_back(pz_or_rhozTable->item(nrow,1)->text().toStdString());
-       //Ppgls->elements[ind].push_back(pz_or_rhozTable->text(nrow,0).toStdString());
-       //Ppgls->pz_or_rhoz[ind].push_back(pz_or_rhozTable->text(nrow,1).toStdString());
        nelements++;
        nrow++;
     }
     Ppgls->nelements[ind]=nelements;
     //now save other data
     Ppgls->rho[ind]=rhoEdit->text();
-    Ppgls->spr[ind]=spComboBox->currentText();
-    Ppgls->bc[ind]=bcComboBox->currentText();
-    Ppgls->isgas[ind]=isGasCheckBox->isChecked();
-    Ppgls->gasp[ind]=gaspEdit->text();
-    if(Ppgls->isgas[ind] && (Ppgls->gasp[ind]=="" || Ppgls->gasp[ind].toFloat()<=0.0)) Ppgls->gasp[ind]="1.0";
-    gaspEdit->setText(Ppgls->gasp[ind]);
+    Ppgls->rho_scale[ind]=1.;
+    if(rhoScaleComboBox->currentIndex()==1) Ppgls->rho_scale[ind]=0.001;
     Ppgls->dffile[ind]=DFEdit->text();
-    Ppgls->sterncid[ind]=sterncidEdit->text();
+    if(DCcheckBox->isChecked())  Ppgls->use_dcfile[ind]=true;
+    else Ppgls->use_dcfile[ind]=false;
   }
   //update list of available media
   listMedia = getPEGSLESSMedia();
   updateMediaLists();
 }
+
+void inputRZImpl::GetDFfileReturn()
+{
+//slot actuated when return pressed in DC file entry box
+   if(!GetMedFromDCfile(DFEdit->text())){
+      QString errStr = "Could not open density correction file "  + DFEdit->text();
+               errStr += "\nPlease select another file and try again!";
+        QMessageBox::information( this, " Warning",errStr, QMessageBox::Ok );
+   }
+}
+
+bool inputRZImpl::GetMedFromDCfile(QString f)
+{
+   if ( !f.isEmpty() ) {
+      QString fname=f;
+      QChar s = QDir::separator();
+      //if the file separator character is in the name, assume
+      //full path specified along with .density extension
+      if(!QFile(fname).exists()) {
+        //start looking following same priority as in 
+        //get_media_inputs
+        //assume .density ext not included
+        fname=ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s + f + ".density");
+        if(!QFile(fname).exists()) {
+          //look in subdirectories
+          fname=ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s + "elements" + s + f + ".density");
+          if(!QFile(fname).exists()) {
+             fname=ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s + "compounds" + s + f + ".density");
+             if(!QFile(fname).exists()) {
+             //look in density subdirectory in case still there
+               fname=ironIt(EGS_HOME + s + "pegs4" + s + "density" + s + f + ".density");
+               if(!QFile(fname).exists()) {
+                //look in HEN_HOUSE
+                fname=ironIt(HEN_HOUSE + s + "pegs4" + s + "density_corrections" + s + "elements" + s + f + ".density");
+                if(!QFile(fname).exists()) {
+                  fname=ironIt(HEN_HOUSE + s + "pegs4" + s + "density_corrections" + s + "compounds" + s + f + ".density");
+                  if(!QFile(fname).exists()) return false;
+                }
+               }
+             }
+           }
+          }
+      }
+      //now open the file if possible and read the composition of
+      //the medium
+      QFile df(fname);
+      QFileInfo fi(fname);
+      if(!df.open(QFile::ReadOnly)) return false;
+      char buf[256]; df.readLine(buf,255);//ignore first line
+      QTextStream data(&df);
+      int ndat, nelem; double Iev, rho;
+      data >> ndat >> Iev >> rho >> nelem;
+      if(nelem==1) {
+        medTypeChanged("Element");
+      }
+      else {
+        medTypeChanged("Mixture");
+      }
+      //modify elements of medium def. tab
+      rhoEdit->setText(QString("%1").arg(rho));
+      rhoScaleComboBox->setCurrentIndex(0);
+      //first clear the element table
+      for( int j=0; j< pz_or_rhozTable->rowCount(); j++) {
+         pz_or_rhozTable->setItem(j,0,0); pz_or_rhozTable->setItem(j,1,0);
+      }
+      //now put the elements of this medium in
+      for(int j=0; j<nelem; j++) {
+         int iz; double frac; data >> iz >> frac;
+         pz_or_rhozTable->setItem(j,0,new QTableWidgetItem(QString::fromStdString(element_data[iz-1].symbol)));
+         pz_or_rhozTable->setItem(j,1,new QTableWidgetItem(QString("%1").arg(frac)));
+      }
+      DFEdit->setText(fi.absoluteFilePath());
+      return true;
+    }
+    return false;
+};
 
 void inputRZImpl::inpmediumChanged( const QString& str)
 {
@@ -1504,69 +1370,75 @@ void inputRZImpl::inpmediumChanged( const QString& str)
   Ppgls->inpmedind=ind;
 
   if(ind<Ppgls->ninpmedia) {
-    if(Ppgls->spec_by_pz[ind]) pzRadioButton->setChecked(true);
-    if(!Ppgls->spec_by_pz[ind]) rhozRadioButton->setChecked(true);
 
-    //now populate the table
+    //first, fill the table based on previous info
+    if(Ppgls->nelements[ind]==1) medTypeChanged("Element");
+    else if(Ppgls->spec_by_pz[ind]) medTypeChanged("Compound");
+    else medTypeChanged("Mixture");
+
+       //now populate the element table
     for (int i=0; i<Ppgls->nelements[ind]; i++) {
-      //qt3to4 -- BW
-      //QString item1 = Ppgls->elements[ind][i];
-      //QString item2 =  Ppgls->pz_or_rhoz[ind][i];
-       QString item1 = QString::fromStdString(Ppgls->elements[ind][i]);
-       QString item2 = QString::fromStdString(Ppgls->pz_or_rhoz[ind][i]);
-      //qt3to4 -- BW
-      //pz_or_rhozTable->setItem(i,0,new Q3TableItem(pz_or_rhozTable,Q3TableItem::OnTyping,item1));
-      //pz_or_rhozTable->setItem(i,1,new Q3TableItem(pz_or_rhozTable,Q3TableItem::OnTyping,item2));
-      pz_or_rhozTable->setItem(i,0,new QTableWidgetItem(item1));
-      pz_or_rhozTable->setItem(i,1,new QTableWidgetItem(item2));
+         QString item1 = QString::fromStdString(Ppgls->elements[ind][i]);
+         QString item2 = QString::fromStdString(Ppgls->pz_or_rhoz[ind][i]);
+         pz_or_rhozTable->setItem(i,0,new QTableWidgetItem(item1));
+         pz_or_rhozTable->setItem(i,1,new QTableWidgetItem(item2));
     }
-    //clear any other items in there
-    //qt3to4 -- BW
-    //for (int i=Ppgls->nelements[ind]; i<pz_or_rhozTable->numRows(); i++) {
+       //clear any other items in there
     for (int i=Ppgls->nelements[ind]; i<pz_or_rhozTable->rowCount(); i++) {
-        //pz_or_rhozTable->clearCell(i,0);
-        //pz_or_rhozTable->clearCell(i,1);
-        pz_or_rhozTable->setItem(i,0,0);
-        pz_or_rhozTable->setItem(i,1,0);
+         pz_or_rhozTable->setItem(i,0,0);
+         pz_or_rhozTable->setItem(i,1,0);
     }
     //get the other values
     rhoEdit->setText(Ppgls->rho[ind]);
-    validate_combo(Ppgls->spr[ind].toLatin1().data(),"ERROR in stopping power ratio specs",spComboBox);
-    validate_combo(Ppgls->bc[ind].toLatin1().data(),"ERROR in bremsstrahlung correction specs",bcComboBox);
+    if(Ppgls->rho_scale[ind]<1.) rhoScaleComboBox->setCurrentIndex(1);
+    else rhoScaleComboBox->setCurrentIndex(0);
+    DFEdit->setText(Ppgls->dffile[ind]);
     gaspEdit->setText(Ppgls->gasp[ind]);
     isGasCheckBox->setChecked(Ppgls->isgas[ind]);
     enable_gaspEdit();
-    DFEdit->setText(Ppgls->dffile[ind]);
-    sterncidEdit->setText(Ppgls->sterncid[ind]);
+    if(Ppgls->bc[ind]=="NRC") ICRUradCheckBox->setChecked(true);
+    else ICRUradCheckBox->setChecked(false);
+    DCcheckBox->setChecked(false);
+    enableDCfileInput(false);
+
+    //if the user wants to use a dc file, then attempt to read in
+    //medium comp. from it
+    if(Ppgls->use_dcfile[ind]) {
+       if(!GetMedFromDCfile(Ppgls->dffile[ind])) {
+           QString errStr = "Could not read composition from specified density correction file for medium "  + Ppgls->inpmedium[ind];
+           QMessageBox::information( this, " Warning",errStr, QMessageBox::Ok );
+           Ppgls->use_dcfile[ind]=false;
+           DCcheckBox->setChecked(false);
+           enableDCfileInput(false);
+       }
+       else {
+           DCcheckBox->setChecked(true);
+           enableDCfileInput(true);
+       }
+    }
   }
   else if(ind==Ppgls->ninpmedia) {
     //prepare to add a new medium
     //clear the table and set defaults
-    pzRadioButton->setChecked(true);
-    //qt3to4 -- BW
-    //for (int i=0; i<pz_or_rhozTable->numRows(); i++) {
+    //default to Element: we could quibble with this
+    medTypeChanged("Element");
+    //clear the element table
     for (int i=0; i<pz_or_rhozTable->rowCount(); i++) {
-        //pz_or_rhozTable->clearCell(i,0);
-        //pz_or_rhozTable->clearCell(i,1);
         pz_or_rhozTable->setItem(i,0,0);
         pz_or_rhozTable->setItem(i,1,0);
     }
     rhoEdit->setText("");
-    validate_combo("restricted total","ERROR in stopping power ratio specs",spComboBox);
-    validate_combo("KM","ERROR in bremsstrahlung correction specs",bcComboBox);
+    rhoScaleComboBox->setCurrentIndex(0);
     gaspEdit->setText("");
     isGasCheckBox->setChecked(false);
     enable_gaspEdit();
     DFEdit->setText("");
-    sterncidEdit->setText("");
+    enableDCfileInput(false);
+    DCcheckBox->setChecked(false);
+    ICRUradCheckBox->setChecked(false);
   }
   //now update the list of media
   QStringList medlst;
-  /* old way
-  for(int i=0; i<Ppgls->ninpmedia; i++) {
-     medlst+=Ppgls->inpmedium[i];
-  }
-  */
   //at this point, delete media that are blank or have blank as first character
   int k=0;
   for(int i=0; i<Ppgls->ninpmedia; i++) {
@@ -1586,10 +1458,12 @@ void inputRZImpl::inpmediumChanged( const QString& str)
              Ppgls->pz_or_rhoz[k].push_back(temppz_or_rhoz[j]);
           }
           Ppgls->rho[k]=Ppgls->rho[i];
+          Ppgls->rho_scale[k]=Ppgls->rho_scale[i];
           Ppgls->spr[k]=Ppgls->spr[i];
           Ppgls->bc[k]=Ppgls->bc[i];
           Ppgls->gasp[k]=Ppgls->gasp[i];
           Ppgls->dffile[k]=Ppgls->dffile[i];
+          Ppgls->use_dcfile[k]=Ppgls->use_dcfile[i];
           Ppgls->sterncid[k]=Ppgls->sterncid[i];
           medlst+=Ppgls->inpmedium[k];
           k++;
@@ -1603,6 +1477,94 @@ void inputRZImpl::inpmediumChanged( const QString& str)
   inpmediumComboBox->setCurrentIndex(ind);
 }
 
+void inputRZImpl::pz_or_rhozTable_clicked(int row, int col) {
+   if(col == 0) {
+     QString str;
+     if(pz_or_rhozTable->item(row,col)) str = pz_or_rhozTable->item(row,col)->text();
+     //if elements has not bee initialized yet, do so
+    //these global variables are defined in peglessinputs.h
+     if(element_list.size()==0) {
+     //copy element symbols into elements
+        for(int j=0; j<n_element; j++) element_list << QString::fromStdString(element_data[j].symbol);
+     }
+     QComboBox *e = new QComboBox;
+     e->addItems(element_list);
+     if(!str.isNull()) {//see if it's already in the media list
+         bool found=false;
+         for(int i=0; i<e->count(); i++) {
+              if(str == e->itemText(i)){
+                found=true;
+                e->setCurrentIndex(i);
+                break;
+              }
+         }
+         if(!found) {
+              e->insertItem(0,str);
+              e->setCurrentIndex(0);
+         }
+     }
+     pz_or_rhozTable->setCellWidget(row,col,e);
+   }
+}
+     
+void inputRZImpl::pz_or_rhozTable_singleclicked( int row, int col) {
+   if(col == 0) {
+     QWidget *editor = pz_or_rhozTable->cellWidget( row, col );
+     if(!editor) {//protect any text already there
+       QTableWidgetItem* w =  pz_or_rhozTable->item(row,col);
+       if(w) {
+          QString str = w->text();
+          pz_or_rhozTable->setItem(row,col,new QTableWidgetItem(str));
+       }
+     }
+   }
+//if we click away from a comboBox, freeze it and just display the text
+   for(int irow =0; irow <pz_or_rhozTable->rowCount(); irow++) {
+     if(row != irow || col !=0) {
+       QWidget *editor = pz_or_rhozTable->cellWidget( irow, 0 );
+       if(editor) {
+        if(string(editor->metaObject()->className())=="QComboBox"){
+          QComboBox* cb = (QComboBox*)editor;
+          QString str = cb->currentText();
+          pz_or_rhozTable->removeCellWidget(irow,0);
+          pz_or_rhozTable->setItem(irow,0,new QTableWidgetItem(str));
+        }
+      }
+     }
+   }
+}
+
+void inputRZImpl::enableDCfileInput(bool is_checked) {
+   pz_or_rhozTable->setEnabled (!is_checked);
+   DFgroupBox->setEnabled(is_checked);
+   rhoGroupBox->setEnabled(!is_checked);
+   medTypeGroupBox->setEnabled(!is_checked);
+}
+
+enum MedIndex {Elem, Comp, Mixt};
+
+void inputRZImpl::medTypeChanged( const QString &s) {
+
+  if( s == "Compound" ) {
+     pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("Stoichiometric index"));
+     medTypeComboBox->setCurrentIndex(Comp);
+  }
+  else if(s== "Mixture") {
+     pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("Fraction by weight"));
+     medTypeComboBox->setCurrentIndex(Mixt);
+  }
+  else if(s=="Element") {
+     pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("Fraction by weight"));
+     medTypeComboBox->setCurrentIndex(Elem);
+  }
+  bool ro = s == "Element";
+  for(int j=0; j < pz_or_rhozTable->rowCount(); j++) {
+    if( ro && j>0 ) {
+      pz_or_rhozTable->setItem(j,0,0); pz_or_rhozTable->setItem(j,1,0);
+    }
+  }
+}
+     
 //end of PEGSLESS routines
 
 void inputRZImpl::update_MCTParam( const MMCPInputs*  EGSmcp )
@@ -2448,7 +2410,6 @@ void inputRZImpl::fill_media_table( const MGEOInputs* EGSgeo )
 
     v_string vstr[1];
     vstr[0] = medium;
-    //qt3to4 -- BW
      vector<QString> vqs[1];
      for(int j=0; j<vstr[0].size(); j++) {
          vqs[0].push_back(vstr[0][j].c_str());
@@ -2546,8 +2507,6 @@ void inputRZImpl::update_mediaTable( const MGEOInputs* EGSgeo )
 //the medium data is changed
 void inputRZImpl::reset_mediaTable ()
 {
-    //qt3to4 -- BW
-    //for(int row=0; row<mediaTable->numRows(); row++) {
     for(int row=0; row<mediaTable->rowCount(); row++) {
        QWidget *editor = mediaTable->cellWidget( row, 0 );
        if(editor) {
@@ -2993,18 +2952,12 @@ void inputRZImpl::update_files( const QString & rDirName, QComboBox* cb, const Q
        if      ( dirName == homeDir )      dirName = hen_houseDir;
        else if ( dirName == hen_houseDir ) dirName = homeDir;
 
-       //qt3to4 -- BW
-       //if ( !d.cd( dirName, true ) ) {
          if ( !d.cd( dirName)) {
-          //dirName = EGS_HOME;
-          //if ( !d.cd( dirName, true ) ) {
              QString information = (QString)"<b>Directory</b> " +
                                                    dirName      +
                                    (QString)" used in your input file does not exist !<br>";
              openErrors += information;
-             //QMessageBox::warning ( this, "Attention", information, 1, 0, 0 );
              return;
-          //}
        }
        if ( dirName == homeDir || dirName == hen_houseDir )
           update_EGSdir( dirName );
@@ -3014,12 +2967,8 @@ void inputRZImpl::update_files( const QString & rDirName, QComboBox* cb, const Q
     d.setNameFilters( QStringList(rFilter) );
     d.setSorting( QDir::Name | QDir::IgnoreCase );
 
-    //qt3to4 -- BW
-    //const QFileInfoList *list = d.entryInfoList();
     const QFileInfoList list = d.entryInfoList();
-    //QFileInfoListIterator it( list );      // create list iterator
     QFileInfoList::const_iterator it;
-    //QFileInfo *fi;                          // pointer for traversing
     QFileInfo fi;
 
     QString tmpText;

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
@@ -37,37 +37,25 @@
 #include "executiondlgImpl.h"
 #include <qlineedit.h>
 #include <qapplication.h>
-//#include <q3filedialog.h>
 #include <qlabel.h>
 #include <qmessagebox.h>
 #include <qcombobox.h>
 #include <qradiobutton.h>
 #include <qspinbox.h>
 #include <qcheckbox.h>
-//#include <q3groupbox.h>
-//#include <q3table.h>
-//Added by qt3to4:
-//#include <Q3TextStream>
 #include <iterator>
 #include <qtabwidget.h>
 #include <qpushbutton.h>
 #include <qdir.h>
-//#include <q3progressdialog.h>
-//#include <q3buttongroup.h>
 #include <qwidget.h>
 #include <qpainter.h>
-//#include <q3paintdevicemetrics.h>
 #include <qprinter.h>
 #include <qvalidator.h>
 #include <typeinfo>
-//#include <q3whatsthis.h>
-//#include <q3process.h>
 #include <qsettings.h>
-//#include <q3dockwindow.h>
 #include <qlibrary.h>
 #include <egs_config_reader.h>
 
-//qt3to4 -- BW
 #include <QTextStream>
 #include <iostream>
 #include <QFileDialog>
@@ -78,12 +66,9 @@ using namespace std;
 
 inputRZImpl::inputRZImpl( QWidget* parent, const char* name,
              bool modal, Qt::WFlags f )
-//qt3to4 -- BW
-//           : InputRZForm( parent, name, f )
              : QWidget(parent)
 {
 
-    //qt3to4 -- BW
     setupUi(this);
     Initialize();
     SetValidator( );
@@ -442,7 +427,6 @@ void inputRZImpl::checkCompilationAbility(){
       "<br><b>Compilation disabled since following files missing:</b><br>" +
                       missing_files;
       confErrors += missing_files;
-      //QMessageBox::warning ( this, "Warning", missing_files, 1, 0, 0 );
   }
 
   caught_errors();
@@ -716,14 +700,11 @@ void inputRZImpl::customFFTable_singleclicked( int row, int col) {
    if(col == 0) {
      QWidget *editor = customFFTable->cellWidget( row, col );
      if(!editor) {//protect any text already there
-       //qt3to4 -- BW
        QTableWidgetItem* w =  customFFTable->item(row,col);
        if(w) {
           QString str = w->text();
           customFFTable->setItem(row,col,new QTableWidgetItem(str));
        }
-       //QString str = customFFTable->text(row,col);
-       //customFFTable->setItem(row,col,new Q3TableItem(customFFTable,Q3TableItem::Never,str));
      }
    }
 
@@ -748,14 +729,10 @@ void inputRZImpl::customFFTable_singleclicked( int row, int col) {
 void inputRZImpl::GetMDfile()
 {
    QString tmpDir;
-   //qt3to4 -- BW
-   //char s = QDir::separator();
    char s = QDir::separator().toAscii();
    //try EGS_HOME/pegs4/data, then HEN_HOUSE/pegs4/data then $HOME/pegs4/data
    tmpDir = GetCurrentDir( "pegs4/data", EGS_HOME, HEN_HOUSE );
    QDir d(tmpDir);
-   //qt3to4 -- BW
-   //QString f = Q3FileDialog::getOpenFileName( tmpDir, "material data file (*)", this );
    QString f = QFileDialog::getOpenFileName( this,"",tmpDir, "material data file (*)" );
    if ( !f.isEmpty() ) {
       Ppgls->matdatafile = f;
@@ -768,50 +745,36 @@ void inputRZImpl::GetMDfile()
 
 void inputRZImpl::GetDFfile()
 {
-   QString tmpDir;
-   //qt3to4 -- BW
-   //char s = QDir::separator();
+   QString start_dir;
    char s = QDir::separator().toAscii();
-   //browse from HEN_HOUSE/pegs4/density_corrections
-   if(df_hen_houseRadioButton->isChecked())
-   tmpDir = ironIt(HEN_HOUSE + s + "pegs4" + s + "density_corrections" + s);
-   else
-   tmpDir = ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s);
-   if (!QDir(tmpDir).exists()) tmpDir.chop(20);
-   QDir d(tmpDir); 
-   //qt3to4 -- BW
-   //QString f = Q3FileDialog::getOpenFileName( this,"",tmpDir, "density correction file (*.density);; all files (*)");
+   if(DFSearchComboBox->currentText() == "HEN_HOUSE")
+     start_dir = ironIt(HEN_HOUSE + s + "pegs4" + s + "density_corrections" + s);
+   else start_dir = ironIt(EGS_HOME + s + "pegs4" + s + "density_corrections" + s);
+   if (!QDir(start_dir).exists()) start_dir.chop(20);
    QString f = QFileDialog::getOpenFileName(
-               this, "",tmpDir,
-               "density correction file (*.density);; all files (*)");
-   if ( !f.isEmpty() ) {
-      //check if the user has selected a .density file from the HEN_HOUSE/pegs4/data/elements or
-      //HEN_HOUSE/pegs4/data/compounds directories
-      if ( (f.indexOf(tmpDir + "elements",0) >=0  || f.indexOf(tmpDir + "compounds",0) >=0 ) &&
-           f.indexOf(".density",1)>=0) {
-         //keep entire filename
-         //remove directory name
-         //f.remove( 0, f.lastIndexOf(s,-1)+1);
-         //remove ".density" extension
-         //f.remove(f.indexOf(".density",1),8);
-      }
-      int ind=inpmediumComboBox->currentIndex();
-      Ppgls->inpmedind=ind;
-      Ppgls->dffile[Ppgls->inpmedind] = f;
-      DFEdit->setText(Ppgls->dffile[Ppgls->inpmedind]);
+               this, tr("Select a density correction file"),start_dir,
+               tr("density correction file (*.density)"));
+
+   //populate the media table
+   if(!GetMedFromDCfile(f)){
+      QString errStr = "Could not open density correction file "  + f;
+               errStr += "\nPlease select another file and try again!";
+        QMessageBox::information( this, " Warning",errStr, QMessageBox::Ok );
    }
+      
+   //set strings to output to .egsinp file 
+   int ind=inpmediumComboBox->currentIndex();
+   Ppgls->inpmedind=ind;
+   Ppgls->dffile[Ppgls->inpmedind] = f;
 }
 
 void inputRZImpl::set_table_header_noa()
 {
-   //qt3to4 -- BW
    pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("no. of atoms"));
 }
 
 void inputRZImpl::set_table_header_pbw()
 {
-   //qt3to4 -- BW
-   //pz_or_rhozTable->horizontalHeader()->setLabel(1,"mass fractions");
    pz_or_rhozTable->setHorizontalHeaderItem(1,new QTableWidgetItem("mass fractions"));
 }
 
@@ -827,8 +790,6 @@ v_string inputRZImpl::getPEGSLESSMedia( )
        QFile f( fname );
        if ( f.open( QIODevice::ReadOnly ) ) {
 
-          //qt3to4 -- BW
-          //Q3TextStream ts( &f );
           QTextStream ts( &f );
           QString     t;
           int         i;
@@ -842,8 +803,6 @@ v_string inputRZImpl::getPEGSLESSMedia( )
                t.trimmed();
                lmed2.push_back( t.toStdString() );
             }
-          //qt3to4 -- BW
-          //} while ( !ts.eof() );
           } while ( !ts.atEnd() );
 
           f.close();
@@ -857,13 +816,9 @@ v_string inputRZImpl::getPEGSLESSMedia( )
     for (int i=0; i<Ppgls->ninpmedia; i++) {
        k=0;
        for (int j=0; j<lmed2.size(); j++) {
-         //qt3to4 -- BW
-         // if(Ppgls->inpmedium[i]==lmed2[j]) break;
           if(Ppgls->inpmedium[i]==QString::fromStdString(lmed2[j])) break;
           k++;
        }
-       //qt3to4 -- BW
-       //if(k==lmed2.size()) lmed2.push_back(Ppgls->inpmedium[i]);
        if(k==lmed2.size()) lmed2.push_back(Ppgls->inpmedium[i].toStdString());
     }
 
@@ -880,10 +835,7 @@ bool inputRZImpl::pegsless_is_ok()
     if (!cavityRadioButton->isChecked())
         med = getMediaFromTable();
     else {
-        //MCAVInputs* EGScav = GetCAV();
         med.push_back(wallmaterialComboBox->currentText().toStdString());
-       //qt3to4 -- BW
-       //if (EGScav->electr_rad > 0.0)
        if (electradEdit->text().toFloat() > 0.0)
            med.push_back(electrmatComboBox->currentText().toStdString());
     }
@@ -901,8 +853,6 @@ bool inputRZImpl::pegsless_is_ok()
                       "</i><br>";
         return false;
     }
-    //qt3to4 -- BW
-    //Q3TextStream ts( &f1 );
     QTextStream ts( &f1 );
 
     std::vector<string>::iterator iter(med.begin());
@@ -920,8 +870,6 @@ bool inputRZImpl::pegsless_is_ok()
                    found = true;
                    break;
             }
-       //qt3to4 -- BW
-       //} while ( !ts.eof() );
        } while ( !ts.atEnd() );
 
        if (!found) {//check media defined in input file

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
@@ -941,7 +941,7 @@ void inputRZImpl::enable_gaspEdit()
 {
 //enable gaspEdit edit box if isGasCheckBox is checked
 //disable it if it is unchecked
-    if (isGasCheckBox->isChecked()){
+    if (isGasCheckBox->isChecked() && !DCcheckBox->isChecked()){
         gaspLabel->setEnabled( true );
         gaspEdit->setEnabled( true );
         gaspUnits->setEnabled( true );

--- a/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
@@ -334,13 +334,13 @@ QTextStream & operator << ( QTextStream & t, PEGSLESSInputs * rPEGSLESS )
        else t << "\n";
      }
      if(rPEGSLESS->rho[i]!="") t << "rho= " << rPEGSLESS->rho_scale[i]*rPEGSLESS->rho[i].toFloat() << "\n";
+     if(rPEGSLESS->gasp[i]!="" && rPEGSLESS->gasp[i].toFloat()>0.0 && rPEGSLESS->isgas[i]) t << "gas pressure= " << rPEGSLESS->gasp[i] << "\n";
    }
    //NB: Certain parameters below are either redundant/unnecessary
    //will be commented out but coding kept just in case
    //  if(rPEGSLESS->spr[i]!="") t << "stopping powers= " << rPEGSLESS->spr[i] << "\n";
    
      if(rPEGSLESS->bc[i]!="") t << "bremsstrahlung correction= " << rPEGSLESS->bc[i] << "\n";
-     if(rPEGSLESS->gasp[i]!="" && rPEGSLESS->gasp[i].toFloat()>0.0 && rPEGSLESS->isgas[i]) t << "gas pressure= " << rPEGSLESS->gasp[i] << "\n";
 
      //if(rPEGSLESS->sterncid[i]!="") t << "sterncid= " << rPEGSLESS->sterncid[i] << "\n";
      t << ":stop " << rPEGSLESS->inpmedium[i] << ":\n\n";

--- a/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/pegslessinputs.cpp
@@ -35,16 +35,119 @@
 
 
 #include "pegslessinputs.h"
-//Added by qt3to4:
-//#include <Q3TextStream>
-//qt3to4 -- BW
 #include <QTextStream>
-
 #include <QMessageBox>
+
+QStringList element_list;
+
+int n_element=100;
+
+Element element_data[] = {
+    {1,"H",1.0079,19.2,8.3748e-05},
+    {2,"He",4.0026,41.8,0.00016632},
+    {3,"Li",6.941,40,0.534},
+    {4,"Be",9.0122,63.7,1.848},
+    {5,"B",10.812,76,2.37},
+    {6,"C",12.011,78,2},
+    {7,"N",14.0067,82,0.0011653},
+    {8,"O",15.9994,95,0.0013315},
+    {9,"F",18.9984,115,0.0015803},
+    {10,"Ne",20.1797,137,0.0008385},
+    {11,"Na",22.9898,149,0.971},
+    {12,"Mg",24.305,156,1.74},
+    {13,"Al",26.9815,166,2.702},
+    {14,"Si",28.0855,173,2.33},
+    {15,"P",30.9738,173,2.2},
+    {16,"S",32.066,180,2},
+    {17,"Cl",35.4527,174,0.0029947},
+    {18,"Ar",39.948,188,0.001662},
+    {19,"K",39.0983,190,0.862},
+    {20,"Ca",40.078,191,1.55},
+    {21,"Sc",44.9559,216,2.989},
+    {22,"Ti",47.88,233,4.54},
+    {23,"V",50.9415,245,6.11},
+    {24,"Cr",51.9961,257,7.18},
+    {25,"Mn",54.938,272,7.44},
+    {26,"Fe",55.847,286,7.874},
+    {27,"Co",58.9332,297,8.9},
+    {28,"Ni",58.69,311,8.902},
+    {29,"Cu",63.546,322,8.96},
+    {30,"Zn",65.39,330,7.133},
+    {31,"Ga",69.723,334,5.904},
+    {32,"Ge",72.61,350,5.323},
+    {33,"As",74.9216,347,5.73},
+    {34,"Se",78.96,348,4.5},
+    {35,"Br",79.904,357,0.0070722},
+    {36,"Kr",83.8,352,0.0034783},
+    {37,"Rb",85.4678,363,1.532},
+    {38,"Sr",87.62,366,2.54},
+    {39,"Y",88.9059,379,4.469},
+    {40,"Zr",91.224,393,6.506},
+    {41,"Nb",92.9064,417,8.57},
+    {42,"Mo",95.94,424,10.22},
+    {43,"Tc",97.9072,428,11.5},
+    {44,"Ru",101.07,441,12.41},
+    {45,"Rh",102.906,449,12.41},
+    {46,"Pd",106.42,470,12.02},
+    {47,"Ag",107.868,470,10.5},
+    {48,"Cd",112.411,469,8.65},
+    {49,"In",114.82,488,7.31},
+    {50,"Sn",118.71,488,7.31},
+    {51,"Sb",121.75,487,6.691},
+    {52,"Te",127.6,485,6.24},
+    {53,"I",126.904,491,4.93},
+    {54,"Xe",131.29,482,0.0054854},
+    {55,"Cs",132.905,488,1.873},
+    {56,"Ba",137.327,491,3.5},
+    {57,"La",138.905,501,6.154},
+    {58,"Ce",140.115,523,6.657},
+    {59,"Pr",140.908,535,6.71},
+    {60,"Nd",144.24,546,6.9},
+    {60,"Nd",144.24,546,6.9},
+    {61,"Pm",144.913,560,7.22},
+    {62,"Sm",150.36,574,7.46},
+    {63,"Eu",151.965,580,5.243},
+    {64,"Gd",157.25,591,7.9004},
+    {65,"Tb",158.925,614,8.229},
+    {66,"Dy",162.5,628,8.55},
+    {67,"Ho",164.93,650,8.795},
+    {68,"Er",167.26,658,9.066},
+    {69,"Tm",168.934,674,9.321},
+    {70,"Yb",173.04,684,6.73},
+    {71,"Lu",174.967,694,9.84},
+    {72,"Hf",178.49,705,13.31},
+    {73,"Ta",180.948,718,16.654},
+    {74,"W",183.85,727,19.3},
+    {75,"Re",186.207,736,21.02},
+    {76,"Os",190.2,746,22.57},
+    {77,"Ir",192.22,757,22.42},
+    {78,"Pt",195.08,790,21.45},
+    {79,"Au",196.966,790,19.32},
+    {80,"Hg",200.59,800,13.546},
+    {81,"Tl",204.383,810,11.72},
+    {82,"Pb",207.2,823,11.34},
+    {83,"Bi",208.98,823,9.747},
+    {84,"Po",208.982,830,9.32},
+    {85,"At",209.987,825,9.32},
+    {86,"Rn",222.018,794,0.0090662},
+    {87,"Fr",223.02,827,1},
+    {88,"Ra",226.025,826,5},
+    {89,"Ac",227.028,841,10.07},
+    {90,"Th",232.038,847,11.72},
+    {91,"Pa",231.036,878,15.37},
+    {92,"U",238.029,890,18.95},
+    {93,"Np",237.048,902,20.25},
+    {94,"Pu",239.052,921,19.84},
+    {95,"Am",243.061,934,13.67},
+    {96,"Cm",247.07,939,13.51},
+    {97,"Bk",247.07,952,14},
+    {98,"Cf",251.08,966,10},
+    {99,"Es",252.083,980,10},
+    {100,"Fm",257.095,994,10}
+};
 
 PEGSLESSInputs::PEGSLESSInputs()
 {
-
 
   AE="";
   UE="";
@@ -103,9 +206,6 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
   bool loop=true;
   while (loop) {
 
-     //qt3to4 -- BW
-     //string temp_start = getIt( codes[5] ,"", rPEGSLESS->errors, p );
-     //string temp_stop = getIt( codes[6] ,"", rPEGSLESS->errors, p );
       string temp_start = getIt( med_delims[0] ,"", rPEGSLESS->errors, p2 ).toStdString();
      string temp_stop = getIt( med_delims[1] ,"", rPEGSLESS->errors, p2 ).toStdString();
   //now strip trailing : off the strings and compare
@@ -130,8 +230,6 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
 
        rPEGSLESS->ninpmedia++;
        int tempint = rPEGSLESS->ninpmedia-1;
-       //qt3to4 -- BW
-       //rPEGSLESS->inpmedium[tempint]=temp_start;
        rPEGSLESS->inpmedium[tempint]=QString::fromStdString(temp_start);
 
        //get a new block of the input file using new delimiters
@@ -144,8 +242,11 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
        //define defaults
 
        rPEGSLESS->elements[tempint].push_back("");
+       rPEGSLESS->nelements[tempint]=0;
        rPEGSLESS->spec_by_pz[tempint]=true;
        rPEGSLESS->isgas[tempint]=false;
+       rPEGSLESS->use_dcfile[tempint]=false;
+       rPEGSLESS->rho_scale[tempint]=1.;
 
        rPEGSLESS->elements[tempint]=getThemAll( codes1[0] , rPEGSLESS->elements[tempint], rPEGSLESS->errors, p1 );
 
@@ -167,6 +268,10 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
        rPEGSLESS->gasp[tempint]=getIt( codes1[6] , "", rPEGSLESS->errors, p1 );
        if(rPEGSLESS->gasp[tempint]!="" && rPEGSLESS->gasp[tempint].toFloat()>0.0) rPEGSLESS->isgas[tempint]=true;
        rPEGSLESS->dffile[tempint]=getIt( codes1[7] , "", rPEGSLESS->errors, p1 );
+       //will check if we can actually read from the DC file later
+       //for now assume if a density correction file is specified it will
+       //be used to determine comp
+       if(!rPEGSLESS->dffile[tempint].isEmpty()) rPEGSLESS->use_dcfile[tempint]=true;
        rPEGSLESS->sterncid[tempint]=getIt( codes1[8] , "", rPEGSLESS->errors, p1 );
 
      }
@@ -179,54 +284,6 @@ std::ifstream & operator >> ( std::ifstream & in, PEGSLESSInputs*  rPEGSLESS )
   return in;
 }
 
-/*
-Q3TextStream & operator << ( Q3TextStream & t, PEGSLESSInputs * rPEGSLESS )
-{
-
-  print_delimeter( "start" , "media definition", t);
-
-
-  if(rPEGSLESS->AE!="") t << "AE= " << rPEGSLESS->AE << "\n";
-  if(rPEGSLESS->UE!="") t << "UE= " << rPEGSLESS->UE << "\n";
-  if(rPEGSLESS->AP!="") t << "AP= " << rPEGSLESS->AP << "\n";
-  if(rPEGSLESS->UP!="") t << "UP= " << rPEGSLESS->UP << "\n" ;
-  if(rPEGSLESS->matdatafile !="") t << "material data file= " << rPEGSLESS->matdatafile << "\n";
-
-  t << "\n";
-
-  for (int i=0; i<rPEGSLESS->ninpmedia; i++) {
-     t << ":start " << rPEGSLESS->inpmedium[i] << ":\n";
-     for(int j=0; j<rPEGSLESS->nelements[i]; j++){
-       if(j==0) t << "elements= ";
-       t << rPEGSLESS->elements[i][j];
-       if(j<rPEGSLESS->nelements[i]-1) t << ",";
-       else t << "\n";
-     }
-     for(int j=0; j<rPEGSLESS->nelements[i]; j++){
-       if(j==0) {
-        if(!rPEGSLESS->spec_by_pz[i]) t << "mass fractions= ";
-        else t << "no. of atoms= ";
-       }
-       t << rPEGSLESS->pz_or_rhoz[i][j];
-       if(j<rPEGSLESS->nelements[i]-1) t << ",";
-       else t << "\n";
-     }
-     if(rPEGSLESS->rho[i]!="") t << "rho= " << rPEGSLESS->rho[i] << "\n";
-     if(rPEGSLESS->spr[i]!="") t << "stopping powers= " << rPEGSLESS->spr[i] << "\n";
-     if(rPEGSLESS->bc[i]!="") t << "bremsstrahlung correction= " << rPEGSLESS->bc[i] << "\n";
-     if(rPEGSLESS->gasp[i]!="") t << "gas pressure= " << rPEGSLESS->gasp[i] << "\n";
-     if(rPEGSLESS->dffile[i]!="") t << "density correction file= " << rPEGSLESS->dffile[i] << "\n";
-     if(rPEGSLESS->sterncid[i]!="") t << "sterncid= " << rPEGSLESS->sterncid[i] << "\n";
-     t << ":stop " << rPEGSLESS->inpmedium[i] << ":\n\n";
-   }
-
-  print_delimeter( "stop" , "media definition", t);
-
-  return t;
-}
-*/
-
-//qt3to4 -- BW
 QTextStream & operator << ( QTextStream & t, PEGSLESSInputs * rPEGSLESS )
 {
 
@@ -243,6 +300,11 @@ QTextStream & operator << ( QTextStream & t, PEGSLESSInputs * rPEGSLESS )
 
   for (int i=0; i<rPEGSLESS->ninpmedia; i++) {
      t << ":start " << rPEGSLESS->inpmedium[i] << ":\n";
+   if(rPEGSLESS->use_dcfile[i] && !rPEGSLESS->dffile[i].isEmpty()) {
+     //medium composition and rho based on density correction file
+     t << "density correction file= " << rPEGSLESS->dffile[i] << "\n";
+   }
+   else {
      for(int j=0; j<rPEGSLESS->nelements[i]; j++){
        if(j==0) t << "elements= ";
        t << rPEGSLESS->elements[i][j];
@@ -271,12 +333,16 @@ QTextStream & operator << ( QTextStream & t, PEGSLESSInputs * rPEGSLESS )
        if(j<rPEGSLESS->nelements[i]-1) t << ",";
        else t << "\n";
      }
-     if(rPEGSLESS->rho[i]!="") t << "rho= " << rPEGSLESS->rho[i] << "\n";
-     if(rPEGSLESS->spr[i]!="") t << "stopping powers= " << rPEGSLESS->spr[i] << "\n";
+     if(rPEGSLESS->rho[i]!="") t << "rho= " << rPEGSLESS->rho_scale[i]*rPEGSLESS->rho[i].toFloat() << "\n";
+   }
+   //NB: Certain parameters below are either redundant/unnecessary
+   //will be commented out but coding kept just in case
+   //  if(rPEGSLESS->spr[i]!="") t << "stopping powers= " << rPEGSLESS->spr[i] << "\n";
+   
      if(rPEGSLESS->bc[i]!="") t << "bremsstrahlung correction= " << rPEGSLESS->bc[i] << "\n";
      if(rPEGSLESS->gasp[i]!="" && rPEGSLESS->gasp[i].toFloat()>0.0 && rPEGSLESS->isgas[i]) t << "gas pressure= " << rPEGSLESS->gasp[i] << "\n";
-     if(rPEGSLESS->dffile[i]!="") t << "density correction file= " << rPEGSLESS->dffile[i] << "\n";
-     if(rPEGSLESS->sterncid[i]!="") t << "sterncid= " << rPEGSLESS->sterncid[i] << "\n";
+
+     //if(rPEGSLESS->sterncid[i]!="") t << "sterncid= " << rPEGSLESS->sterncid[i] << "\n";
      t << ":stop " << rPEGSLESS->inpmedium[i] << ":\n\n";
    }
 

--- a/HEN_HOUSE/gui/egs_inprz/ui/inputRZ.ui
+++ b/HEN_HOUSE/gui/egs_inprz/ui/inputRZ.ui
@@ -94,6 +94,9 @@
        <height>88</height>
       </size>
      </property>
+     <property name="toolTip">
+      <string/>
+     </property>
      <property name="frameShape">
       <enum>QFrame::Box</enum>
      </property>
@@ -5871,397 +5874,148 @@
       <attribute name="title">
        <string>Media Definition</string>
       </attribute>
-      <widget class="QGroupBox" name="inpmediaGroupBox">
-       <property name="geometry">
-        <rect>
-         <x>10</x>
-         <y>160</y>
-         <width>880</width>
-         <height>398</height>
-        </rect>
-       </property>
-       <property name="title">
-        <string>media defined in .egsinp file</string>
-       </property>
-       <widget class="QWidget" name="layoutWidget11">
-        <property name="geometry">
-         <rect>
-          <x>18</x>
-          <y>36</y>
-          <width>848</width>
-          <height>353</height>
-         </rect>
-        </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_28">
+      <layout class="QVBoxLayout" name="verticalLayout_52">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_51">
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_9">
+          <layout class="QHBoxLayout" name="horizontalLayout_28">
            <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_9">
-             <item>
-              <widget class="QLabel" name="inpmediumLabel">
-               <property name="text">
-                <string>medium name</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="inpmediumComboBox">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="editable">
-                <bool>true</bool>
-               </property>
-               <property name="insertPolicy">
-                <enum>QComboBox::InsertAtCurrent</enum>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <widget class="QGroupBox" name="compositionGroupBox">
+            <widget class="QGroupBox" name="ELGroupBox">
              <property name="toolTip">
-              <string>specify medium composition</string>
+              <string>Specify upper and lower energy limits for all PEGSless data</string>
              </property>
              <property name="title">
-              <string>composition</string>
+              <string>energy limits (MeV)</string>
              </property>
-             <layout class="QVBoxLayout" name="verticalLayout_8">
+             <layout class="QVBoxLayout" name="verticalLayout_47">
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_8">
+               <layout class="QHBoxLayout" name="horizontalLayout_7">
                 <item>
-                 <spacer name="horizontalSpacer">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>40</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
+                 <layout class="QVBoxLayout">
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLabel" name="AELabel">
+                      <property name="text">
+                       <string>AE</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="AEEdit">
+                      <property name="toolTip">
+                       <string>minimum total e- energy for cross-sections</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLabel" name="APLabel">
+                      <property name="text">
+                       <string>AP</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="APEdit">
+                      <property name="toolTip">
+                       <string>minimum photon energy for cross-sections</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
                 </item>
                 <item>
-                 <widget class="QLabel" name="pz_or_rhozLabel">
-                  <property name="acceptDrops">
-                   <bool>false</bool>
-                  </property>
-                  <property name="text">
-                   <string>specify by</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QGroupBox" name="pz_or_rhozButtonGroup">
-                  <property name="title">
-                   <string/>
-                  </property>
-                  <layout class="QVBoxLayout">
-                   <item>
-                    <widget class="QRadioButton" name="pzRadioButton">
-                     <property name="text">
-                      <string>stoichiometric coefficients</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QRadioButton" name="rhozRadioButton">
-                     <property name="text">
-                      <string>fraction of total weight</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
+                 <layout class="QVBoxLayout">
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLabel" name="UELabel">
+                      <property name="text">
+                       <string>UE</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="UEEdit">
+                      <property name="toolTip">
+                       <string>maximum e- kinetic energy for cross-sections</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLabel" name="UPLabel">
+                      <property name="text">
+                       <string>UP</string>
+                      </property>
+                      <property name="wordWrap">
+                       <bool>false</bool>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="UPEdit">
+                      <property name="toolTip">
+                       <string>maximum photon energy for cross-sections</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
                 </item>
                </layout>
               </item>
+             </layout>
+            </widget>
+           </item>
+           <item>
+            <widget class="QGroupBox" name="MDGroupBox">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use this if PEGSless media specified in a material data file. Additional media can be specified in the .egsinp file (see below).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="title">
+              <string>material data file name</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_48">
               <item>
-               <widget class="QTableWidget" name="pz_or_rhozTable">
-                <property name="toolTip">
-                 <string>elements must be specified by their chemical symbol all uppercase.</string>
-                </property>
-                <property name="rowCount">
-                 <number>50</number>
-                </property>
-                <property name="columnCount">
-                 <number>2</number>
-                </property>
-                <row>
-                 <property name="text">
-                  <string>1</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>2</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>3</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>4</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>5</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>6</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>7</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>8</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>9</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>10</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>11</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>12</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>13</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>14</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>15</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>16</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>17</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>18</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>19</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>20</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>21</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>22</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>23</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>24</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>25</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>26</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>27</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>28</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>29</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>30</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>31</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>32</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>33</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>34</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>35</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>36</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>37</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>38</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>39</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>40</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>41</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>42</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>43</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>44</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>45</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>46</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>47</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>48</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>49</string>
-                 </property>
-                </row>
-                <row>
-                 <property name="text">
-                  <string>50</string>
-                 </property>
-                </row>
-                <column>
-                 <property name="text">
-                  <string>element</string>
-                 </property>
-                </column>
-                <column>
-                 <property name="text">
-                  <string>no. of atoms</string>
-                 </property>
-                </column>
-               </widget>
+               <layout class="QHBoxLayout">
+                <item>
+                 <widget class="QLineEdit" name="MDFEdit"/>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="MDFileButton">
+                  <property name="toolTip">
+                   <string>Browse to select a material data file.
+Browsing starts in your $EGS_HOME/pegs4/data directory.</string>
+                  </property>
+                  <property name="text">
+                   <string>...</string>
+                  </property>
+                  <property name="autoDefault">
+                   <bool>false</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
               </item>
              </layout>
             </widget>
@@ -6269,503 +6023,578 @@
           </layout>
          </item>
          <item>
-          <layout class="QVBoxLayout" name="verticalLayout_37">
-           <item>
-            <spacer name="verticalSpacer_6">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>448</width>
-               <height>18</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <layout class="QHBoxLayout">
-             <item>
-              <widget class="QLabel" name="rhoLabel">
-               <property name="text">
-                <string>rho</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="rhoEdit">
-               <property name="toolTip">
-                <string>medium density in g/cm^3</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLabel" name="rhoUnits">
-               <property name="text">
-                <string>g/cm^3</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout">
-             <item>
-              <widget class="QLabel" name="spLabel">
-               <property name="text">
-                <string>stopping powers</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="spComboBox">
-               <property name="maximumSize">
-                <size>
-                 <width>370</width>
-                 <height>32767</height>
-                </size>
-               </property>
-               <property name="font">
-                <font/>
-               </property>
-               <property name="toolTip">
-                <string>choose which type of e- stopping power to calculate/use in the simulation</string>
-               </property>
-               <item>
-                <property name="text">
-                 <string>restricted total</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>unrestricted collision</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>unrestricted collision and radiative</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>unrestricted collision and restricted radiative</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>restricted collision and unrestricted radiative</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>unrestricted radiative</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout">
-             <item>
-              <widget class="QLabel" name="bcLabel">
-               <property name="text">
-                <string>bremsstrahlung correction</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QComboBox" name="bcComboBox">
-               <property name="toolTip">
-                <string>choose which type of correction to apply to brem cross-sections.  The default is KM (Koch and Motz).</string>
-               </property>
-               <item>
-                <property name="text">
-                 <string>KM</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>NRC</string>
-                </property>
-               </item>
-               <item>
-                <property name="text">
-                 <string>none</string>
-                </property>
-               </item>
-              </widget>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QVBoxLayout" name="verticalLayout_35">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_24">
-               <item>
-                <widget class="QLabel" name="DFLabel">
-                 <property name="text">
-                  <string>density correction file:</string>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QGroupBox" name="df_searchButtonGroup">
-                 <property name="title">
-                  <string>search in:</string>
-                 </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_10">
+          <widget class="QGroupBox" name="inpmediaGroupBox">
+           <property name="title">
+            <string>media defined in .egsinp file</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_50">
+            <item>
+             <layout class="QVBoxLayout" name="verticalLayout_49">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_24">
+                <item>
+                 <widget class="QGroupBox" name="compositionGroupBox">
+                  <property name="toolTip">
+                   <string>specify medium composition</string>
+                  </property>
+                  <property name="title">
+                   <string>Medium composition</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_8">
+                   <item>
+                    <widget class="QTableWidget" name="pz_or_rhozTable">
+                     <property name="toolTip">
+                      <string>Elements must be specified by their chemical symbol all uppercase.
+For mixtures, composition is specified by fraction by weight of each element.
+For compounds, composition is specified by stoichiometric index of each element.</string>
+                     </property>
+                     <property name="rowCount">
+                      <number>50</number>
+                     </property>
+                     <property name="columnCount">
+                      <number>2</number>
+                     </property>
+                     <row>
+                      <property name="text">
+                       <string>1</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>2</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>3</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>4</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>5</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>6</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>7</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>8</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>9</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>10</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>11</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>12</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>13</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>14</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>15</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>16</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>17</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>18</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>19</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>20</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>21</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>22</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>23</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>24</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>25</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>26</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>27</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>28</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>29</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>30</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>31</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>32</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>33</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>34</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>35</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>36</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>37</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>38</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>39</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>40</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>41</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>42</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>43</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>44</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>45</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>46</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>47</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>48</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>49</string>
+                      </property>
+                     </row>
+                     <row>
+                      <property name="text">
+                       <string>50</string>
+                      </property>
+                     </row>
+                     <column>
+                      <property name="text">
+                       <string>Element</string>
+                      </property>
+                     </column>
+                     <column>
+                      <property name="text">
+                       <string>Fraction by weight</string>
+                      </property>
+                     </column>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="verticalLayout_46">
+                  <item>
+                   <widget class="QGroupBox" name="medNameGroupBox">
+                    <property name="title">
+                     <string>Medium name</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_9">
+                     <item>
+                      <widget class="QComboBox" name="inpmediumComboBox">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="toolTip">
+                        <string/>
+                       </property>
+                       <property name="editable">
+                        <bool>true</bool>
+                       </property>
+                       <property name="insertPolicy">
+                        <enum>QComboBox::InsertAtCurrent</enum>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
                   <item>
                    <layout class="QHBoxLayout" name="horizontalLayout_19">
                     <item>
-                     <widget class="QRadioButton" name="df_egs_homeRadioButton">
-                      <property name="text">
-                       <string>EGS_HOME</string>
+                     <widget class="QGroupBox" name="medTypeGroupBox">
+                      <property name="title">
+                       <string>Medium type</string>
                       </property>
-                      <attribute name="buttonGroup">
-                       <string notr="true">buttonGroup</string>
-                      </attribute>
+                      <layout class="QVBoxLayout" name="verticalLayout_37">
+                       <item>
+                        <widget class="QComboBox" name="medTypeComboBox">
+                         <property name="toolTip">
+                          <string>Select 'Mixture' to specify composition by fraction by weight,
+'Compound' to specify by stoichiometric index</string>
+                         </property>
+                         <property name="editable">
+                          <bool>false</bool>
+                         </property>
+                         <property name="maxVisibleItems">
+                          <number>3</number>
+                         </property>
+                         <item>
+                          <property name="text">
+                           <string>Element</string>
+                          </property>
+                         </item>
+                         <item>
+                          <property name="text">
+                           <string>Compound</string>
+                          </property>
+                         </item>
+                         <item>
+                          <property name="text">
+                           <string>Mixture</string>
+                          </property>
+                         </item>
+                        </widget>
+                       </item>
+                      </layout>
                      </widget>
                     </item>
                     <item>
-                     <widget class="QRadioButton" name="df_hen_houseRadioButton">
-                      <property name="text">
-                       <string>HEN_HOUSE</string>
+                     <widget class="QGroupBox" name="rhoGroupBox">
+                      <property name="title">
+                       <string>Mass density</string>
                       </property>
-                      <attribute name="buttonGroup">
-                       <string notr="true">buttonGroup</string>
-                      </attribute>
+                      <layout class="QVBoxLayout" name="verticalLayout_44">
+                       <item>
+                        <layout class="QHBoxLayout" name="horizontalLayout_8">
+                         <item>
+                          <widget class="QLineEdit" name="rhoEdit">
+                           <property name="toolTip">
+                            <string>medium density in g/cm^3 or kg/cm^3</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QComboBox" name="rhoScaleComboBox">
+                           <item>
+                            <property name="text">
+                             <string>g/cm^3</string>
+                            </property>
+                           </item>
+                           <item>
+                            <property name="text">
+                             <string>kg/cm^3</string>
+                            </property>
+                           </item>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
                      </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
                     </item>
                    </layout>
                   </item>
+                  <item>
+                   <widget class="QGroupBox" name="medOptionsGroupBox">
+                    <property name="title">
+                     <string>Options</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_45">
+                     <item>
+                      <layout class="QVBoxLayout" name="verticalLayout_35">
+                       <item>
+                        <widget class="QCheckBox" name="DCcheckBox">
+                         <property name="toolTip">
+                          <string>Select to specify an ICRU density correction file (see below).</string>
+                         </property>
+                         <property name="text">
+                          <string>ICRU density correction</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QCheckBox" name="ICRUradCheckBox">
+                         <property name="toolTip">
+                          <string>Select to use ICRU corrections to brems cross-sections.
+Otherwise, Koch-Motz (KM) corrections will be used. </string>
+                         </property>
+                         <property name="text">
+                          <string>ICRU radiative stopping power</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <layout class="QHBoxLayout" name="horizontalLayout_10">
+                         <item>
+                          <widget class="QCheckBox" name="isGasCheckBox">
+                           <property name="toolTip">
+                            <string>Check this if the medium is a gas.
+This will enable you to input the gas pressure of the medium.</string>
+                           </property>
+                           <property name="text">
+                            <string>medium is a gas</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <spacer name="horizontalSpacer_5">
+                           <property name="orientation">
+                            <enum>Qt::Horizontal</enum>
+                           </property>
+                           <property name="sizeHint" stdset="0">
+                            <size>
+                             <width>40</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                          </spacer>
+                         </item>
+                         <item>
+                          <widget class="QLabel" name="gaspLabel">
+                           <property name="text">
+                            <string>gas pressure</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>false</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QLineEdit" name="gaspEdit">
+                           <property name="toolTip">
+                            <string>If the medium is a gas, specify gas pressure (atm) here.
+Defaults to 1 atm. if left blank or zero.</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QLabel" name="gaspUnits">
+                           <property name="text">
+                            <string>atm</string>
+                           </property>
+                           <property name="wordWrap">
+                            <bool>false</bool>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
                  </layout>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout">
-               <item>
-                <widget class="QLineEdit" name="DFEdit"/>
-               </item>
-               <item>
-                <layout class="QHBoxLayout">
+                </item>
+               </layout>
+              </item>
+              <item>
+               <widget class="QGroupBox" name="DFgroupBox">
+                <property name="toolTip">
+                 <string>Specify a density correction file which, when applied to calculated cross-sections,
+results in agreement with stopping powers published in ICRU37.  Note that medium
+composition and density as specified in the density correction file are used.</string>
+                </property>
+                <property name="title">
+                 <string>Density correction file</string>
+                </property>
+                <layout class="QVBoxLayout" name="verticalLayout_10">
                  <item>
-                  <widget class="QPushButton" name="MDBrowse">
-                   <property name="text">
-                    <string>...</string>
-                   </property>
-                  </widget>
+                  <layout class="QHBoxLayout" name="horizontalLayout_9">
+                   <item>
+                    <widget class="QLabel" name="DFSearchLabel">
+                     <property name="text">
+                      <string>Look in</string>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QComboBox" name="DFSearchComboBox">
+                     <property name="toolTip">
+                      <string>Select in which directory to begin browsing for the density correction file.  
+Will start in /pegs4/density_corrections/ subdirectory off the directory selected here.</string>
+                     </property>
+                     <item>
+                      <property name="text">
+                       <string>EGS_HOME</string>
+                      </property>
+                     </item>
+                     <item>
+                      <property name="text">
+                       <string>HEN_HOUSE</string>
+                      </property>
+                     </item>
+                    </widget>
+                   </item>
+                   <item>
+                    <layout class="QHBoxLayout">
+                     <item>
+                      <widget class="QLineEdit" name="DFEdit">
+                       <property name="toolTip">
+                        <string>Full name of density correction file.</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <layout class="QHBoxLayout">
+                       <item>
+                        <widget class="QPushButton" name="DFBrowse">
+                         <property name="toolTip">
+                          <string>Browse for density correction file.</string>
+                         </property>
+                         <property name="text">
+                          <string>...</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
                  </item>
                 </layout>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout" name="horizontalLayout_10">
-             <item>
-              <widget class="QCheckBox" name="isGasCheckBox">
-               <property name="toolTip">
-                <string>Check this if the medium is a gas.  This will enable you to input the gas pressure of the medium.</string>
-               </property>
-               <property name="text">
-                <string>medium is a gas</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <layout class="QHBoxLayout">
-               <item>
-                <spacer name="horizontalSpacer_5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QLabel" name="gaspLabel">
-                 <property name="text">
-                  <string>gas pressure</string>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="gaspEdit">
-                 <property name="toolTip">
-                  <string>If the medium is a gas, specify gas pressure (atm) here.  Defaults to 1 atm.</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="gaspUnits">
-                 <property name="text">
-                  <string>atm</string>
-                 </property>
-                 <property name="wordWrap">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <layout class="QHBoxLayout">
-             <item>
-              <widget class="QLabel" name="sterncidLabel">
-               <property name="text">
-                <string>sterncid</string>
-               </property>
-               <property name="wordWrap">
-                <bool>false</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QLineEdit" name="sterncidEdit"/>
-             </item>
-            </layout>
-           </item>
-           <item>
-            <spacer name="spacer55">
-             <property name="orientation">
-              <enum>Qt::Vertical</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Expanding</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>448</width>
-               <height>18</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-          </layout>
-         </item>
-        </layout>
-       </widget>
-      </widget>
-      <widget class="QWidget" name="layoutWidget1">
-       <property name="geometry">
-        <rect>
-         <x>9</x>
-         <y>1</y>
-         <width>881</width>
-         <height>161</height>
-        </rect>
-       </property>
-       <layout class="QHBoxLayout">
-        <item>
-         <widget class="QGroupBox" name="ELGroupBox">
-          <property name="title">
-           <string>energy limits (MeV)</string>
-          </property>
-          <widget class="QWidget" name="layoutWidget2">
-           <property name="geometry">
-            <rect>
-             <x>15</x>
-             <y>33</y>
-             <width>358</width>
-             <height>68</height>
-            </rect>
-           </property>
-           <layout class="QHBoxLayout" name="horizontalLayout_7">
-            <item>
-             <layout class="QVBoxLayout">
-              <item>
-               <layout class="QHBoxLayout">
-                <item>
-                 <widget class="QLabel" name="AELabel">
-                  <property name="text">
-                   <string>AE</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="AEEdit">
-                  <property name="toolTip">
-                   <string>minimum total e- energy for cross-sections</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout">
-                <item>
-                 <widget class="QLabel" name="APLabel">
-                  <property name="text">
-                   <string>AP</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="APEdit">
-                  <property name="toolTip">
-                   <string>minimum photon energy for cross-sections</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <layout class="QVBoxLayout">
-              <item>
-               <layout class="QHBoxLayout">
-                <item>
-                 <widget class="QLabel" name="UELabel">
-                  <property name="text">
-                   <string>UE</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="UEEdit">
-                  <property name="toolTip">
-                   <string>maximum e- kinetic energy for cross-sections</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QHBoxLayout">
-                <item>
-                 <widget class="QLabel" name="UPLabel">
-                  <property name="text">
-                   <string>UP</string>
-                  </property>
-                  <property name="wordWrap">
-                   <bool>false</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QLineEdit" name="UPEdit">
-                  <property name="toolTip">
-                   <string>maximum photon energy for cross-sections</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
-            </item>
-           </layout>
-          </widget>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="MDGroupBox">
-          <property name="title">
-           <string>material data file name</string>
-          </property>
-          <widget class="QWidget" name="layout156">
-           <property name="geometry">
-            <rect>
-             <x>10</x>
-             <y>25</y>
-             <width>420</width>
-             <height>65</height>
-            </rect>
-           </property>
-           <layout class="QVBoxLayout">
-            <item>
-             <spacer name="spacer56_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <layout class="QHBoxLayout">
-              <item>
-               <widget class="QLineEdit" name="MDFEdit"/>
-              </item>
-              <item>
-               <widget class="QPushButton" name="MDFileButton">
-                <property name="toolTip">
-                 <string>load EGSnrc input file using an Open File Dialog.</string>
-                </property>
-                <property name="text">
-                 <string>...</string>
-                </property>
-                <property name="autoDefault">
-                 <bool>false</bool>
-                </property>
                </widget>
               </item>
              </layout>
             </item>
            </layout>
           </widget>
-         </widget>
-        </item>
-       </layout>
-      </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
      </widget>
      <widget class="QWidget" name="SItab">
       <attribute name="title">
@@ -12640,74 +12469,10 @@
    </hints>
   </connection>
   <connection>
-   <sender>inpmediumComboBox</sender>
-   <signal>highlighted(QString)</signal>
-   <receiver>InputRZForm</receiver>
-   <slot>inpmediumSave(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>inpmediumComboBox</sender>
-   <signal>activated(QString)</signal>
-   <receiver>InputRZForm</receiver>
-   <slot>inpmediumChanged(QString)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>MDBrowse</sender>
+   <sender>DFBrowse</sender>
    <signal>clicked()</signal>
    <receiver>InputRZForm</receiver>
    <slot>GetDFfile()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>pzRadioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>InputRZForm</receiver>
-   <slot>set_table_header_noa()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>rhozRadioButton</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>InputRZForm</receiver>
-   <slot>set_table_header_pbw()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>
@@ -12895,8 +12660,117 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>pz_or_rhozTable</sender>
+   <signal>cellDoubleClicked(int,int)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>pz_or_rhozTable_clicked(int,int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>235</x>
+     <y>563</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>511</x>
+     <y>389</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pz_or_rhozTable</sender>
+   <signal>cellClicked(int,int)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>pz_or_rhozTable_singleclicked(int,int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>235</x>
+     <y>563</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>511</x>
+     <y>389</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>inpmediumComboBox</sender>
+   <signal>highlighted(QString)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>inpmediumSave(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>inpmediumComboBox</sender>
+   <signal>activated(QString)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>inpmediumChanged(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>DCcheckBox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>enableDCfileInput(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>641</x>
+     <y>514</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>511</x>
+     <y>389</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>medTypeComboBox</sender>
+   <signal>activated(QString)</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>medTypeChanged(QString)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>470</x>
+     <y>441</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>511</x>
+     <y>389</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>DFEdit</sender>
+   <signal>returnPressed()</signal>
+   <receiver>InputRZForm</receiver>
+   <slot>GetDFfileReturn()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>527</x>
+     <y>647</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>511</x>
+     <y>389</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
- <buttongroups>
-  <buttongroup name="buttonGroup"/>
- </buttongroups>
 </ui>


### PR DESCRIPTION
For egs_gui: Add an input for gas pressure if medium is a gas
For egs_gui and egs_inprz: disable the option to specify that the medium is a gas if a density correction file is used.  GASP is not used in this case.