### PR TITLE
Fix #97: Remove infinite loops and add veryFar parameter

### DIFF
--- a/HEN_HOUSE/egs++/egs_alias_table.cpp
+++ b/HEN_HOUSE/egs++/egs_alias_table.cpp
@@ -187,7 +187,11 @@ int EGS_AliasTable::initialize(EGS_Float xmin, EGS_Float xmax, EGS_Float accu,
     fi[1] = f(xi[1],data);
     EGS_Float *xtemp, *ftemp;
     int error = 0;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_AliasTable::initialize: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return 1;
+        }
         int nnn = (n-1)*AT_NCHECK + n;
         xtemp = new EGS_Float[nnn];
         ftemp = new EGS_Float[nnn];

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
 #                   Blake Walters
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -829,7 +830,7 @@ int EGS_Application::simulateSingleShower() {
             source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,p.x,p.u);
         ireg = geometry->isWhere(p.x);
         if (ireg < 0) {
-            EGS_Float t = 1e30;
+            EGS_Float t = veryFar;
             ireg = geometry->howfar(ireg,p.x,p.u,t);
             if (ireg >= 0) {
                 p.x += p.u*t;

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -349,7 +349,7 @@ EGS_Float EGS_BaseGeometry::howfarToOutside(int ireg, const EGS_Vector &x,
             egsFatal("EGS_BaseGeometry::howfarToOutside: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
             return 0;
         }
-        EGS_Float t = 1e30;
+        EGS_Float t = veryFar;
         int inew = howfar(ireg,xx,u,t);
         ttot += t;
         if (inew < 0) {
@@ -784,7 +784,7 @@ int EGS_BaseGeometry::computeIntersections(int ireg, int n, const EGS_Vector &X,
     EGS_Vector x(X);
     int imed;
     if (ireg < 0) {
-        t = 1e30;
+        t = veryFar;
         ireg = howfar(ireg,x,u,t,&imed);
         if (ireg < 0) {
             return 0;
@@ -805,7 +805,7 @@ int EGS_BaseGeometry::computeIntersections(int ireg, int n, const EGS_Vector &X,
         isections[j].imed = imed;
         isections[j].rhof = getRelativeRho(ireg);
         isections[j].ireg = ireg;
-        t = 1e30;
+        t = veryFar;
         int inew = howfar(ireg,x,u,t,&imed);
         ttot += t;
         isections[j].t = ttot;

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -344,7 +344,11 @@ EGS_Float EGS_BaseGeometry::howfarToOutside(int ireg, const EGS_Vector &x,
     }
     EGS_Vector xx(x);
     EGS_Float ttot = 0;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_BaseGeometry::howfarToOutside: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return 0;
+        }
         EGS_Float t = 1e30;
         int inew = howfar(ireg,xx,u,t);
         ttot += t;

--- a/HEN_HOUSE/egs++/egs_functions.h
+++ b/HEN_HOUSE/egs++/egs_functions.h
@@ -53,6 +53,24 @@ using namespace std;
  */
 const EGS_Float epsilon = 1e-10;
 
+/*! \brief The maximum number of iterations for near-infinite loops
+ *
+ * \ingroup egspp_main
+ *
+ * The loopMax constant can be used to replace while(1){} loops
+ * so that the code returns after some large number of iterations.
+ */
+const EGS_I64 loopMax = 1e10;
+
+/*! \brief A very large float
+ *
+ * \ingroup egspp_main
+ *
+ * The veryLargeFloat constant is simply a very large float. It is usually
+ * used as an initial value for geometry bounds.
+ */
+const EGS_Float veryLargeFloat = 1e30;
+
 /*! \brief Writes the 64 bit integer \a n to the output stream data
  * and returns \c true on success, \c false on failure.
  *

--- a/HEN_HOUSE/egs++/egs_functions.h
+++ b/HEN_HOUSE/egs++/egs_functions.h
@@ -66,10 +66,10 @@ const EGS_I64 loopMax = 1e10;
  *
  * \ingroup egspp_main
  *
- * The veryLargeFloat constant is simply a very large float. It is usually
- * used as an initial value for geometry bounds.
+ * The veryFar constant is simply a very large float used as a large ditance
+ * It is often used as an initial large value for geometry bounds.
  */
-const EGS_Float veryLargeFloat = 1e30;
+const EGS_Float veryFar = 1e30;
 
 /*! \brief Writes the 64 bit integer \a n to the output stream data
  * and returns \c true on success, \c false on failure.

--- a/HEN_HOUSE/egs++/egs_geometry_tester.cpp
+++ b/HEN_HOUSE/egs++/egs_geometry_tester.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -396,7 +396,7 @@ void EGS_PrivateTester::testHowfar(EGS_BaseGeometry *g, bool time) {
 retry:
         //if( !go_back ) egsWarning("Initial position: (%g,%g,%g) direction: "
         //      "(%g,%g,%g)\n",x.x,x.y,x.z,u.x,u.y,u.z);
-        EGS_Float t_step = 1e15;
+        EGS_Float t_step = veryFar;
         int ireg = g->inside(x);
         int ireg_first = ireg;
         ireg = g->howfar(ireg,x,u,t_step);
@@ -419,7 +419,7 @@ retry:
         //if( !go_back && ireg >= 0 ) egsWarning("Starting loop: ireg=%d "
         //       "x=(%g,%g,%g)\n",ireg,x.x,x.y,x.z);
         while (ireg >= 0) {
-            t_step = 1e15;
+            t_step = veryFar;
             int ireg_new = g->howfar(ireg,x,u,t_step);
             //if( !go_back ) egsWarning("new region=%d step=%g x=(%g,%g,%g)\n",
             //        ireg_new,t_step,x.x,x.y,x.z);

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -306,7 +306,11 @@ get_input(const EGS_InputPrivate *p, const string &key, vector<T> &values) {
     values.erase(values.begin(),values.end());
     S_STREAM in(p1->value.c_str());
     int error = 0;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_InputPrivate::findStart: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return 2;
+        }
         T tmp;
         in >> tmp;
         if (!in.fail()) {
@@ -869,7 +873,11 @@ void EGS_InputPrivate::processInputLoop(EGS_InputPrivate *p) {
 int EGS_InputPrivate::addContent(istream &in) {
     string input;
     bool last_was_space = false;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_InputPrivate::addContent: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return -1;
+        }
         char c;
         in.get(c);
         if (in.eof() || !in.good()) {
@@ -929,7 +937,7 @@ int EGS_InputPrivate::addContent(istream &in) {
             }
         }
         else {
-            egsWarning("No matching stop delimeter for %s\n",what.c_str());
+            egsWarning("No matching stop delimiter for %s\n",what.c_str());
             return -1;
         }
     }
@@ -1033,7 +1041,11 @@ int EGS_InputPrivate::findStart(int start, int stop, const string &start_key,
                                 string &what, int &end) {
     string::size_type pos = start;
     unsigned int ns=0;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_InputPrivate::findStart: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return -2;
+        }
         if (pos >= stop) {
             return -1;
         }

--- a/HEN_HOUSE/egs++/egs_interpolator.cpp
+++ b/HEN_HOUSE/egs++/egs_interpolator.cpp
@@ -145,7 +145,11 @@ void EGS_Interpolator::initialize(EGS_Float Xmin, EGS_Float Xmax,
     for (j=0; j<nnow; j++) {
         tmp[j] = func(Xmin + ddx*j, data);
     }
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_Interpolator::initialize: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return;
+        }
         EGS_Float *tmp1 = new EGS_Float [nnow-1];
         for (j=0; j<nnow-1; j++) {
             tmp1[j] = func(Xmin + ddx*(0.5+j),data);

--- a/HEN_HOUSE/egs++/egs_polygon.cpp
+++ b/HEN_HOUSE/egs++/egs_polygon.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -107,7 +107,8 @@ EGS_2DPolygon::EGS_2DPolygon(vector<EGS_2DVector> &points, bool Open) {
     d = new EGS_Float [np-1];
     uj = new EGS_2DVector [np-1];
     pc = new bool [np-1];
-    xmin = 1e30, xmax = -1e30, ymin = 1e30, ymax = -1e30;
+    xmin = veryFar, xmax = -veryFar;
+    ymin = veryFar, ymax = -veryFar;
     for (j=0; j<np-1; j++) {
         pc[j] = true;
         if (p[j].x < xmin) {

--- a/HEN_HOUSE/egs++/egs_polygon.cpp
+++ b/HEN_HOUSE/egs++/egs_polygon.cpp
@@ -195,7 +195,11 @@ EGS_2DPolygon::EGS_2DPolygon(vector<EGS_2DVector> &points, bool Open) {
     int nc=2;
     j=2;
     bool doing_chull=true;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_2DPolygon::EGS_2DPolygon: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return;
+        }
         EGS_2DVector s(pp[j]-chull[nc-1]);
         EGS_2DVector sperp(-s.y,s.x);
         if (!ccw) {

--- a/HEN_HOUSE/egs++/egs_polygon.h
+++ b/HEN_HOUSE/egs++/egs_polygon.h
@@ -99,7 +99,7 @@ public:
     */
     EGS_Float hownear(bool in, const EGS_2DVector &x) const {
         if (!open) {
-            EGS_Float tperp = 1e30;
+            EGS_Float tperp = veryFar;
             bool do_it = true;
             for (int j=0; j<np-1; j++) {
                 EGS_2DVector v(x - p[j]);
@@ -133,7 +133,7 @@ public:
         }
         else {
             do_it = true;
-            tperp = 1e30;
+            tperp = veryFar;
         }
         v = x - p[1];
         lam = uj[1]*v;

--- a/HEN_HOUSE/egs++/egs_simple_application.cpp
+++ b/HEN_HOUSE/egs++/egs_simple_application.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -303,7 +303,7 @@ int EGS_SimpleApplication::run() {
         sum_w2 += wt*wt;
         int ireg = g->isWhere(x);
         if (ireg < 0) {
-            EGS_Float t = 1e30;
+            EGS_Float t = veryFar;
             ireg = g->howfar(ireg,x,u,t);
             if (ireg >= 0) {
                 x += u*t;

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -444,7 +444,11 @@ static char spec_msg1[] = "EGS_BaseSpectrum::createSpectrum:";
 //
 istream &skipsep(istream &in) {
     char c;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("skipsep: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return in;
+        }
         in.get(c);
         if (in.eof() || in.fail() || !in.good()) {
             break;

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
@@ -158,7 +158,7 @@ public:
 
     EGS_Float howfarToOutside(int ireg, const EGS_Vector &x,
                               const EGS_Vector &u) {
-        EGS_Float t = 1e30;
+        EGS_Float t = veryFar;
         howfar(ireg,x,u,t);
         return t;
     };
@@ -171,7 +171,7 @@ public:
             up = u*T->getRotation();
         }
         if (ireg == 0) {
-            EGS_Float t1 = 1e30;
+            EGS_Float t1 = veryFar;
             int inew = 0;
             EGS_Vector n;
             if (up.x > 0) {
@@ -186,7 +186,7 @@ public:
                 t = t1;
                 inew = -1;
             }
-            t1 = 1e30;
+            t1 = veryFar;
             if (up.y > 0) {
                 t1 = (ay - 2*xp.y)/(2*up.y);
             }
@@ -199,7 +199,7 @@ public:
                 t = t1;
                 inew = -1;
             }
-            t1 = 1e30;
+            t1 = veryFar;
             if (up.z > 0) {
                 t1 = (az - 2*xp.z)/(2*up.z);
             }
@@ -227,7 +227,7 @@ public:
             }
             return inew;
         }
-        EGS_Float t1 = 1e30;
+        EGS_Float t1 = veryFar;
         if (2*xp.x + ax < 0 && up.x > 0) {
             t1 = -(2*xp.x + ax)/(2*up.x);
         }
@@ -264,7 +264,7 @@ public:
                 return 0;
             }
         }
-        t1 = 1e30;
+        t1 = veryFar;
         if (2*xp.y + ay < 0 && up.y > 0) {
             t1 = -(2*xp.y + ay)/(2*up.y);
         }
@@ -301,7 +301,7 @@ public:
                 return 0;
             }
         }
-        t1 = 1e30;
+        t1 = veryFar;
         if (2*xp.z + az < 0 && up.z > 0) {
             t1 = -(2*xp.z + az)/(2*up.z);
         }

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -546,7 +546,7 @@ public:
                 // Call to CD geometry howfar with updated region ixold. If it is aimed away from
                 // geometry, it will return ixnew = -1 and assumption a) was correct. If it is
                 // aimed into geometry, it will return ixnew >=0 and assumption b) was correct.
-                tb = 1e30;
+                tb = veryFar;
                 int ixnew = howfar(ixold,x,u,tb,0,pn);
                 // Enters geometry and at a boundary or very close to one.
                 //if( ixnew_pos >= 0 && ixnew_neg < 0 && tb_neg <= boundaryTolerance && tb_pos <= boundaryTolerance) {
@@ -569,7 +569,7 @@ public:
                 }
                 // If a particle approaching the geometry sits on a boundary, we look back to see
                 // if we just entered the geometry (the previous checks fail to catch this case).
-                EGS_Float tb_neg = 1e30;
+                EGS_Float tb_neg = veryFar;
                 int ixnew_neg = howfar(ixold,x,u*(-1),tb_neg,0,pn);
                 if (ixnew_neg < 0 && tb_neg <= epsilon) {                             // (b) is true
                     t = 0;
@@ -586,7 +586,7 @@ public:
 
                 // 1. Check if we exit the base geometry after a sufficiently small
                 // distance.
-                EGS_Float t1=1e30, t2 = 1e30;
+                EGS_Float t1=veryFar, t2 = veryFar;
                 int ibase_n, ic_n=0;
                 ibase_n = bg->howfar(ibase,x,u,t1);
                 if (ibase_n < 0 && t1 < boundaryTolerance) {

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -681,7 +681,11 @@ public:
 do_checks:
         EGS_Vector tmp(x + u*tb);  // position at which we are inside
         // the base geometry
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_CDGeometry::howfar: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
             if (!g[ibase]) { // no inscribed geometry in this base geometry region
                 t = ttot;
                 if (newmed) {

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -430,7 +430,7 @@ public:
         EGS_Float A   = 1 - b*b*g12;                // 1 - cos^2(t)/cos^2(t_cone)
         EGS_Float B   = c - aa*b*g12;
         EGS_Float C   = r2 - aa*aa*g12;
-        EGS_Float tt  = 1e30;
+        EGS_Float tt  = veryFar;
         EGS_Float lam = -1;
 
         if (fabs(A) < boundaryTolerance) {
@@ -853,11 +853,11 @@ public:
             EGS_Float A  = 1 - b*b*g12;
             EGS_Float B  = c - aa*b*g12;
             EGS_Float C  = r2 - aa*aa*g12;
-            EGS_Float tt = 1e30;
+            EGS_Float tt = veryFar;
             EGS_Float lam = -1;
 
             // moving parallel to cone surface
-            if (fabs(A) < boundaryTolerance) {                   // guarding against /0 in general solution
+            if (fabs(A) < boundaryTolerance) {      // guarding against /0 in general solution
                 EGS_Float ttt = -C/(2*B);           // distance to hit
                 lam = aa+b*ttt;                     // axial position of hit
                 if (ttt >= 0 && lam >= 0) {
@@ -899,7 +899,7 @@ public:
         EGS_Vector xp(x-xo[ireg]);
         EGS_Float aa = xp*a, b = u*a, r2 = xp.length2(), c = u*xp;
         EGS_Float A = 1 - b*b*g12, B = c - aa*b*g12, C = r2 - aa*aa*g12;
-        EGS_Float to = 1e30, lamo = -1;
+        EGS_Float to = veryFar, lamo = -1;
         if (fabs(A) < boundaryTolerance) {  // moving parallel to the cone surface.
             // for the outer cone we only have a solution if a*u < 0.
             // i.e. if we are moving towards the apex.
@@ -939,7 +939,7 @@ public:
 
     // hownear
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tc = 1E30;
+        EGS_Float tc = veryFar;
         if (ireg < 0 || ireg < nc-1) {
             EGS_Vector xp;
             if (ireg < 0) {
@@ -1302,7 +1302,7 @@ public:
     }
 
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tc = 1E30;
+        EGS_Float tc = veryFar;
         EGS_Vector xp(x-xo);
         EGS_Float aa = xp*a, r2 = xp.length2(), ag;
         //egsWarning("hownear: ireg = %d x = (%g,%g,%g) aa = %g r2 = %g\n",
@@ -1545,7 +1545,7 @@ public:
             }
             else {                                  // u is perpendicular to a (u*a = 0)
                 dir = 0;                            // null direction
-                tp = 1e30;                          // init to large distance
+                tp = veryFar;                       // init to large distance
             }
             bool hitp = false;                      // assume we don't hit the plane
             if (tp <= t) {                          // check against maximum distance t
@@ -1658,7 +1658,7 @@ public:
                 // BUT indeed we may be glancing on a "corner" of the ConeStack, so we should still
                 // check if a subsequent call to howfar(ir,tmp,...) takes us outside within boundaryTolerance.
                 // It that case we are not really entering the geometry.
-                EGS_Float tb = 1e30;
+                EGS_Float tb = veryFar;
                 int inew_g = howfar(ir,tmp,u,tb,0,normal);
                 if (inew_g < 0 && tb <= boundaryTolerance) {
                     return ireg;    // exits geometry
@@ -1701,7 +1701,7 @@ public:
                 // BUT indeed we may be glancing on a "corner" of the ConeStack, so we should still
                 // check if a subsequent call to howfar(il*nmax+ir) takes us outside within boundaryTolerance.
                 // It that case we are not really entering the geometry.
-                EGS_Float tb = 1e30;
+                EGS_Float tb = veryFar;
                 int inew_g = howfar(il*nmax+ir,tmp,u,tb,0,normal);
                 if (inew_g < 0 && tb <= boundaryTolerance) {
                     return ireg;    // exits geometry
@@ -1752,7 +1752,7 @@ public:
 
                 // fp inconsistency: irnow >= 0 (inside) but called with ireg = -1 (outside)
                 if (irnow >= 0) {
-                    EGS_Float tb = 1e30;
+                    EGS_Float tb = veryFar;
                     int inew_g = howfar(irnow,x,u,tb,0,&tmp_normal);
                     if (inew_g < 0 && tb <= boundaryTolerance) {
                         return ireg;    // exits geometry
@@ -1793,7 +1793,7 @@ public:
                 // IK, March 7 2008: same problem as in CD geometry.
                 // we think we are outside but we just found we are inside.
                 // Hopefully a roundoff problem.
-                EGS_Float tp = 1e30;
+                EGS_Float tp = veryFar;
 
                 if (up > 0) {
                     dir = 1;
@@ -1818,7 +1818,7 @@ public:
                 }
 
                 if (isc) {
-                    EGS_Float tc = 1e30;
+                    EGS_Float tc = veryFar;
                     int isc_new = cones[il][nr[il]-1]->howfar(0,x,u,tc);
                     if (!(isc_new < 0 && tc < boundaryTolerance)) {
                         egsWarning("EGS_ConeStack::howfar: called from the outside"
@@ -1850,7 +1850,7 @@ public:
             }
             else {                                  // moving perpendicular to axis (u*a = 0)
                 dir = 0;                            // null direction
-                tp  = 1e30;                         // init to large distance
+                tp  = veryFar;                      // init to large distance
             }
 
             // distance to outer cone in layer 'il'

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -1833,7 +1833,11 @@ public:
         }
 
         // traverse layers until we hit a cone, or else move beyond conestack boundary planes
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_ConeStack::howfar: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
 
             // calculate distance to next plane boundary
             if (up > 0) {                           // moving along conestack axis a

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -210,7 +210,7 @@ public:
         EGS_Float up=a*u;
         EGS_Float rcp=a*rc;
         EGS_Vector rcp_vec=a*rcp;
-        EGS_Float d=1e30;
+        EGS_Float d=veryFar;
         int new_region=-1;
 
         egsInformation("howfar: %2d %12.9f %12.9f\n",

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
@@ -256,7 +256,7 @@ public:
         }
         EGS_Float up=a*u;
         if (fabs(up)>=1) {
-            return 1e30;    // parallel to axis
+            return veryFar;    // parallel to axis
         }
         EGS_Float A=1-up*up;
         EGS_Vector rc(x-xo);
@@ -274,7 +274,7 @@ public:
     int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u,
                EGS_Float &t, int *newmed = 0, EGS_Vector *normal = 0) {
 
-        EGS_Float d=1e30;  // large distance to any boundry
+        EGS_Float d=veryFar;  // large distance to any boundry
 
         // projections
         double up=a*u;

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
@@ -322,7 +322,7 @@ public:
                 EGS_Float xx = Ax*xp*axi[ireg], xy = Ay*xp*ayi[ireg];
                 EGS_Float xu = xx*ux + xy*uy;
                 EGS_Float r2 = xx*xx + xy*xy - 1;
-                EGS_Float d = 1e30;
+                EGS_Float d = veryFar;
                 if (r2 >= 0) {
                     // we think we are inside but the math shows we are
                     // outside. Hopefully a truncation problem.
@@ -371,7 +371,7 @@ public:
 
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
         EGS_Float xx = fabs(Ax*x), xy = fabs(Ay*x);
-        EGS_Float tperp = ireg >= 0 ? hownear(ireg,xx,xy) : 1e30;
+        EGS_Float tperp = ireg >= 0 ? hownear(ireg,xx,xy) : veryFar;
         if (ireg && tperp > 0) {
             int n = ireg < 0 ? nreg-1 : ireg-1;
             EGS_Float t1 = hownear(n,xx,xy);

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
@@ -415,7 +415,11 @@ private:
                     uo*(uo*uo-4*(vo*vo+3))/(16*(1+vo*vo)) :
                     1 - 0.5*vo*vo/(vo*vo+(uo+1)*(uo+1));
         int ntry=0;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_EllipticCylindersT::hownear: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return 0;
+            }
             if (++ntry > 50) {
                 if (++nwarn < 20) egsWarning("EGS_EllipticCylindersT::"
                                                  "hownear: failed to find solution\n");

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
@@ -321,7 +321,11 @@ public:
 
         int j = ifirst;
         int ij = -1, ig;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_EnvelopeGeometry::computeIntersections: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
             if (ireg >= nbase) {
                 if (new_indexing) {
                     ig = reg_to_inscr[ireg-nbase];
@@ -710,7 +714,11 @@ public:
 
         int j = ifirst;
         int ij = -1, ig;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_FastEnvelope::computeIntersections: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
             //egsInformation("in loop: j=%d ireg=%d imed=%d x=(%g,%g,%g)\n",
             //        j,ireg,imed,x.x,x.y,x.z);
             if (ireg >= nbase) {

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
@@ -301,7 +301,7 @@ public:
         EGS_Vector x(X);
         int imed;
         if (ireg < 0) {
-            t = 1e30;
+            t = veryFar;
             ireg = howfar(ireg,x,u,t,&imed);
             if (ireg < 0) {
                 return 0;
@@ -340,7 +340,7 @@ public:
             isections[j].ireg = ireg;
             isections[j].rhof = getRelativeRho(ireg);
             if (ireg < nbase) { // in one of the regions of the base geometry
-                t = 1e30;
+                t = veryFar;
                 int ibase = g->howfar(ireg,x,u,t,&imed);
                 ij = -1, ig;
                 for (int i=0; i<n_in; i++) {
@@ -692,7 +692,7 @@ public:
         //egsInformation("computeIntersections: ireg=%d x=(%g,%g,%g) "
         //     "u=(%g,%g,%g)\n",ireg,x.x,x.y,x.z,u.x,u.y,u.z);
         if (ireg < 0) {
-            t = 1e30;
+            t = veryFar;
             ireg = howfar(ireg,x,u,t,&imed);
             if (ireg < 0) {
                 return 0;
@@ -729,7 +729,7 @@ public:
             isections[j].ireg = ireg;
             isections[j].rhof = getRelativeRho(ireg);
             if (ireg < nbase) { // in one of the regions of the base geometry
-                t = 1e30;
+                t = veryFar;
                 int ibase = g->howfar(ireg,x,u,t,&imed);
                 //egsInformation("In base geometry: t=%g inew=%d\n",t,ibase);
                 ij = -1, ig;

--- a/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.h
+++ b/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.h
@@ -415,7 +415,11 @@ public:
         EGS_Float ttot = 0;
         //EGS_Vector tmp_n;
         //EGS_Vector *norm = normal ? &tmp_n : 0;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_RadialRepeater::howfar: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
             EGS_Float this_t = t_left;
             //EGS_Vector xp = xtmp*R[ir], up = u*R[ir];
             EGS_Vector xp = (xtmp-xo)*R[ir], up = u*R[ir];

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Reid Townson
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -323,7 +323,12 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
             rho_def.push_back(rdef);
         }
     }
-    else while (1) {
+    else {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_XYZGeometry::constructGeometry: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return 0;
+            }
             // other format of data
             string medname;
             EGS_Float rmin,rmax,rdef;
@@ -338,6 +343,7 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
             rho_max.push_back(rmax);
             rho_def.push_back(rdef);
         }
+    }
     if (med_names.size() < 1) {
         egsWarning("%s: no media defined in the CT ramp "
                    "file %s!\n",func,ramp_file);
@@ -464,7 +470,11 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
         string data_file("");
         int data_type = -1;
         float scale_x=0.0, scale_y=0.0, scale_z=0.0;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_XYZGeometry::constructGeometry: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return 0;
+            }
             string line, key, value;
             size_t pos;
             getline(h_file, line);

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -343,7 +343,7 @@ public:
             return 0;
         }
         int itmp = ireg;
-        EGS_Float d = 1e30;
+        EGS_Float d = veryFar;
         for (int j=N-1; j>=0; j--) {
             int l = itmp/n[j];
             EGS_Float t = g[j]->howfarToOutside(l,x,u);
@@ -487,7 +487,7 @@ public:
     };
 
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tmin = 1e30;
+        EGS_Float tmin = veryFar;
         if (ireg >= 0) {
             int itmp = ireg;
             for (int j=N-1; j>=0; j--) {
@@ -520,7 +520,7 @@ public:
             return sqrt(s2);
         }
         else {
-            EGS_Float tmin = 1e30;
+            EGS_Float tmin = veryFar;
             for (int j=0; j<N; j++) {
                 EGS_Float t;
                 int i = g[j]->isWhere(x);
@@ -748,7 +748,7 @@ public:
         EGS_Vector x(X);
         int imed;
         if (ireg < 0) {
-            t = 1e30;
+            t = veryFar;
             ireg = howfar(ireg,x,u,t,&imed);
             if (ireg < 0) {
                 return 0;
@@ -784,7 +784,7 @@ public:
             icx = 0;
         }
         else               {
-            uxi = 1e33;
+            uxi = veryFar*1e3;
             dirx =  1;
             icx = 1;
         }
@@ -799,7 +799,7 @@ public:
             icy = 0;
         }
         else               {
-            uyi = 1e33;
+            uyi = veryFar*1e3;
             diry =  1;
             icy = 1;
         }
@@ -814,7 +814,7 @@ public:
             icz = 0;
         }
         else               {
-            uzi = 1e33;
+            uzi = veryFar*1e3;
             dirz =  1;
             icz = 1;
         }
@@ -1458,7 +1458,7 @@ public:
         normvec = (n3-n1)%(n2-n1);
         dpi[3] = normvec.length2();
         disti[3] = normvec*(n0x+n1);
-        EGS_Float mindist = 1e30, mindp=1;
+        EGS_Float mindist = veryFar, mindp=1;
         for (int i=0; i<4; ++i) {
             if (disti[i]*mindp < mindist*dpi[i]) {
                 mindist = disti[i];

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -429,7 +429,11 @@ public:
                 EGS_Float tleft = t;
                 int ii = g[j]->isWhere(x);
                 EGS_Float ttot = 0;
-                while (1) {
+                for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+                    if (loopCount == loopMax) {
+                        egsFatal("EGS_NDGeometry::howfar: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                        return -1;
+                    }
                     EGS_Float tt = tleft;
                     int inew = g[j]->howfar(ii,tmp,u,tt);
                     if (inew == ii) {
@@ -1728,7 +1732,11 @@ public:
         EGS_Float t_left = t;
         EGS_Vector xtmp(x);
         EGS_Float ttot = 0;
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("EGS_XYZRepeater::howfar: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return -1;
+            }
             EGS_Float this_t = t_left;
             EGS_Vector xp(xtmp - translation[cell]);
             int inew = g->howfar(-1,xp,u,this_t,newmed,normal);

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
@@ -222,7 +222,7 @@ public:
             }
             else {
                 nreg = 1;
-                p_last = 1e15;
+                p_last = veryFar*1e-15;
                 n_plane = 0;
             }
         }
@@ -252,7 +252,7 @@ public:
             }
             else {
                 nreg = 1;
-                p_last = 1e15;
+                p_last = veryFar*1e-15;
                 n_plane = 0;
             }
         }
@@ -318,7 +318,7 @@ public:
             return 0;
         }
         double xp = a*x, up = a*u;
-        EGS_Float t = 1e30;
+        EGS_Float t = veryFar;
         if (up > 0) {
             t = (p_last-xp)/up;
         }
@@ -330,9 +330,9 @@ public:
 
     int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u,
                EGS_Float &t, int *newmed=0, EGS_Vector *normal=0) {
-        //EGS_Float d = 1e30; int res=ireg;
+        //EGS_Float d = veryFar; int res=ireg;
         //EGS_Float xp = a*x, up = a*u;
-        double d = 1e35;
+        double d = veryFar*1e5;
         int res=ireg;
         double xp = a*x, up = a*u;
         if (ireg >= 0) {

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
@@ -207,7 +207,7 @@ public:
         }
         EGS_Float up = a*u, d = p->distance(x);
         if (!ireg) {  // inside
-            EGS_Float tt = 1e30;
+            EGS_Float tt = veryFar;
             int inew = ireg;
             if (up > boundaryTolerance) {
                 tt = (d2 - d)/up;
@@ -241,7 +241,7 @@ public:
             return -1;
         }
         if (d < d1 || d > d2) {
-            EGS_Float tt = 1e30;
+            EGS_Float tt = veryFar;
             if (d < d1 && up > boundaryTolerance) {
                 tt = (d1 - d)/up;
             }

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.h
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.h
@@ -247,7 +247,7 @@ public:
 
     // TODO: optimize. this implementation is waaaay too slow.
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        EGS_Float tperp = 1e30;
+        EGS_Float tperp = veryFar;
         for (int j=0; j<n; j++) {
             EGS_Float t = s[j]->hownear(true,x);
             if (t < tperp) {

--- a/HEN_HOUSE/egs++/geometry/egs_space/egs_space.h
+++ b/HEN_HOUSE/egs++/geometry/egs_space/egs_space.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -106,7 +106,7 @@ public:
 
     EGS_Float howfarToOutside(int ireg, const EGS_Vector &x,
                               const EGS_Vector &u) {
-        return 1e30;
+        return veryFar;
     };
 
     int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u,
@@ -115,7 +115,7 @@ public:
     };
 
     EGS_Float hownear(int ireg, const EGS_Vector &x) {
-        return 1e30;
+        return veryFar;
     };
 
     const string &getType() const {

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Frederic Tessier
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -149,7 +150,7 @@ int EGS_cSpheres::howfar(int ireg, const EGS_Vector &x,
                          const EGS_Vector &u, EGS_Float &t, int *newmed, EGS_Vector *normal) {
     int direction_flag=-1;  /* keep track of direction entering or exiting a
                              sphere boundary */
-    double d=1e35;      // set a maximum distance from a boundary
+    double d=veryFar*1e5;   // set a maximum distance from a boundary
 
     EGS_Vector xp(x - xo);
     double aa = xp*u, aa2 = aa*aa;

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
@@ -266,7 +266,7 @@ public:
             return tmin;
         }
         // if here, we are outside of all geomtries in the union.
-        EGS_Float tmin = 1e30;
+        EGS_Float tmin = veryFar;
         for (int j=ng-1; j>=0; j--) {
             EGS_Float t = g[j]->hownear(-1,x);
             if (t < tmin) {

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2008
 #
 #  Contributors:    Frederic Tessier
+#                   Reid Townson
 #
 ###############################################################################
 #
@@ -330,7 +331,7 @@ public:
         EGS_Vector x(X);
         int imed;
         if (ireg < 0) {
-            t = 1e30;
+            t = veryFar;
             ireg = howfar(ireg,x,u,t);
             if (ireg < 0) {
                 return 0;
@@ -363,8 +364,8 @@ public:
         }
         else {
             dirx =  1;
-            nextx = 1e33;
-            sx = 1e33;
+            nextx = veryFar*1e3;
+            sx = veryFar*1e3;
         }
         if (u.y > 0)      {
             uyi = 1/u.y;
@@ -380,8 +381,8 @@ public:
         }
         else {
             diry =  1;
-            nexty = 1e33;
-            sy = 1e33;
+            nexty = veryFar*1e3;
+            sy = veryFar*1e3;
         }
         if (u.z > 0)      {
             uzi = 1/u.z;
@@ -397,8 +398,8 @@ public:
         }
         else  {
             dirz =  1;
-            nextz = 1e33;
-            sz = 1e33;
+            nextz = veryFar*1e3;
+            sz = veryFar*1e3;
         }
         for (int j=ifirst; j<n; j++) {
             isections[j].ireg = ireg;
@@ -453,11 +454,11 @@ public:
             return 0;
         }
         EGS_Float tx = u.x > 0 ? (xmax-x.x)/u.x :
-                       u.x < 0 ? (xmin-x.x)/u.x : 1e35;
+                       u.x < 0 ? (xmin-x.x)/u.x : veryFar*1e5;
         EGS_Float ty = u.y > 0 ? (ymax-x.y)/u.y :
-                       u.y < 0 ? (ymin-x.y)/u.y : 1e35;
+                       u.y < 0 ? (ymin-x.y)/u.y : veryFar*1e5;
         EGS_Float tz = u.z > 0 ? (zmax-x.z)/u.z :
-                       u.z < 0 ? (zmin-x.z)/u.z : 1e35;
+                       u.z < 0 ? (zmin-x.z)/u.z : veryFar*1e5;
         return tx < ty && tx < tz ? tx : ty < tz ? ty : tz;
     };
 
@@ -801,7 +802,7 @@ struct VHPBox {
         return false;
     };
     EGS_Float howfarToOut(const EGS_Vector &x, const EGS_Vector &u) {
-        EGS_Float t = 1e35, t1;
+        EGS_Float t = veryFar*1e5, t1;
         if (u.x > 0) {
             t1 = (xmax-x.x)/u.x;
             if (t1 < t) {

--- a/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
@@ -205,7 +205,11 @@ EGS_VoxelizedShape::EGS_VoxelizedShape(int file_format, const char *fname,
     int data_type = -1;
     int Nx, Ny, Nz;
     float scale_x=0.0, scale_y=0.0, scale_z=0.0;
-    while (1) {
+    for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+        if (loopCount == loopMax) {
+            egsFatal("EGS_VoxelizedShape::EGS_VoxelizedShape: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+            return;
+        }
         string line, key, value;
         size_t pos;
         getline(h_file, line);

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -59,12 +59,12 @@ EGS_BeamSource::EGS_BeamSource(EGS_Input *input, EGS_ObjectFactory *f) :
     i_reuse_electron = 0;
     is_valid = false;
     lib = 0;
-    Xmin = -1e30;
-    Xmax = 1e30;
-    Ymin = -1e30;
-    Ymax = 1e30;
-    wmin = -1e30;
-    wmax = 1e30;
+    Xmin = -veryFar;
+    Xmax = veryFar;
+    Ymin = -veryFar;
+    Ymax = veryFar;
+    wmin = -veryFar;
+    wmax = veryFar;
     string beam_code;
     int err1 = input->getInput("beam code",beam_code);
     string pegs_file;

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -50,10 +50,10 @@ EGS_PhspSource::EGS_PhspSource(const string &phsp_file,
 void EGS_PhspSource::init() {
     otype = "EGS_PhspSource";
     recl = 0;
-    Xmin = -1e30;
-    Xmax = 1e30;
-    Ymin = -1e30;
-    Ymax = 1e30;
+    Xmin = -veryFar;
+    Xmax = veryFar;
+    Ymin = -veryFar;
+    Ymax = veryFar;
     is_valid = false;
     record = 0;
     mode2 = false;
@@ -67,8 +67,8 @@ void EGS_PhspSource::init() {
     Nrecycle = 0;
     Npos = 0;
     Nlast = 0;
-    wmin = -1e30;
-    wmax = 1e30;
+    wmin = -veryFar;
+    wmax = veryFar;
     Nreuse_g = 1;
     Nreuse_e = 1;
     Nreuse = 1;

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Blake Walters, 2013
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -47,10 +47,10 @@ IAEA_PhspSource::IAEA_PhspSource(const string &phsp_file,
 
 void IAEA_PhspSource::init() {
     otype = "IAEA_PhspSource";
-    Xmin = -1e30;
-    Xmax = 1e30;
-    Ymin = -1e30;
-    Ymax = 1e30;
+    Xmin = -veryFar;
+    Xmax = veryFar;
+    Ymin = -veryFar;
+    Ymax = veryFar;
     is_valid = false;
     mode2 = false;
     swap_bytes = false;
@@ -63,8 +63,8 @@ void IAEA_PhspSource::init() {
     Nrecycle = 0;
     Npos = 0;
     Nlast = 0;
-    wmin = -1e30;
-    wmax = 1e30;
+    wmin = -veryFar;
+    wmax = veryFar;
     Nreuse_g = 1;
     Nreuse_e = 1;
     Nreuse = 1;

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -382,7 +382,11 @@ void ImageWindow::paintEvent(QPaintEvent *) {
         }
         QString mxstring = QString::number(mxval);
 
-        while (1) {
+        for (EGS_I64 loopCount=0; loopCount<=loopMax; ++loopCount) {
+            if (loopCount == loopMax) {
+                egsFatal("ImageWindow::paintEvent: Too many iterations were required! Input may be invalid, or consider increasing loopMax.");
+                return;
+            }
             int wmax = p.fontMetrics().width(mxstring);
             if (wmax < 41) {
                 break;

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Manuel Stoeckl
+#                   Reid Townson
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
 #                   Manuel Stoeckl
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -905,7 +906,7 @@ int GeometryViewControl::setGeometry(
 #endif
     }
 
-    EGS_Vector pmin(1e10,1e10,1e10), pmax(-1e10,-1e10,-1e10);
+    EGS_Vector pmin(veryFar,veryFar,veryFar), pmax(-veryFar,-veryFar,-veryFar);
     //egsWarning("xo = (%g,%g,%g)\n",xo.x,xo.y,xo.z);
     for (int isize=0; isize<6; isize++) {
         progress.setValue(100+5*isize);
@@ -942,7 +943,7 @@ int GeometryViewControl::setGeometry(
                 int ir = ireg;
                 int nstep = 0;
                 do {
-                    EGS_Float t = 1e30;
+                    EGS_Float t = veryFar;
                     int inew = g->howfar(ir,x,u,t);
                     if (inew == ir) {
                         break;


### PR DESCRIPTION
Remove infinite loops from egs++, replacing them with for loops. Add a new parameter `loopMax` that dictates how many times near-infinite loops will iterate. Upon hitting the maximum, `egsFatal` will report an error.

Add a `veryLargeFloat` parameter to replace hard-coded instances of `1e30` and such.