### PR TITLE
Fix bug setting wrong $EGS_HOME/bin/my_machine folder

### DIFF
--- a/HEN_HOUSE/scripts/egsnrc_bashrc_additions
+++ b/HEN_HOUSE/scripts/egsnrc_bashrc_additions
@@ -52,8 +52,9 @@ PATH="${HEN_HOUSE}bin/$my_machine:$PATH"
 # Only needed by egs_view pre-compiled for release without
 # hard-coded run-time search path (no -rpath)
 #
-test -d $HEN_HOUSE/egs++/dso/linux-static && my_machine=linux-static
-export LD_LIBRARY_PATH="${HEN_HOUSE}egs++/dso/$my_machine:$LD_LIBRARY_PATH"
+if test -d $HEN_HOUSE/egs++/dso/linux-static; then
+   export LD_LIBRARY_PATH="${HEN_HOUSE}egs++/dso/linux-static:$LD_LIBRARY_PATH"
+fi
 
 # Now check for EGS_HOME.
 # If EGS_HOME is not empty and exists, check for $EGS_HOME/bin and


### PR DESCRIPTION
BUG: In order to set LD_LIBRARY_PATH for pre-compiled egs_view my_machine
     was changed to linux-static. This affected the location of the
     application in $EGS_HOME.

This commit fixes it.