### PR TITLE
Fix #100: Fix egs_gui not working with compound and dc file

### DIFF
--- a/HEN_HOUSE/gui/egs_gui/pegs_page.h
+++ b/HEN_HOUSE/gui/egs_gui/pegs_page.h
@@ -119,6 +119,7 @@ public slots:
 
 protected:
     void init();
+    void readDensityFile(QString dfile);
 private:
     bool output_is_active;
     PEGS_RunOutput *run_output;


### PR DESCRIPTION
Fixed a bug in which, by unchecking and then re-checking the
ICRU density correction box, the user was able to attempt
to run PEGS4 with a density correction but with medium type
specified as "Compound" (and potentially with a different
composition than that specified in the density correction
file).  PEGS4 failed, but this led to frustration.