### PR TITLE
Fix #179: electr bug when ustep in single scattering is zero

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1280,6 +1280,9 @@ $start_new_particle;
                         domultiple = .false.; "Do not do multiple scattering
                         "Sample the distance to a single scattering event
                         $RANDOMSET rnnoss;
+                        IF( rnnoss < 1.e-30 ) [
+                            rnnoss = 1.e-30;
+                        ]
                         lambda = - Log(1 - rnnoss);
                         lambda_max = 0.5*blccl*rm/dedx*(eke/rm+1)**3;
                         IF( lambda >= 0 & lambda_max > 0 ) [


### PR DESCRIPTION
Fix a bug that happens rarely when the random number rnnoss is set to
zero. This results in ustep=tustep=0 but occasionally they are set to
an erroneous value. With electric and magnetic fields this leads to
infinite loops. See issue #179 for more details.

Now, when the random number is less than 1e-30 it is set to 1e-30. 

@victorMalkov, does this fix the problem? Does anyone see a problem with this solution?

Notice a similar solution in FLURZnrc at line 1461:
```
REPLACE {$SELECT-PHOTON-MFP;} WITH
"==========================="

{;$RANDOMSET RNNO35;IF(RNNO35 = 0.0) RNNO35=1.E-30;
IF(IFORCE = 0)["photon interaction forcing option not chosen"
    DPMFP=-LOG(RNNO35);
    ]
ELSE[
```