### PR TITLE
Fix #230: Fix min. no. of control points

### DIFF
--- a/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
+++ b/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
@@ -1839,8 +1839,8 @@ Charge of the incident beam (-1: electron, 0: photon, 1: positron, 2: all partic
 \indexm{nset}
 \indexm{\$MXANG}
 The number of control points.  Control points define the beginning and end points of ranges of incident direction angles, SSD's and isocentre coordinates over which continuous motion of the source is simulated
-(see below).  The maximum value of {\tt nset} is defined by the parameter {\tt \$MXANG} in
-the file {\tt \$EGS\_HOME/dosxyznrc/dosxyznrc\_user\_macros.mortran}.
+(see below).  {\tt nset} must be in the range 2 $\leq$ {\tt nset} $\leq$ {\tt \$MXANG}, where {\tt \$MXANG} is defined in
+the file\\ {\tt \$EGS\_HOME/dosxyznrc/dosxyznrc\_user\_macros.mortran}.
 \item [~~~~{\tt i\_dbs}]
 \indexm{i\_dbs}
 Set to 1 if the phase space source was generated using directional bremsstrahlung splitting (DBS) in BEAM and you wish
@@ -1879,7 +1879,7 @@ the phantom. The number of times to recycle each source particle before proceedi
 library geometry to the number of incident particles (survival ratio).  The default is to do the calibration run if a BEAM shared library geometry is present.
 \end{description}
 
-For i=1,2,...,{\tt nset} (the no. of control points), the following parameters are entered:
+For i=2,...,{\tt nset} (the no. of control points), the following parameters are entered:
 \begin{description}
 \item[~~~~{\tt xiso(i)/yiso(i)/ziso(i)}]
 \indexm{xiso,yiso,ziso}
@@ -2244,7 +2244,8 @@ Charge of the incident beam (-1: electron, 0: photon, 1: positron, 2: all partic
 \indexm{nset}
 \indexm{\$MXANG}
 The number of control points defining ranges of continuous source motion.  Same as for source 20 (see above).
-The maximum value of {\tt nset} is defined by the parameter {\tt \$MXANG} in
+{\tt nset} must be in the range 2 $\leq$ {\tt nset} $\leq$ {\tt \$MXANG}, where
+{\tt \$MXANG} is defined in
 the file {\tt \$EGS\_HOME/dosxyznrc/dosxyznrc\_user\_macros.mortran}.
 \item [~~~~{\tt i\_dbs}]
 \indexm{i\_dbs}
@@ -2291,7 +2292,7 @@ delivered up to control point i.  This is slightly different from source 20, whe
 of incident particles up to control point i.  Thus, for source 21, {\tt muIndex(i)} is actually related to the fractional
 monitor units delivered by the BEAM simulation.
 Note that {\tt muIndex(i)} $\geq$ {\tt muIndex(i-1)}. Also note that for correct selection of the range
-of incident source parameters, {\tt muIndex(i)=0.0} and {\tt muIndex(nset)=1.0}.
+of incident source parameters, {\tt muIndex(1)=0.0} and {\tt muIndex(nset)=1.0}.
 \end{description}
 This is the end of inputs required for each control point.
 

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_source.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_source.tcl
@@ -147,6 +147,8 @@ proc set_src_options { isource } {
     }
     if {$isource==20 || $isource==21} {
 	#get settings
+        #min. of 2 set points
+        set numsets [expr max($numsets,2)] 
 	frame $w.setdef -bd 4
 	button $w.setdef.but -text "define settings"\
                                  -command {define_setting}
@@ -1488,7 +1490,8 @@ proc define_setting { } {
           $top.b.okb configure -state disabled
     }
 
-    if {$numsets==0} {
+    #must have at least 2 set points
+    if {$numsets==2} {
           $top.b.delb configure -state disabled
     }
 
@@ -1606,7 +1609,8 @@ proc add_setting { } {
     entry $w.grid.e8$k -textvariable muI($i) -width 8
     grid configure $w.grid.e8$k -row $k -column 8
 
-    if {$numsets==1} {
+    #min. of 2 set points
+    if {$numsets==3} {
          #re-enable the delete last pair/group button
          $w.b.delb configure -state normal -command "del_setting"
     }
@@ -1712,7 +1716,8 @@ proc del_setting { } {
     }
     incr numsets -1
 
-    if {$numsets==0} {
+    #min no. of pts=2
+    if {$numsets==2} {
           set w .main_w.srcopt.sett$prev
           $w.b.delb configure -state disabled
     }

--- a/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
@@ -485,7 +485,7 @@
 "                           = 2 all the particles will be used
 "                           internally renamed as iqinc
 "               isource     = 20
-"               nset        number of settings (control points)
+"               nset        number of settings (control points) (>=2)
 "               i_dbs       set to 1 if you are using directional bremsstrahlung
 "                           splitting (DBS) in the BEAM simulation
 "                           AND you wish to reject fat photons not aimed into
@@ -537,7 +537,7 @@
 "                           = 2 all the particles will be used
 "                           internally renamed as iqinc
 "               isource     = 21
-"               nset        number of settings (control points)
+"               nset        number of settings (control points) (>=2)
 "               i_dbs       set to 1 if you are using directional bremsstrahlung
 "                           splitting (DBS) in the BEAM simulation
 "                           AND you wish to reject fat photons not aimed into
@@ -1556,7 +1556,7 @@ ELSEIF(isource = 20)[ "Phase Space Incident from multiple settings and "
         r_dbs = 0;
         e_split = temp(3);
     ]
-    IF(nset>0)[
+    IF(nset>1)[
     OUTPUT nset,e_split;
     ( / ' Phase Space source though dynamic library with multiple variable'/
         ' geometry settings'/
@@ -1629,11 +1629,11 @@ ELSEIF(isource = 20)[ "Phase Space Incident from multiple settings and "
       ]
       dsource=dsourcetemp(1);"set to first one arbitrarily since its done"
 				     "later on the fly"
-    ]"if nset is greater than 0
-    ELSEIF(nset<0) [
+    ]"if nset is greater than 1
+    ELSEIF(nset<2) [
 	  OUTPUT61 nset;
 	  (//' ***ERROR in source 20***'/
-	  'nset (',I8,') must be positive'//);
+	  'nset (',I8,') must be >= 2'//);
 	  STOP;
     ]
     OUTPUT;(' ');
@@ -1647,7 +1647,7 @@ ELSEIF(isource = 21)[ "BEAM simulation with multiple settings and through"
     e_split=temp(3);
     i_muidx_out=temp(4);
     iqinc=iqin;
-    IF(nset>0)[
+    IF(nset>1)[
         OUTPUT nset,e_split;
         ( / ' Full BEAM Sim. incident from multiple settings'/
             ' Number of settings:',t55,i10/
@@ -1692,10 +1692,10 @@ ELSEIF(isource = 21)[ "BEAM simulation with multiple settings and through"
       dsource=dsourcetemp(1);"set to first one arbitrarily since its done"
 				     "later on the fly"
   ]
-  ELSEIF(nset<0) [
+  ELSEIF(nset<2) [
 	  OUTPUT61 nset;
 	  (//' ***ERROR in source 21***'/
-	  'nset (',I8,') must be positive'//);
+	  'nset (',I8,') must be >= 2'//);
 	  STOP;
 	  ]
 	  OUTPUT;(' ');
@@ -3243,7 +3243,7 @@ ELSEIF(isource=10)[
    ]
 ]
 ELSEIF(isource=20)  [
-  IF(nset>0) [
+  IF(nset>1) [
     OUTPUT61 nset,dsource,nshist,$cstring(the_shared_lib),
        $cstring(the_input_file);
    ( t15,'Phase Space Incident from multiple settings through a BEAM/MLC '//
@@ -3287,7 +3287,7 @@ ELSEIF(isource=20)  [
    ]
 ]
 ELSEIF(isource=21)  [
-  IF(nset>0) [
+  IF(nset>1) [
     OUTPUT61 nset,dsource,
        $cstring(the_beam_code),$cstring(the_input_file),
        $cstring(the_pegs_file),$cstring(the_vcu_code),


### PR DESCRIPTION
DOSXYZnrc code, GUI now do not allow input for sources 20, 21
to have fewer than 2 control points.  This has always been the
min. no. of points required for these sources but it was never
enforced elegantly; the code was simply allowed to crash.
This min. is also explicitly stated in the DOSXYZnrc manual.