### PR TITLE
Fix a minor egs_cbct bug in an error message

### DIFF
--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -1464,12 +1464,13 @@ void EGS_CBCT::initOutput() {
             EGS_BaseFile *bs = new EGS_BaseFile(blank_scan.c_str());
             if (bs->fileExist()){
               if(bs->fileSize()!=Nx*Ny*sizeof(float)){
+                int fileSize = bs->fileSize();
                 delete bs;
                 egsFatal(
                 "\n\n***  Wrong blank scan file size = %d bytes\n"
                 "     It should be %d bytes"
                 "     This is a fatal error.\n\n",
-                bs->fileSize(),Nx*Ny*sizeof(float));
+                fileSize,Nx*Ny*sizeof(float));
               }
               else{
                 egsInformation(


### PR DESCRIPTION
One error message in egs_cbct failed to report the file size correctly because the `EGS_BaseFile` object `bs` was deleted before the `egsFatal` message. Now we save the file size in a variable before deleting the object.

This bug fix was suggested by Felix Thoma.