### PR TITLE
Fix use of LD_LIBRARY_PATH for egs_view static

### DIFF
--- a/HEN_HOUSE/scripts/egsnrc_bashrc_additions
+++ b/HEN_HOUSE/scripts/egsnrc_bashrc_additions
@@ -48,14 +48,6 @@ export OMEGA_HOME=${HEN_HOUSE}omega
 #
 PATH="${HEN_HOUSE}bin/$my_machine:$PATH"
 
-# Set dynamic library path
-# Only needed by egs_view pre-compiled for release without
-# hard-coded run-time search path (no -rpath)
-#
-if test -d $HEN_HOUSE/egs++/dso/linux-static; then
-   export LD_LIBRARY_PATH="${HEN_HOUSE}egs++/dso/linux-static:$LD_LIBRARY_PATH"
-fi
-
 # Now check for EGS_HOME.
 # If EGS_HOME is not empty and exists, check for $EGS_HOME/bin and
 # $EGS_HOME/bin/$my_machine and create them if they don't exist.
@@ -92,7 +84,13 @@ alias dosxyznrc_gui='$OMEGA_HOME/progs/gui/dosxyznrc/dosxyznrc_gui.tcl'
 alias dosxyz_gui='$OMEGA_HOME/progs/gui/dosxyznrc/dosxyznrc_gui.tcl'
 alias beamdp_gui='$OMEGA_HOME/progs/gui/beamdp/beamdp_gui.tcl'
 alias pprocess='$HEN_HOUSE/scripts/pprocess'
-
+#
+# Alias needed by egs_view pre-compiled for release without
+# hard-coded run-time search path (no -rpath)
+#
+if test -d $HEN_HOUSE/egs++/dso/linux-static; then
+   alias egs_view='(LD_LIBRARY_PATH=${HEN_HOUSE}egs++/dso/linux-static/ ${HEN_HOUSE}pieces/linux/egs_view_64)'
+fi
 # OS X specific settings
 canonical_system=$( cat $EGS_CONFIG | grep "canonical_system =" | sed 's/canonical_system = //' )
 is_darwin=$(echo $canonical_system | grep -i darwin)


### PR DESCRIPTION
Define an alias in `$HEN_HOUSE/scripts/egsnrc_bashrc_additions` to run `egs_view` that sets `LD_LIBRARY_PATH` temporarily in a subshell. Fixes issue #254 .