### PR TITLE
Fix edep_local missing from cpp interfaces

### DIFF
--- a/HEN_HOUSE/interface/egs_interface1.h
+++ b/HEN_HOUSE/interface/egs_interface1.h
@@ -228,8 +228,10 @@ struct EGS_Thresh {
     for user scoring and for interacting with the user geometry
  */
 struct EGS_Epcont {
-  /*! Energy being deposited locally */
+  /*! Energy being deposited locally (may be several depositions) */
   double    edep;
+  /*! A single sub-threshold energy deposition */
+  double    edep_local;
   /*! Step length to an interaction */
   EGS_Float tstep;
   /*! Step length after step-size restrictions */

--- a/HEN_HOUSE/interface/egs_interface2.h
+++ b/HEN_HOUSE/interface/egs_interface2.h
@@ -228,8 +228,10 @@ struct EGS_Thresh {
     for user scoring and for interacting with the user geometry
  */
 struct EGS_Epcont {
-  /*! Energy being deposited locally */
+  /*! Energy being deposited locally (may be several depositions) */
   double    edep;
+  /*! A single sub-threshold energy deposition */
+  double    edep_local;
   /*! Step length to an interaction */
   EGS_Float tstep;
   /*! Step length after step-size restrictions */


### PR DESCRIPTION
The new `edep_local` variable from recent kerma/g fixes was not declared in the cpp interface files. This resulted in the wrong dose in cpp applications that used `iarg=4` (tutor2pp). 