### PR TITLE
Fix #244: a compile error when using rad_compton1 due to medium

### DIFF
--- a/HEN_HOUSE/src/rad_compton1.mortran
+++ b/HEN_HOUSE/src/rad_compton1.mortran
@@ -163,7 +163,7 @@ character     radc_file*256;
 integer*4     lnblnk1,egs_get_unit;
 $INTEGER      radc_unit, want_radc_unit;
 $INTEGER      nskip,i,j,ne,nu,ny1,ny2,nw,jh,jl;
-$INTEGER      medium,lgle,icheck;
+$INTEGER      lgle,icheck;
 real*8        aux1,gmfp,gmfp_old,gbr1,gbr1_old,gbr2,gbr2_old,gle,frad,
               acheck,acheck1,sum,aux;
 $INTEGER      nx,nbox,ixtot,ibtot;


### PR DESCRIPTION
The recent rest mass changes added the `medium` variable to `COMIN/USEFUL`. This meant that local definitions of `medium` had to be removed, but `rad_compton1.mortran` got missed in the process. This bug fix simply removes the extra declaration of `medium` from a function, fixing a compile error when you added radiative compton corrections to the Makefile.

This should get cherry-picked into master asap.