### PR TITLE
Fix #244: compile error in rad_compton1.mortran

### DIFF
--- a/HEN_HOUSE/src/rad_compton1.mortran
+++ b/HEN_HOUSE/src/rad_compton1.mortran
@@ -163,7 +163,7 @@ character     radc_file*256;
 integer*4     lnblnk1,egs_get_unit;
 $INTEGER      radc_unit, want_radc_unit;
 $INTEGER      nskip,i,j,ne,nu,ny1,ny2,nw,jh,jl;
-$INTEGER      medium,lgle,icheck;
+$INTEGER      lgle,icheck;
 real*8        aux1,gmfp,gmfp_old,gbr1,gbr1_old,gbr2,gbr2_old,gle,frad,
               acheck,acheck1,sum,aux;
 $INTEGER      nx,nbox,ixtot,ibtot;


### PR DESCRIPTION
Remove the extraneous declaration of variable "medium" in the radc_init
subroutine. The recent rest mass changes added the medium variable to
COMIN/USEFUL (commit 3bff6ed), hence local definitions of medium had to
be removed. But rad_compton1.mortran got missed in this update.