### PR TITLE
Fix LATCH/ZLAST with DBS when z(np)> ssd

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -6111,7 +6111,7 @@ IF(IBRSPL=1 & IRRLTT=0)["uniform bremsstrahlung splitting without Russ. Roul."
 
 ELSEIF(IBRSPL=2) ["directional bremsstrahlung splitting"
 
-   IF( iarg > 5 & z(np) > ssd ) [ nbr_split = 1; return; ]
+   IF( iarg > 5 & z(np) > ssd ) [ nbr_split = 1; GOTO :ZLAST_AND_LATCH:; ]
 
 
    IF(i_dsb=1 & z(np)<Z_min_CM(splitcm_dsb) & dsb_nbin>1)[do_dsb=1;]
@@ -6450,7 +6450,7 @@ IF(IARG=6) NUM_BREM=NUM_BREM+nbr_split;
 
 "macro below sets prob_RR, the probability that a charged particle will"
 "survive Russian Roulette, when seletive bremsstrahlung is on"
-
+:ZLAST_AND_LATCH:;
 "******************************************************************************
 "
 "         LAST INTERACTION SITE SCORING (FOR PHOTONS AND ELECTRONS) ""toc:


### PR DESCRIPTION
Fixed a bug in DBS which resulted in no further LATCH
bits being set once z(np) was > the ssd of the splitting
field.  The bug also meant that ZLAST for these particles
was not set.  The fix involved using a GOTO statement
to jump to the BEAMnrc default LATCH (and ZLAST) setting routines
in AUSGAB instead of immediately exiting when z(np) > ssd.

This is probably a rare bug, given that, in general, users
set ssd = the bottom of the accelerator.