### PR TITLE
Fix #182: Increase beamnrc sync maxfield and add check

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_cm.mortran
@@ -2421,6 +2421,14 @@ IF(MODE_$SYNCHDMLC=1|MODE_$SYNCHDMLC=2)["dynamic or step-and-shoot leaf inputs"
   read(mlc_unit,'(A80)') MLC_TITLE;
   read(mlc_unit,'(I10)') NFIELDS_$SYNCHDMLC;
   OUTPUT NFIELDS_$SYNCHDMLC; (I10);
+
+  IF(NFIELDS_$SYNCHDMLC>$MAXFIELD_$SYNCHDMLC) [
+   OUTPUT $MAXFIELD_$SYNCHDMLC;
+        (/' The number of fields is greater than $MAXFIELD_$SYNCHDMLC: ',I10, /
+        ' Increase $MAXFIELD_$SYNCHDMLC in SYNCHDMLC_macros.mortran'/);
+   STOP;
+  ];
+
   DO I=1,NFIELDS_$SYNCHDMLC[
   "read in non-default leaf positions for each field"
      read(mlc_unit,'(F15.0)')INDEX_$SYNCHDMLC(I);

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_macros.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_macros.mortran
@@ -90,7 +90,7 @@ REPLACE {$MAXIMUM_N_$SYNCHDMLC} WITH {3};
 REPLACE {$MAXLEAF} WITH {160}
 
 " The max no. of different fields--dynamic and step-and-shoot only"
-REPLACE {$MAXFIELD_$SYNCHDMLC} WITH {256}
+REPLACE {$MAXFIELD_$SYNCHDMLC} WITH {1024}
 
 "used for arrays that store data for each leaf for each field"
 REPLACE {$MAXFIELDLEAF} WITH {{COMPUTE $MAXLEAF*$MAXFIELD_$SYNCHDMLC}}

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCJAWS_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCJAWS_cm.mortran
@@ -1053,6 +1053,14 @@ IF(MODE_$SYNCJAWS=1 | MODE_$SYNCJAWS=2)[
   open(jaws_unit,file=jaws_file,status='old',err=:no-jaws-data-file:);
   read(jaws_unit,'(A80)') JAWS_TITLE;
   read(jaws_unit,'(I10)') NFIELDS_$SYNCJAWS;
+
+  IF(NFIELDS_$SYNCJAWS>$MAXFIELD_$SYNCJAWS) [
+   OUTPUT $MAXFIELD_$SYNCJAWS;
+        (/' The number of fields is greater than $MAXFIELD_$SYNCJAWS: ',I10, /
+        ' Increase $MAXFIELD_$SYNCJAWS in SYNCJAWS_macros.mortran'/);
+   STOP;
+  ];
+
   DO I=1,NFIELDS_$SYNCJAWS[
   "read in jaw positions for each field"
      read(jaws_unit,'(F15.0)')INDEX_$SYNCJAWS(I);

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCJAWS_macros.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCJAWS_macros.mortran
@@ -69,7 +69,7 @@
 "-------------------------------------------------------------------------------
 REPLACE {$MAX_N_$SYNCJAWS} WITH {12}
 
-REPLACE {$MAXFIELD_$SYNCJAWS} WITH {100}
+REPLACE {$MAXFIELD_$SYNCJAWS} WITH {1024}
 
 REPLACE {$MAXFS_$SYNCJAWS} WITH {{COMPUTE $MAX_N_$SYNCJAWS*$MAXFIELD_$SYNCJAWS}}
 

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCMLCE_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCMLCE_cm.mortran
@@ -1343,6 +1343,14 @@ IF(MODE_$SYNCMLCE=1|MODE_$SYNCMLCE=2)["dynamic or step-and-shoot leaf inputs"
   read(mlc_unit,'(A80)') MLC_TITLE;
   read(mlc_unit,'(I10)') NFIELDS_$SYNCMLCE;
   OUTPUT NFIELDS_$SYNCMLCE; (I10);
+
+  IF(NFIELDS_$SYNCMLCE>$MAXFIELD_$SYNCMLCE) [
+   OUTPUT $MAXFIELD_$SYNCMLCE;
+        (/' The number of fields is greater than $MAXFIELD_$SYNCMLCE: ',I10, /
+        ' Increase $MAXFIELD_$SYNCMLCE in SYNCMLCE_macros.mortran'/);
+   STOP;
+  ];
+
   DO I=1,NFIELDS_$SYNCMLCE[
   "read in non-default leaf positions for each field"
      read(mlc_unit,'(F15.0)')INDEX_$SYNCMLCE(I);

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCMLCE_macros.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCMLCE_macros.mortran
@@ -79,7 +79,7 @@ REPLACE {$MAXIMUM_N_$SYNCMLCE} WITH {3}
 REPLACE {$MAXLEAF} WITH {170}
 
 " The max no. of different fields--dynamic and step-and-shoot only"
-REPLACE {$MAXFIELD_$SYNCMLCE} WITH {256}
+REPLACE {$MAXFIELD_$SYNCMLCE} WITH {1024}
 
 "used for arrays that store data for each leaf for each field"
 REPLACE {$MAXFIELDLEAF} WITH {{COMPUTE $MAXLEAF*$MAXFIELD_$SYNCMLCE}}

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCVMLC_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCVMLC_cm.mortran
@@ -1924,6 +1924,14 @@ IF(MODE_$SYNCVMLC=1|MODE_$SYNCVMLC=2)["dynamic or step-and-shoot leaf inputs"
   read(mlc_unit,'(A80)') MLC_TITLE;
   read(mlc_unit,'(I10)') NFIELDS_$SYNCVMLC;
   OUTPUT NFIELDS_$SYNCVMLC; (I10);
+
+  IF(NFIELDS_$SYNCVMLC>$MAXFIELD_$SYNCVMLC) [
+   OUTPUT $MAXFIELD_$SYNCVMLC;
+        (/' The number of fields is greater than $MAXFIELD_$SYNCVMLC: ',I10, /
+        ' Increase $MAXFIELD_$SYNCVMLC in SYNCVMLC_macros.mortran'/);
+   STOP;
+  ];
+
   DO I=1,NFIELDS_$SYNCVMLC[
   "read in non-default leaf positions for each field"
      read(mlc_unit,'(F15.0)')INDEX_$SYNCVMLC(I);

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCVMLC_macros.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCVMLC_macros.mortran
@@ -78,7 +78,7 @@ REPLACE {$MAXIMUM_N_$SYNCVMLC} WITH {3};
 REPLACE {$MAXLEAF} WITH {160}
 
 " The max no. of different fields--dynamic and step-and-shoot only"
-REPLACE {$MAXFIELD_$SYNCVMLC} WITH {256}
+REPLACE {$MAXFIELD_$SYNCVMLC} WITH {1024}
 
 "used for arrays that store data for each leaf for each field"
 REPLACE {$MAXFIELDLEAF} WITH {{COMPUTE $MAXLEAF*$MAXFIELD_$SYNCVMLC}}


### PR DESCRIPTION
I am creating this new pull request for increase-beamnrc-sync-maxfield because I unintentionally merge the pull request earlier today, before @mainegra had a chance to review.

Here is the original pull request message:

Increases the MAXFIELD parameter for the BEAMnrc SYNC component modules to 1024 instead of 256. This will reduce the number of users than need to increase the parameter manually. Also adds a check to make sure that the number of fields read in from a file is less than the maximum.
