### PR TITLE
Fix markdown links in top-level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,26 +26,25 @@ before downloading the software. In practice, this licence imposes no
 restriction on using EGSnrc. However, if you want to further convey
 verbatim or modified versions of the code, or any work based on any
 EGSnrc component (including any such work operated remotely over a
-network), you must do so under the same licence terms. Please [contact NRC]
-(http://www.nrc-cnrc.gc.ca/eng/solutions/advisory/egsnrc_index.html)
+network), you must do so under the same licence terms. Please
+[contact NRC](http://www.nrc-cnrc.gc.ca/eng/solutions/advisory/egsnrc_index.html)
 if you wish to licence EGSnrc under different terms.
 
 
 ## Installation
 
 EGSnrc can be installed on computers running Linux, macOS or Windows. Please
-read the [installation instructions]
-(https://github.com/nrc-cnrc/EGSnrc/wiki/Installation-overview) for details on
-how to download and properly configure EGSnrc on your operating system.
+read the [installation instructions](https://github.com/nrc-cnrc/EGSnrc/wiki/Installation-overview)
+for details on how to download and properly configure EGSnrc on your operating system.
 
 
 ## Issues
 
-For technical support and questions, consider the [EGSnrc Google+ community]
-(https://plus.google.com/communities/106437507294474212197), or [contact NRC]
-(http://www.nrc-cnrc.gc.ca/eng/solutions/advisory/egsnrc_index.html). To report
-genuine bugs, defects or even small typos in the EGSnrc project please [submit
-an issue](https://github.com/nrc-cnrc/EGSnrc/issues). The issue tracker lets you
+For technical support and questions, consider the
+[EGSnrc Google+ community](https://plus.google.com/communities/106437507294474212197), or
+[contact NRC](http://www.nrc-cnrc.gc.ca/eng/solutions/advisory/egsnrc_index.html). To report
+genuine bugs, defects or even small typos in the EGSnrc project please
+[submit an issue](https://github.com/nrc-cnrc/EGSnrc/issues). The issue tracker lets you
 browse and search all documented issues, comment on open issues, and track their
 progress. Note that the issue tracker is **not meant for technical support.**
 
@@ -54,10 +53,10 @@ progress. Note that the issue tracker is **not meant for technical support.**
 
 You can contribute to the EGSnrc project by implementing new features, creating
 new data sets, correcting errors, or improving documentation. For small
-corrections and improvements, feel free to [submit an
-issue](https://github.com/nrc-cnrc/EGSnrc/issues). For more extensive
+corrections and improvements, feel free to
+[submit an issue](https://github.com/nrc-cnrc/EGSnrc/issues). For more extensive
 contributions, familiarize yourself with git and github, work on your own EGSnrc
-project fork and open a [pull
-request](https://github.com/nrc-cnrc/EGSnrc/issues). Note that significant
+project fork and open a
+[pull request](https://github.com/nrc-cnrc/EGSnrc/issues). Note that significant
 contributions will require a transfer of copyright to the National Research
 Council of Canada before they can be merged into the EGSnrc distribution.


### PR DESCRIPTION
The lines in the top-level `README.md` file were wrapped, which caused newlines to be inserted in the mardown links `[...]` or between the links and their href `(...)`. Consequently the links were not parsed properly but displayed as text. This will have to be cherry-picked to master as well. Cherry picked from commit 1b7bea330d56672fca6ddb647bdf8e9075fc1552 to fix the default github repository top page.