### PR TITLE
Fix compilation warnings in egs++

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -95,9 +95,9 @@
 
 EGS_DoseScoring::EGS_DoseScoring(const string &Name,
                                  EGS_ObjectFactory *f) :
-    EGS_AusgabObject(Name,f), nreg(0), m_lastCase(-1), nmedia(0),
-    dose(0), doseM(0), max_dreg(-1), max_medl(0),
-    score_medium_dose(false), score_region_dose(false), norm_u(1.0) {
+    EGS_AusgabObject(Name,f), dose(0), doseM(0),
+    norm_u(1.0), nreg(0), nmedia(0), max_dreg(-1), max_medl(0),
+    m_lastCase(-1),score_medium_dose(false), score_region_dose(false) {
     otype = "EGS_DoseScoring";
 }
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -208,8 +208,8 @@ void EGS_Application::storeGeometryStep(int ireg, int inew,
 }
 
 EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
-    source(0), rndm(0), run(0), last_case(0), current_case(0),
-    data_out(0), data_in(0), simple_run(false), a_objects(0),
+    source(0), rndm(0), run(0), simple_run(false), current_case(0),
+    last_case(0), data_out(0), data_in(0), a_objects(0),
     ghistory(new EGS_GeometryHistory) {
 
     app_index = n_apps++;

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -27,6 +27,7 @@
 #                   Ernesto Mainegra-Hing
 #                   Blake Walters
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Marc Chamberland
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -386,8 +386,8 @@ extern "C" void __list_geometries() {
 */
 
 EGS_BaseGeometry::EGS_BaseGeometry(const string &Name) : nreg(0), name(Name),
-    med(-1), region_media(0), nref(0), debug(false), is_convex(true),
-    boundaryTolerance(epsilon), has_rho_scaling(false), rhor(0), bproperty(0), bp_array(0) {
+    region_media(0), med(-1), has_rho_scaling(false), rhor(0), nref(0), debug(false),
+    is_convex(true), bproperty(0), bp_array(0), boundaryTolerance(epsilon){
     if (!egs_geometries.size()) {
         egs_geometries.addList(new EGS_GeometryPrivate);
     }

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -543,10 +543,10 @@ void EGS_BaseGeometry::setName(EGS_Input *i) {
         EGS_Float rot_angle, rot_angle_o;
         int err1 = inp->getInput("type",typ);
         int err2 = inp->getInput("number of copies",ncopy);
-        int err3 = inp->getInput("translation delta",trans);
+        inp->getInput("translation delta",trans);
         int err3a = inp->getInput("first translation",trans_o);
         int err4 = inp->getInput("rotation axis",rot_axis);
-        int err5 = inp->getInput("rotation delta",rot_angle);
+        inp->getInput("rotation delta",rot_angle);
         int err5a = inp->getInput("first rotation",rot_angle_o);
         bool do_it = true;
         int ttype;

--- a/HEN_HOUSE/egs++/egs_geometry_tester.cpp
+++ b/HEN_HOUSE/egs++/egs_geometry_tester.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_geometry_tester.cpp
+++ b/HEN_HOUSE/egs++/egs_geometry_tester.cpp
@@ -46,7 +46,7 @@
 #include <string>
 using namespace std;
 
-static int __geometry_error = 0;
+//static int __geometry_error = 0;
 
 #ifndef SKIP_DOXYGEN
 /*! \brief This class implements the functionality of the EGS_GeometryTester

--- a/HEN_HOUSE/egs++/egs_geometry_tester.cpp
+++ b/HEN_HOUSE/egs++/egs_geometry_tester.cpp
@@ -544,7 +544,7 @@ private:
 class EGS_LOCAL EGS_SphereTester : public EGS_GeometryTester {
 public:
     EGS_SphereTester(const EGS_Vector &Xo, EGS_Input *i) :
-        xo(Xo), EGS_GeometryTester(i) {};
+        EGS_GeometryTester(i), xo(Xo) {};
     ~EGS_SphereTester() {};
     void printPosition(const EGS_Vector &x) {
         EGS_Vector xp(x-xo);
@@ -558,7 +558,7 @@ private:
 class EGS_LOCAL EGS_TransformedTester : public EGS_GeometryTester {
 public:
     EGS_TransformedTester(const EGS_AffineTransform &t, EGS_Input *i) :
-        T(t), EGS_GeometryTester(i) {};
+        EGS_GeometryTester(i), T(t) {};
     ~EGS_TransformedTester() {};
     void printPosition(const EGS_Vector &x) {
         EGS_Vector xp(x*T);

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -902,7 +902,6 @@ int EGS_InputPrivate::addContent(istream &in) {
     removeComment("//","\n",input,true);
     removeComment("/*","*/",input,false);
     removeEmptyLines(input);
-    int res = 0;
     vector<string> start_keys, stop_keys;
     int p = 0;
     int ep = input.size();

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -74,7 +74,7 @@ public:
     EGS_InputPrivate(const string &Key, const string &Val = "") : key(Key),
         value(Val), children(), nref(0) { };
     EGS_InputPrivate(const EGS_InputPrivate &p, bool deep=false) :
-        key(p.key), value(p.value), nref(0), children() {
+        key(p.key), value(p.value), children(), nref(0) {
         for (unsigned int j=0; j<p.children.size(); j++) {
             if (deep) {
                 children.push_back(new EGS_InputPrivate(*p.children[j],deep));
@@ -668,7 +668,7 @@ public:
     string vname,//!< Loop variable name.
            vr;   //!< Loop variable replacement string.
     char buf[128];
-    EGS_InputLoopVariable(const string &var) : vname(var), is_list(false) {
+    EGS_InputLoopVariable(const string &var) : is_list(false), vname(var) {
         vr = "$(";
         vr += vname;
         vr += ")";

--- a/HEN_HOUSE/egs++/egs_object_factory.cpp
+++ b/HEN_HOUSE/egs++/egs_object_factory.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Ernesto Mainegra-Hing
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_object_factory.cpp
+++ b/HEN_HOUSE/egs++/egs_object_factory.cpp
@@ -44,7 +44,7 @@
 static unsigned int object_count = 0;
 
 EGS_Object::EGS_Object(const string &Name, EGS_ObjectFactory *f) :
-    nref(0), otype("EGS_Object"), name(Name), factory(f) {
+    name(Name), otype("EGS_Object"), nref(0), factory(f) {
     object_count++;
     if (!name.size()) {
         name = getUniqueName(this);
@@ -53,7 +53,7 @@ EGS_Object::EGS_Object(const string &Name, EGS_ObjectFactory *f) :
 }
 
 EGS_Object::EGS_Object(EGS_Input *input, EGS_ObjectFactory *f) :
-    nref(0), otype("EGS_Object"), name(""), factory(f) {
+    name(""), otype("EGS_Object"), nref(0), factory(f) {
     object_count++;
     setName(input);
     //if( factory ) factory->addObject(this);

--- a/HEN_HOUSE/egs++/egs_rndm.cpp
+++ b/HEN_HOUSE/egs++/egs_rndm.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_rndm.cpp
+++ b/HEN_HOUSE/egs++/egs_rndm.cpp
@@ -142,7 +142,7 @@ public:
      * initial seeds.
      */
     EGS_Ranmar(int ixx=1802, int jxx=9373, int n=128) :
-        EGS_RandomGenerator(n), copy(0), high_res(false) {
+      EGS_RandomGenerator(n), high_res(false), copy(0) {
         setState(ixx,jxx);
     };
 

--- a/HEN_HOUSE/egs++/egs_run_control.cpp
+++ b/HEN_HOUSE/egs++/egs_run_control.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/egs_run_control.cpp
+++ b/HEN_HOUSE/egs++/egs_run_control.cpp
@@ -48,9 +48,9 @@ using namespace std;
 vector<EGS_Library *> rc_libs;
 static int n_run_controls = 0;
 
-EGS_RunControl::EGS_RunControl(EGS_Application *a) : app(a), input(0),
-    ncase(0), ndone(0), nbatch(10), maxt(-1), accu(-1), restart(0), nchunk(1),
-    cpu_time(0), previous_cpu_time(0), geomErrorCount(0), geomErrorMax(0) {
+EGS_RunControl::EGS_RunControl(EGS_Application *a) : geomErrorCount(0),
+    geomErrorMax(0), app(a), input(0), ncase(0), ndone(0), maxt(-1), accu(-1),
+    nbatch(10), restart(0), nchunk(1), cpu_time(0), previous_cpu_time(0) {
     n_run_controls++;
     if (!app) egsFatal("EGS_RunControl::EGS_RunControl: it is not allowed\n"
                            " to construct a run control object on a NULL application\n");
@@ -416,11 +416,10 @@ public:
 #endif
 
 EGS_JCFControl::EGS_JCFControl(EGS_Application *a, int Nbuf) :
-    EGS_RunControl(a), p(new EGS_FileLocking),
-    npar(app->getNparallel()), ipar(app->getIparallel()),
-    ifirst(app->getFirstParallel()),
-    first_time(true), nbuf(Nbuf), njob(0), tsum(0), tsum2(0), tcount(0),
-    norm(1), last_sum(0), last_sum2(0), last_count(0), removed_jcf(false) {
+    EGS_RunControl(a), tsum(0), tsum2(0), tcount(0), norm(1), last_sum(0),
+    last_sum2(0), last_count(0), njob(0), npar(app->getNparallel()),
+    ipar(app->getIparallel()), ifirst(app->getFirstParallel()),
+    first_time(true), removed_jcf(false), nbuf(Nbuf), p(new EGS_FileLocking) {
     if (input) {
         int err = input->getInput("nchunk",nchunk);
         if (err) {

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
@@ -206,7 +206,6 @@ public:
           up=a*u,
           rcp=a*rc;
           */
-        EGS_Float urc=u*rc;
         EGS_Float up=a*u;
         EGS_Float rcp=a*rc;
         EGS_Vector rcp_vec=a*rcp;

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
@@ -82,7 +82,7 @@ public:
 
     EGS_ConezT(int nc, const EGS_Float *angle,
                const EGS_Vector &position, const string &Name,
-               const T &A) : EGS_BaseGeometry(Name), a(A), xo(position) {
+               const T &A) : EGS_BaseGeometry(Name), xo(position), a(A) {
         if (nc>0) {
             theta=new EGS_Float [nc];
             cos_t=new EGS_Float [nc];

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
@@ -172,7 +172,7 @@ public:
     */
     EGS_CylindersT(int nc, const EGS_Float *radius,
                    const EGS_Vector &position, const string &Name,
-                   const T &A) : EGS_BaseGeometry(Name), a(A), xo(position) {
+                   const T &A) : EGS_BaseGeometry(Name), xo(position), a(A) {
         if (nc>0) {
             R=new EGS_Float [nc];
             R2=new EGS_Float [nc];

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2006
 #
 #  Contributors:    Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.h
@@ -221,7 +221,7 @@ public:
                            const vector<EGS_Float> &y_rad,
                            const EGS_Vector &position, const string &Name,
                            const Tx &A_x, const Ty &A_y) : EGS_BaseGeometry(Name),
-        Ax(A_x), Ay(A_y), xo(position), nwarn(0) {
+        xo(position), Ax(A_x), Ay(A_y), nwarn(0) {
         int nc = x_rad.size();
         if (nc>0) {
             ax = new EGS_Float [nc];

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -57,7 +57,6 @@ void EGS_TransformedGeometry::setRelativeRho(EGS_Input *) {
 extern "C" {
 
     EGS_GTRANSFORMED_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
-        int error = 0;
         EGS_BaseGeometry *g = 0;
         EGS_Input *ij = input->takeInputItem("geometry",false);
         if (ij) {

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -653,7 +653,7 @@ EGS_XYZGeometry *EGS_XYZGeometry::constructGeometry(const char *dens_file,
             return 0;
         }
         int nr = Nx*Ny*Nz;
-        int med;
+        //int med;
         //for(j=0; j<nr; ++j) data >> med;
         data.getline(buf,1023);
         for (int iz=0; iz<Nz; ++iz) {

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -24,6 +24,7 @@
 #  Author:          Frederic Tessier, 2008
 #
 #  Contributors:    Iwan Kawrakow
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -188,8 +188,8 @@ string EGS_Octree::type("EGS_Octree");
 
 static char EGS_OCTREE_LOCAL eoctree_message1[]  = "createGeometry(octree): %s\n";
 static char EGS_OCTREE_LOCAL eoctree_message2[]  = "null input?";
-static char EGS_OCTREE_LOCAL eoctree_message3[]  = "wrong/missing 'octree size' input?";
-static char EGS_OCTREE_LOCAL eoctree_message4[]  = "expecting 1 or 3 float inputs for 'octree size'";
+//static char EGS_OCTREE_LOCAL eoctree_message3[]  = "wrong/missing 'octree size' input?";
+//static char EGS_OCTREE_LOCAL eoctree_message4[]  = "expecting 1 or 3 float inputs for 'octree size'";
 static char EGS_OCTREE_LOCAL eoctree_message5[]  = "wrong/missing 'min' or input?";
 static char EGS_OCTREE_LOCAL eoctree_message6[]  = "expecting 3 float inputs for 'box min' input";
 static char EGS_OCTREE_LOCAL eoctree_message7[]  = "wrong/missing 'max' or input?";

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.h
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.h
@@ -24,6 +24,7 @@
 #  Author:          Frederic Tessier, 2008
 #
 #  Contributors:    Iwan Kawrakow
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.h
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.h
@@ -756,9 +756,6 @@ public:
                 int ix = node->ix << shift;
                 int iy = node->iy << shift;
                 int iz = node->iz << shift;
-                float xx = xmin+(ix+0.5)*dx;
-                float yy = ymin+(iy+0.5)*dy;
-                float zz = zmin+(iz+0.5)*dz;
                 int ireg = geom->isWhere(EGS_Vector(xmin+(ix+0.5)*dx, ymin+(iy+0.5)*dy, zmin+(iz+0.5)*dz));
                 if (ireg>=0) {
                     node->medium = geom->medium(ireg);
@@ -1160,7 +1157,7 @@ public:
     // howfarOut
     int howfarOut(const EGS_Vector &r, const EGS_Vector &u, EGS_Float &t, EGS_Vector *normal=0) {
 
-        int inew = -1, tmp;
+        int tmp;
         int ix, iy, iz;
         EGS_Float d, tlong = 2*t;
         EGS_Octree_node *node = NULL;

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.h
@@ -337,8 +337,8 @@ public:
         double xp = a*x, up = a*u;
         if (ireg >= 0) {
             int dir = 0;
-            bool warn=false;
-            EGS_Float dist;
+//             bool warn=false;
+//             EGS_Float dist;
             if (up > 0 && ireg < n_plane) {
                 d = (p[ireg+1]-xp)/up;
                 //if( xp <= p[ireg+1] ) d = (p[ireg+1]-xp)/up;

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.h
@@ -24,6 +24,7 @@
 #  Author:          Manuel Stoeckl, 2016
 #
 #  Contributors:    Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.h
@@ -199,7 +199,7 @@ public:
                             const vector<EGS_Float> &rad,
                             const EGS_Vector &position, const string &Name,
                             const Tx &A_x, const Ty &A_y) : EGS_BaseGeometry(Name),
-        Ax(A_x), Ay(A_y), xo(position) {
+        xo(position), Ax(A_x), Ay(A_y) {
         int nc = rad.size();
         if (nc>0) {
             ax = new EGS_Float [nc];

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -117,7 +117,6 @@ EGS_SmartEnvelope::EGS_SmartEnvelope(EGS_BaseGeometry *G,
     for (j=0; j<fgeoms.size(); j++) {
         itype[j] = 0;
     }
-    int nlist = 0;
     int nreg_inscribed = 0;
     bool ok = true;
     for (j=0; j<fgeoms.size(); j++) {
@@ -224,14 +223,14 @@ static char EGS_SMART_ENVELOPE_LOCAL eeg_message5[] =
     "missing/incorrect 'base geometry' input";
 static char EGS_SMART_ENVELOPE_LOCAL eeg_message6[] =
     "createGeometry(smart envelope): no geometry with name %s defined\n";
-static char EGS_SMART_ENVELOPE_LOCAL eeg_message7[] =
-    "no inscirebed geometries defined?. I hope you know what you are doing";
-static char EGS_SMART_ENVELOPE_LOCAL eeg_message8[] =
-    "an error occured while constructing inscibed geometries";
+//static char EGS_SMART_ENVELOPE_LOCAL eeg_message7[] =
+    //"no inscirebed geometries defined?. I hope you know what you are doing";
+//static char EGS_SMART_ENVELOPE_LOCAL eeg_message8[] =
+    //"an error occured while constructing inscibed geometries";
 
 static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword1[] = "base geometry";
 static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword2[] = "geometry";
-static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword3[] = "inscribed geometries";
+//static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword3[] = "inscribed geometries";
 
 extern "C" {
 
@@ -323,7 +322,6 @@ extern "C" {
 
         // label defined in the inscribed geometries
         vector<int> gregs;
-        int shift=0;
         for (int i=0; i<n_in; i++) {
 
             // add regions from set geometries

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -193,7 +193,6 @@ extern "C" {
 
         // label defined in the sub-geometries
         vector<int> gregs;
-        int shift=0;
         for (int i=0; i<ng; i++) {
 
             // add regions from set geometries

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -430,8 +430,8 @@ bool   EGS_MicroMatrixCluster::bm_boxes_initialized = false;
 
 EGS_MicroMatrixCluster::EGS_MicroMatrixCluster(
     EGS_Float Dx, EGS_Float Dy, EGS_Float Dz, EGS_Float bsc_thickness,
-    int tb_med, int bm_med, const char *micro_file) : micros(0), vg(0),
-    med_tb(tb_med), med_bm(bm_med) {
+    int tb_med, int bm_med, const char *micro_file) : med_tb(tb_med), med_bm(bm_med),
+    micros(0), vg(0){
     //
     // *** open micro-matrix file
     //

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2008
 #
 #  Contributors:    Frederic Tessier
+#                   Hubert Ho
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.h
@@ -329,7 +329,6 @@ public:
         int ifirst = 0;
         EGS_Float t, ttot = 0;
         EGS_Vector x(X);
-        int imed;
         if (ireg < 0) {
             t = veryFar;
             ireg = howfar(ireg,x,u,t);
@@ -349,7 +348,7 @@ public:
         int iy = ir/nx;
         int ix = ir - iy*nx;
         EGS_Float uxi, uyi, uzi, nextx, nexty, nextz, sx, sy, sz;
-        int dirx, icx, diry, icy, dirz, icz;
+        int dirx, diry, dirz;
         if (u.x > 0)      {
             uxi = 1/u.x;
             dirx =  1;
@@ -484,7 +483,7 @@ public:
 
     int howfarIn(int ireg, const EGS_Vector &x, const EGS_Vector &u,
                  EGS_Float &t, EGS_Vector *normal=0) {
-        int ixs = ix, iys = iy, izs = iz;
+        int ixs = ix, iys = iy;
         int inew = ireg;
         if (u.x > 0) {
             EGS_Float d = (dx*(ix+1)-x.x)/u.x;
@@ -588,7 +587,6 @@ public:
     int howfarOut(const EGS_Vector &x, const EGS_Vector &u,
                   EGS_Float &t, EGS_Vector *normal=0) {
         EGS_Float tlong = 2*t, d;
-        int inew = -1;
         if (x.x <= xmin && u.x > 0) {
             ix = 0;
             d = (xmin-x.x)/u.x;
@@ -1569,7 +1567,6 @@ public:
         int imic, ix, iy, iz;
         EGS_MicroMatrixCluster *micro = micros[mict];
         micro->getIndeces(iloc,imic,ix,iy,iz);
-        int ilocal = iloc - imic*micro->nreg;
         // now we have to figure out the macro voxel indeces
         // in principle one could simply use vg->isWhere(x), but
         // this is bound to get us in trouble with roundoff errors.

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
@@ -39,7 +39,7 @@
 
 EGS_CollimatedSource::EGS_CollimatedSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f),
-    source_shape(0), target_shape(0), dist(1), ctry(0) {
+    source_shape(0), target_shape(0), ctry(0), dist(1) {
     EGS_Input *ishape = input->takeInputItem("source shape");
     if (ishape) {
         source_shape = EGS_BaseShape::createShape(ishape);

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
@@ -169,7 +169,7 @@ public:
                          EGS_BaseShape *sshape, EGS_BaseShape *tshape,
                          const string &Name="", EGS_ObjectFactory *f=0) :
         EGS_BaseSimpleSource(Q,Spec,Name,f), source_shape(sshape),
-        target_shape(tshape), dist(1), ctry(0) {
+	target_shape(tshape), ctry(0), dist(1) {
         setUp();
     };
 

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -40,8 +40,8 @@
 
 EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f), shape(0), geom(0),
-    regions(0), nrs(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
-    gc(IncludeAll) {
+    regions(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
+    nrs(0), gc(IncludeAll) {
     vector<EGS_Float> pos;
     EGS_Input *ishape = input->takeInputItem("shape");
     if (ishape) {

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -227,9 +227,9 @@ public:
                         EGS_BaseGeometry *geometry,
                         const string &Name="", EGS_ObjectFactory *f=0) :
         EGS_BaseSimpleSource(Q,Spec,Name,f), shape(Shape),
-        min_theta(85.), max_theta(95.), min_phi(0), max_phi(2*M_PI),
-        buf_1(1), buf_2(-1),
-        geom(geometry), regions(0), nrs(0), gc(IncludeAll) {
+        geom(geometry), regions(0), min_theta(85.), max_theta(95.),
+         buf_1(1), buf_2(-1), min_phi(0), max_phi(2*M_PI),
+        nrs(0), gc(IncludeAll) {
         setUp();
     };
 

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -24,6 +24,7 @@
 #  Author:          Blake Walters, 2013
 #
 #  Contributors:    Reid Townson
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -135,7 +135,7 @@ void IAEA_PhspSource::openFile(const string &phsp_file) {
 
     //now get some info from the header
     EGS_I64 n, n_photon, pinc;
-    float emax, zposn;
+    float emax;
     int iaea_type=-1; //for getting no. of particles
     iaea_get_max_particles(&iaea_fileid,&iaea_type,&n);
     if (n<0) {


### PR DESCRIPTION
Resolve the `reorder` and `unused-variable` warnings given when compiling egs++. Unused variables that were used for debugging have been commented out rather than removed. The `cmp` linux command revealed no differences between object files compiled before and after these modifications.