### PR TITLE
Implement a simple Travis-CI continuous integration script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: bash
+
+addons:
+  apt:
+    packages:
+      - gfortran
+      - gcc
+      - g++
+      - expect
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y grace
+  - sudo apt-get install -y libmotif-dev
+
+install:
+  - HEN_HOUSE/scripts/configure.expect linux.conf | tee configure.log
+
+script:
+  - pwd
+  - for f in HEN_HOUSE/log/*.log configure.log; do echo $f; cat $f; done
+  - (! grep -i fail configure.log)
+  - export EGS_HOME=/home/travis/build/nrc-cnrc/EGSnrc/egs_home
+  - export EGS_CONFIG=/home/travis/build/nrc-cnrc/EGSnrc/HEN_HOUSE/specs/linux.conf
+  - source /home/travis/build/nrc-cnrc/EGSnrc/HEN_HOUSE/scripts/egsnrc_bashrc_additions
+  - date

--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -142,7 +142,7 @@ for prog in gmake make make.exe gmake.exe mingw32-make.exe; do
         IFS=$save_IFS
         $as_executable "$make_dir/$prog" || continue
         have_make=yes
-        make_prog=$prog
+        make_prog="$prog -j12"
         abs_make="$make_dir/$prog"
         break
     done

--- a/HEN_HOUSE/scripts/configure.expect
+++ b/HEN_HOUSE/scripts/configure.expect
@@ -1,0 +1,50 @@
+#!/usr/bin/expect -f
+
+set timeout -1
+
+# configuration filename
+set confname "expect.conf"
+if {$argc > 0} {
+    set confname [lindex $argv 0]
+}
+
+# clear environment variables
+set env(HEN_HOUSE)  ""
+set env(EGS_CONFIG) ""
+set env(EGS_HOME)   ""
+
+# spawn EGSnrc configuration script
+spawn HEN_HOUSE/scripts/configure
+
+# Information
+expect "Press enter to continue."                       { send "\n" }
+
+# Fortran compiler
+expect "Input fortran compiler:"                        { send "\n" }
+expect "Input standard compilation flags:"              { send "\n" }
+expect "Input optimization flags:"                      { send "\n" }
+expect "Input flags for debugging:"                     { send "\n" }
+expect "Input libraries that your compiler may need:"   { send "\n" }
+
+# C compiler
+expect "Input the one you would like to use:"           { send "\n" }
+expect "Input C compiler flags to use:"                 { send "\n" }
+
+# Configuration
+expect "Input path to EGSnrc HEN_HOUSE directory:"      { send "\n" }
+expect "Choose a configuration file name:"              { send "$confname\n" }
+set timeout 1
+expect "Do you want to overwrite ?"                     { puts "no\n"; exit }
+set timeout -1
+
+# C++ compiler
+expect "Input C++ compiler:"                            { send "\n" }
+expect "Input option to change, or enter to proceed:"   { send "\n" }
+
+# Finalize for user
+expect "Do you want to finalize"                        { send "yes\n" }
+expect "Press enter to continue."                       { send "\n" }
+
+expect "Choose a directory for your user codes:"        { send "\n" }
+expect "Choose 1 (all), 2 (some) or 3 (none):"          { send "1\n" }
+expect "EOF"

--- a/HEN_HOUSE/scripts/egsnrc_bashrc_additions
+++ b/HEN_HOUSE/scripts/egsnrc_bashrc_additions
@@ -111,10 +111,14 @@ export HEN_HOUSE PATH
 
 # Now check for local system wide sh additions
 #
-test -f $HEN_HOUSE/scripts/local_bashrc_additions && \. $HEN_HOUSE/scripts/local_bashrc_additions
+if test -f $HEN_HOUSE/scripts/local_bashrc_additions; then
+    source $HEN_HOUSE/scripts/local_bashrc_additions
+fi
 
 # Every individual user may customize their settings by creating a
 # .egsnrc_bashrc_additions file in their HOME directory.
 # Source this file if available
 #
-test -f $HOME/.egsnrc_bashrc_additions && \. $HOME/.egsnrc_bashrc_additions
+if test -f $HOME/.egsnrc_bashrc_additions; then
+    source $HOME/.egsnrc_bashrc_additions
+fi


### PR DESCRIPTION
Implement a simple Travis-CI continuous integration script which automatically build and configures EGSnrc on each pull request. In time we can add more sophisticated tests, but as a starting point this will at least catch basic configuration failures. @mainegra I added the make -j12 flag as a default in the configuration script; if you want to add it in the guis as well, add a commit to this branch and I will squash it with mine.