### PR TITLE
Fix #260: rest mass not initialized in C interface

### DIFF
--- a/HEN_HOUSE/interface/egs_c_interface1.macros
+++ b/HEN_HOUSE/interface/egs_c_interface1.macros
@@ -202,6 +202,7 @@ REPLACE {;COMIN/USEFUL/;} WITH {
   real*8         pzero, prm, prmt2;
   $REAL          rm, rhor, rhor_new;
   $INTEGER       medium, medium_new, medold;
+  data rm,prm,prmt2,pzero/0.5109989461,0.5109989461,1.0219978922,0.D0/;
 };
 
 " And now the cross section options common                             "

--- a/HEN_HOUSE/interface/egs_c_interface2.macros
+++ b/HEN_HOUSE/interface/egs_c_interface2.macros
@@ -232,6 +232,7 @@ REPLACE {;COMIN/USEFUL/;} WITH {
   real*8         pzero, prm, prmt2;
   $REAL          rm, rhor, rhor_new;
   $INTEGER       medium, medium_new, medold;
+  data rm,prm,prmt2,pzero/0.5109989461,0.5109989461,1.0219978922,0.D0/;
 };
 
 " And now the cross section options common                             "


### PR DESCRIPTION
Fix the rest mass initialization for EGSnrc applications that depend on
the C interface. The bug fix in the parent commit moved the declaration
of the rest mass inside the COMIN/USEFUL/ macro. However this in turn
breaks C and C++ EGSnrc applications because the C interface relies on
its own declaration of the COMIN/USEFUL/ macro, which also has to be
updated with the rest mass data statement.