### PR TITLE
Fix #186: Addendum--eliminate variable type mismatch

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -4396,7 +4396,7 @@ return; end;
 subroutine beam_shower(icase);
 /**************************************************************************/
 implicit none;
-$INTEGER icase;
+$LONG_INT icase;
 
 ;COMIN/SCORE,SOURCE,EPCONT,RANDOM,CMs,USER,IO_INFO,TIMING-INFO,USEFUL,EGS-IO,
 RWPHSP/;


### PR DESCRIPTION
In changing ICASE to $LONG_INT (integer*8) in BEAM main,
I neglected to change its local version in subroutine
beam_shower(icase) to $LONG_INT.  This caused compiler
warnings.