### PR TITLE
Add Fano source and magnetic field scaling

### DIFF
--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -707,6 +707,9 @@ int EGS_AdvancedApplication::helpInit(EGS_Input *transportp, bool do_hatch) {
         the_emf->BxIN=bfield_v[0];
         the_emf->ByIN=bfield_v[1];
         the_emf->BzIN=bfield_v[2];
+        the_emf->Bx=bfield_v[0];
+        the_emf->By=bfield_v[1];
+        the_emf->Bz=bfield_v[2];
     }
     if (efield.size()==3 || bfield.size()==3) {
         estepem.info(nc);
@@ -1028,6 +1031,16 @@ void EGS_AdvancedApplication::startNewParticle() {
         the_useful->rhor = 1;
         the_useful->rhor_new = 1;
     }
+    if (geometry->hasBScaling()) {
+        int ireg = the_stack->ir[the_stack->np-1] - 2;
+        EGS_Float bf = geometry->getBScaling(ireg);
+        the_emf->Bx = bf*the_emf->BxIN;
+        the_emf->By = bf*the_emf->ByIN;
+        the_emf->Bz = bf*the_emf->BzIN;
+        the_emf->Bx_new = the_emf->Bx;
+        the_emf->By_new = the_emf->By;
+        the_emf->Bz_new = the_emf->Bz;
+    }
 }
 
 void EGS_AdvancedApplication::enterNewRegion() {
@@ -1040,6 +1053,15 @@ void EGS_AdvancedApplication::enterNewRegion() {
     }
     else {
         the_useful->rhor_new = 1;
+    }
+    if (geometry->hasBScaling()) {
+        int ireg = the_epcont->irnew-2;
+        if (ireg >= 0) {
+            EGS_Float bf = geometry->getBScaling(ireg);
+            the_emf->Bx_new = bf*the_emf->BxIN;
+            the_emf->By_new = bf*the_emf->ByIN;
+            the_emf->Bz_new = bf*the_emf->BzIN;
+        }
     }
 }
 

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1041,6 +1041,14 @@ void EGS_AdvancedApplication::startNewParticle() {
         the_emf->By_new = the_emf->By;
         the_emf->Bz_new = the_emf->Bz;
     }
+    else {
+        the_emf->Bx = the_emf->BxIN;
+        the_emf->By = the_emf->ByIN;
+        the_emf->Bz = the_emf->BzIN;
+        the_emf->Bx_new = the_emf->Bx;
+        the_emf->By_new = the_emf->By;
+        the_emf->Bz_new = the_emf->Bz;
+    }
 }
 
 void EGS_AdvancedApplication::enterNewRegion() {
@@ -1062,6 +1070,11 @@ void EGS_AdvancedApplication::enterNewRegion() {
             the_emf->By_new = bf*the_emf->ByIN;
             the_emf->Bz_new = bf*the_emf->BzIN;
         }
+    }
+    else {
+        the_emf->Bx_new = the_emf->BxIN;
+        the_emf->By_new = the_emf->ByIN;
+        the_emf->Bz_new = the_emf->BzIN;
     }
 }
 

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -49,6 +49,7 @@
 #include "egs_input.h"
 #include "egs_interpolator.h"
 #include "egs_rndm.h"
+#include "egs_math.h"
 #include "egs_ausgab_object.h"
 
 #include <string>
@@ -1103,7 +1104,7 @@ void EGS_AdvancedApplication::resetRNGState() {
 }
 
 //************************************************************
-// Utility functions for use with ausgab dose scoring objects
+// Utility functions for use with ausgab dose scoring object
 //************************************************************
 // Returns density for medium ind
 EGS_Float EGS_AdvancedApplication::getMediumRho(int ind) {

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -701,6 +701,7 @@ int EGS_Application::initSimulation() {
     }
     initAusgabObjects();
     //describeSimulation();
+
     return 0;
 }
 

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -599,6 +599,7 @@ int EGS_Application::initGeometry() {
         return 1;
     }
     geometry->ref();
+    geometry->setApplication(this);
     return 0;
 }
 

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -732,11 +732,11 @@ void EGS_BaseGeometry::setMedia(EGS_Input *inp) {
     }
     setMedia(input,nmed,med_ind);
     setRelativeRho(input);
+    setBScaling(input);
     delete [] med_ind;
     if (delete_it) {
         delete input;
     }
-    setBScaling(input);
 }
 
 void EGS_BaseGeometry::setMedia(EGS_Input *input, int nmed, const int *mind) {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -441,7 +441,7 @@ public:
     virtual EGS_Float getBScaling(int ireg) const {
         if (has_Ref_rho && has_B_scaling) {
             if (bfactor && ireg >= 0 && ireg < nreg) {
-                return getMediumRho(ireg)/rhoRef*bfactor[ireg];
+                return getMediumRho(medium(ireg))/rhoRef*bfactor[ireg];
             }
             else {
                 return 1.0;
@@ -449,7 +449,7 @@ public:
         }
         else if (has_Ref_rho && !has_B_scaling) {
             if (ireg >= 0 && ireg < nreg) {
-                return  getMediumRho(ireg)/rhoRef;
+                return  getMediumRho(medium(ireg))/rhoRef;
             }
             else {
                 return 1.0;

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -27,6 +27,8 @@
 #                   Blake Walters
 #                   Marc Chamberland
 #                   Reid Townson
+#                   Ernesto Mainegra-Hing
+#                   Hugo Bouchard
 #
 ###############################################################################
 */
@@ -44,10 +46,12 @@
 
 #include <string>
 #include <vector>
+#include <iostream>
 
 using std::string;
 using std::vector;
 
+class EGS_Application; // forward declaration
 class EGS_Input;
 struct EGS_GeometryIntersections;
 
@@ -422,6 +426,67 @@ public:
      */
     virtual void setRelativeRho(EGS_Input *);
 
+    EGS_Float getMediumRho(int ind) const;
+
+    void setApplication(EGS_Application *app);
+
+    /*! \brief Does this geometry object have a B field scaling feature?
+     */
+    inline bool hasBScaling() const {
+        return (has_B_scaling || has_Ref_rho);
+    };
+
+    /*! \brief Get the B field scaling factor in region \a ireg
+     */
+    virtual EGS_Float getBScaling(int ireg) const {
+        if (has_Ref_rho && has_B_scaling) {
+            if (bfactor && ireg >= 0 && ireg < nreg) {
+                return getMediumRho(ireg)/rhoRef*bfactor[ireg];
+            }
+            else {
+                return 1.0;
+            }
+        }
+        else if (has_Ref_rho && !has_B_scaling) {
+            if (ireg >= 0 && ireg < nreg) {
+                return  getMediumRho(ireg)/rhoRef;
+            }
+            else {
+                return 1.0;
+            }
+        }
+        else if (!has_Ref_rho && has_B_scaling) {
+            if (bfactor && ireg >= 0 && ireg < nreg) {
+                return bfactor[ireg];
+
+            }
+            else {
+                return 1.0;
+            }
+        }
+        else {
+            return 1.0;
+        }
+    }
+
+    /*! \brief Set the B field scaling factor in regions.
+
+     Sets the B field scaling factor to \a bf in all regions between
+     start and end (inclusive).
+     */
+    virtual void setBScaling(int start, int end, EGS_Float bf);
+
+    /*! \brief Set the B field scaling factor from an user input.
+
+     Looks for input
+     \verbatim
+     set B scaling = start end bfact
+     \endverbatim
+     and sets the B field scaling factor to bfact in all regions between
+     start and end (inclusive).
+     */
+    virtual void setBScaling(EGS_Input *);
+
     /*! \brief Get the name of this geometry
 
       Every geometry must have a name and this method can be used to retrieve
@@ -702,6 +767,21 @@ protected:
 
      */
     EGS_Float *rhor;
+
+    /*! \brief Does this geometry has B field scaling factor?
+
+     */
+    bool has_B_scaling, has_Ref_rho;
+
+    /*! \brief Array with B field scaling factors.
+
+     */
+    EGS_Float *bfactor;
+
+    /*! \brief Reference density for B field scaling.
+
+     */
+    EGS_Float rhoRef;
 
     /*! \brief Number of references to this geometry.
 

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -61,6 +62,18 @@ void EGS_CDGeometry::setRelativeRho(int start, int end, EGS_Float rho) {
 void EGS_CDGeometry::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_CDGeometry::setRelativeRho(): don't use this method\n"
                "  Use the setRelativeRho() methods of the geometry objects that make"
+               " up this geometry\n");
+}
+
+void EGS_CDGeometry::setBScaling(int start, int end, EGS_Float bf) {
+    egsWarning("EGS_CDGeometry::setBScaling(): don't use this method\n"
+               "  Use the setBScaling() methods of the geometry objects that make"
+               " up this geometry\n");
+}
+
+void EGS_CDGeometry::setBScaling(EGS_Input *) {
+    egsWarning("EGS_CDGeometry::setBScaling(): don't use this method\n"
+               "  Use the setBScaling() methods of the geometry objects that make"
                " up this geometry\n");
 }
 

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -264,6 +264,7 @@ class EGS_CDGEOMETRY_EXPORT EGS_CDGeometry : public EGS_BaseGeometry {
 
 public:
 
+
     EGS_CDGeometry(EGS_BaseGeometry *G1, EGS_BaseGeometry **G,
                    const string &Name = "", int indexing=0) : EGS_BaseGeometry(Name) {
         nmax = 0;
@@ -292,6 +293,7 @@ public:
             setUpIndexing();
         }
         setHasRhoScaling();
+        setHasBScaling();
     };
 
     EGS_CDGeometry(EGS_BaseGeometry *G1, const vector<EGS_BaseGeometry *> &G,
@@ -327,6 +329,7 @@ public:
             setUpIndexing();
         }
         setHasRhoScaling();
+        setHasBScaling();
     };
 
 
@@ -847,6 +850,17 @@ do_checks:
                bg->getRelativeRho(ibase);
     };
 
+    void  setBScaling(int start, int end, EGS_Float bf);
+    void  setBScaling(EGS_Input *);
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nbase*nmax) {
+            return 1;
+        }
+        int ibase = ireg/nmax;
+        return g[ibase] ? g[ibase]->getBScaling(ireg-ibase*nmax) :
+               bg->getBScaling(ibase);
+    };
+
     virtual void getLabelRegions(const string &str, vector<int> &regs);
 
 protected:
@@ -896,6 +910,22 @@ private:
             if (g[j]) {
                 if (g[j]->hasRhoScaling()) {
                     has_rho_scaling = true;
+                    return;
+                }
+            }
+        }
+    };
+
+    void setHasBScaling() {
+        has_B_scaling = false;
+        if (bg->hasBScaling()) {
+            has_B_scaling = true;
+            return;
+        }
+        for (int j=0; j<nbase; j++) {
+            if (g[j]) {
+                if (g[j]->hasBScaling()) {
+                    has_B_scaling = true;
                     return;
                 }
             }

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -319,6 +319,7 @@ extern "C" {
             g->setName(input);
             g->setBoundaryTolerance(input);
             g->setLabels(input);
+            g->setBScaling(input);  // Perhaps add density scaling as well?
             return g;
         }
 

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -60,6 +61,16 @@ void EGS_EnvelopeGeometry::setRelativeRho(EGS_Input *) {
                " this geometry\n");
 }
 
+void EGS_EnvelopeGeometry::setBScaling(int start, int end, EGS_Float bf) {
+    setBScaling(0);
+}
+
+void EGS_EnvelopeGeometry::setBScaling(EGS_Input *) {
+    egsWarning("EGS_EnvelopeGeometry::setBScaling(): don't use this method."
+               " Use the\n setBScaling methods of the geometry objects that make up"
+               " this geometry\n");
+}
+
 void EGS_FastEnvelope::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_FastEnvelope::setMedia: don't use this method. Use the\n"
                " setMedia() methods of the geometry objects that make up this geometry\n");
@@ -72,6 +83,16 @@ void EGS_FastEnvelope::setRelativeRho(int start, int end, EGS_Float rho) {
 void EGS_FastEnvelope::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_FastEnvelope::setRelativeRho(): don't use this method."
                " Use the\n setRelativeRho methods of the geometry objects that make up"
+               " this geometry\n");
+}
+
+void EGS_FastEnvelope::setBScaling(int start, int end, EGS_Float bf) {
+    setBScaling(0);
+}
+
+void EGS_FastEnvelope::setBScaling(EGS_Input *) {
+    egsWarning("EGS_FastEnvelope::setBScaling(): don't use this method."
+               " Use the\n setBScaling methods of the geometry objects that make up"
                " this geometry\n");
 }
 
@@ -115,6 +136,7 @@ EGS_EnvelopeGeometry::EGS_EnvelopeGeometry(EGS_BaseGeometry *G,
     }
     nreg = nbase + n_in*nmax;
     is_convex = g->isConvex();
+
     has_rho_scaling = g->hasRhoScaling();
     if (!has_rho_scaling) {
         for (int j=0; j<n_in; j++) {
@@ -124,6 +146,16 @@ EGS_EnvelopeGeometry::EGS_EnvelopeGeometry(EGS_BaseGeometry *G,
             }
         }
     }
+    has_B_scaling = g->hasBScaling();
+    if (!has_B_scaling) {
+        for (int j=0; j<n_in; j++) {
+            if (geometries[j]->hasBScaling()) {
+                has_B_scaling = true;
+                break;
+            }
+        }
+    }
+
     if (!n_in) {
         return;
     }
@@ -211,6 +243,17 @@ EGS_FastEnvelope::EGS_FastEnvelope(EGS_BaseGeometry *G,
             }
         }
     }
+
+    has_B_scaling = g->hasBScaling();
+    if (!has_B_scaling) {
+        for (int j=0; j<n_in; j++) {
+            if (geometries[j]->hasBScaling()) {
+                has_B_scaling = true;
+                break;
+            }
+        }
+    }
+
     delete [] iaux;
     if (newindexing) {
         new_indexing = true;

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
@@ -573,8 +573,20 @@ public:
         return geometries[jg]->getRelativeRho(ireg - nbase - jg*nmax);
     };
 
-    virtual void getLabelRegions(const string &str, vector<int> &regs);
+    void setBScaling(int start, int end, EGS_Float bf);
+    void setBScaling(EGS_Input *);
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nreg) {
+            return 1;
+        }
+        if (ireg < nbase) {
+            return g->getBScaling(ireg);
+        }
+        int jg = (ireg - nbase)/nmax;
+        return geometries[jg]->getBScaling(ireg - nbase - jg*nmax);
+    };
 
+    virtual void getLabelRegions(const string &str, vector<int> &regs);
 
 protected:
 
@@ -963,8 +975,20 @@ public:
         return geometries[jg]->getRelativeRho(ireg - nbase - jg*nmax);
     };
 
-    virtual void getLabelRegions(const string &str, vector<int> &regs);
+    void setBScaling(int start, int end, EGS_Float bf);
+    void setBScaling(EGS_Input *);
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nreg) {
+            return 1;
+        }
+        if (ireg < nbase) {
+            return g->getBScaling(ireg);
+        }
+        int jg = (ireg - nbase)/nmax;
+        return geometries[jg]->getBScaling(ireg - nbase - jg*nmax);
+    };
 
+    virtual void getLabelRegions(const string &str, vector<int> &regs);
 
 protected:
 

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Marc Chamberland
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -61,10 +62,21 @@ EGS_StackGeometry::EGS_StackGeometry(const vector<EGS_BaseGeometry *> &geoms,
             has_rho_scaling = g[j]->hasRhoScaling();
         }
     }
+    has_B_scaling = false;
+    for (int j=0; j<ng; j++) {
+        g[j] = geoms[j];
+        g[j]->ref();
+        int n = g[j]->regions();
+        if (n > nmax) {
+            nmax = n;
+        }
+        if (!has_B_scaling) {
+            has_B_scaling = g[j]->hasBScaling();
+        }
+    }
     nreg = ng*nmax;
     is_convex = false;
 }
-
 
 EGS_StackGeometry::~EGS_StackGeometry() {
     for (int j=0; j<ng; j++)
@@ -95,6 +107,16 @@ void EGS_StackGeometry::setRelativeRho(int start, int end, EGS_Float rho) {
 void EGS_StackGeometry::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_StackGeometry::setRelativeRho(): don't use this method.\n"
                " Use the setRelativeRho methods of the geometry objects that make up"
+               " this geometry\n");
+}
+
+void EGS_StackGeometry::setBScaling(int start, int end, EGS_Float rho) {
+    setBScaling(0);
+}
+
+void EGS_StackGeometry::setBScaling(EGS_Input *) {
+    egsWarning("EGS_StackGeometry::setBScaling(): don't use this method.\n"
+               " Use the setBScaling methods of the geometry objects that make up"
                " this geometry\n");
 }
 

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.h
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Marc Chamberland
 #                   Reid Townson
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -312,6 +313,16 @@ public:
     };
     void setRelativeRho(int start, int end, EGS_Float rho);
     void setRelativeRho(EGS_Input *);
+
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nreg) {
+            return 1;
+        }
+        int jg = ireg/nmax;
+        return g[jg]->getBScaling(ireg-jg*nmax);
+    };
+    void setBScaling(int start, int end, EGS_Float bf);
+    void setBScaling(EGS_Input *);
 
     virtual void getLabelRegions(const string &str, vector<int> &regs);
 

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -51,6 +52,16 @@ void EGS_TransformedGeometry::setRelativeRho(int start, int end, EGS_Float rho) 
 void EGS_TransformedGeometry::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_TransformedGeometry::setRelativeRho(): don't use this "
                "method. Use the \n setRelativeRho() methods of the underlying "
+               "geometry\n");
+}
+
+void EGS_TransformedGeometry::setBScaling(int start, int end, EGS_Float rho) {
+    setBScaling(0);
+}
+
+void EGS_TransformedGeometry::setBScaling(EGS_Input *) {
+    egsWarning("EGS_TransformedGeometry::setBScaling(): don't use this "
+               "method. Use the \n setBScaling() methods of the underlying "
                "geometry\n");
 }
 

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.h
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.h
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -148,6 +149,7 @@ public:
         nreg = g->regions();
         is_convex = g->isConvex();
         has_rho_scaling = g->hasRhoScaling();
+        has_B_scaling = g->hasBScaling();
     };
 
     ~EGS_TransformedGeometry() {
@@ -251,6 +253,13 @@ public:
     void setRelativeRho(int start, int end, EGS_Float rho);
 
     void setRelativeRho(EGS_Input *);
+
+    EGS_Float getBScaling(int ireg) const {
+        return g->getBScaling(ireg);
+    }
+    void setBScaling(int start, int end, EGS_Float bf);
+
+    void setBScaling(EGS_Input *);
 
     virtual void getLabelRegions(const string &str, vector<int> &regs);
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -1155,6 +1155,7 @@ extern "C" {
                     EGS_XYZGeometry::constructGeometry(dens_file.c_str(),ramp_file.c_str(),dens_or_egsphant_or_interfile);
                 result->setName(input);
                 result->setBoundaryTolerance(input);
+                result->setBScaling(input);
                 return result;
             }
             vector<EGS_Float> xpos, ypos, zpos, xslab, yslab, zslab;

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -958,7 +959,12 @@ void EGS_XYZGeometry::voxelizeGeometry(EGS_Input *input) {
         delete [] rhor;
         rhor = 0;
     }
+    if (bfactor) {
+        delete [] bfactor;
+        bfactor = 0;
+    }
     region_media = new short [nreg];
+
     bool hrs = geometry->hasRhoScaling();
     if (hrs) {
         has_rho_scaling = true;
@@ -967,6 +973,16 @@ void EGS_XYZGeometry::voxelizeGeometry(EGS_Input *input) {
     else {
         has_rho_scaling = false;
     }
+
+    bool hbs = geometry->hasBScaling();
+    if (hbs) {
+        has_B_scaling = true;
+        bfactor = new EGS_Float [nreg];
+    }
+    else {
+        has_B_scaling = false;
+    }
+
     EGS_Vector v1(xp->position(0),yp->position(0),zp->position(0));
     EGS_Vector v2(xp->position(nx),yp->position(ny),zp->position(nz));
     egsInformation("  top/left/front corner   : (%g,%g,%g)\n",v1.x,v1.y,v1.z);
@@ -992,11 +1008,17 @@ void EGS_XYZGeometry::voxelizeGeometry(EGS_Input *input) {
                     if (hrs) {
                         rhor[ir] = geometry->getRelativeRho(ir);
                     }
+                    if (hbs) {
+                        bfactor[ir] = geometry->getBScaling(ir);
+                    }
                 }
                 else {
                     region_media[ir] = -1;
                     if (hrs) {
                         rhor[ir] = 1;
+                    }
+                    if (hbs) {
+                        bfactor[ir] = 1;
                     }
                 }
             }

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2008
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 #
@@ -76,6 +77,16 @@ void EGS_SmartEnvelope::setRelativeRho(int start, int end, EGS_Float rho) {
 void EGS_SmartEnvelope::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_SmartEnvelope::setRelativeRho(): don't use this method."
                " Use the\n setRelativeRho methods of the geometry objects that make up"
+               " this geometry\n");
+}
+
+void EGS_SmartEnvelope::setBScaling(int start, int end, EGS_Float bf) {
+    setBScaling(0);
+}
+
+void EGS_SmartEnvelope::setBScaling(EGS_Input *) {
+    egsWarning("EGS_SmartEnvelope::setsetBScaling(): don't use this method."
+               " Use the\n setsetBScaling methods of the geometry objects that make up"
                " this geometry\n");
 }
 
@@ -163,6 +174,15 @@ EGS_SmartEnvelope::EGS_SmartEnvelope(EGS_BaseGeometry *G,
         for (int j=0; j<n_in; j++) {
             if (geometries[j]->hasRhoScaling()) {
                 has_rho_scaling = true;
+                break;
+            }
+        }
+    }
+    has_B_scaling = g->hasBScaling();
+    if (!has_B_scaling) {
+        for (int j=0; j<n_in; j++) {
+            if (geometries[j]->hasBScaling()) {
+                has_B_scaling = true;
                 break;
             }
         }

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.h
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.h
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2008
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 #
@@ -367,8 +368,21 @@ public:
         return geometries[j]->getRelativeRho(ireg-local_start[j]);
     };
 
-    virtual void getLabelRegions(const string &str, vector<int> &regs);
+    void setBScaling(int start, int end, EGS_Float bf);
+    void setBScaling(EGS_Input *);
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nreg) {
+            return 1;
+        }
+        if (ireg < nbase) {
+            return g->getBScaling(ireg);
+        }
+        int i = ireg-nbase;
+        int j = reg_to_inscr[i];
+        return geometries[j]->getBScaling(ireg-local_start[j]);
+    };
 
+    virtual void getLabelRegions(const string &str, vector<int> &regs);
 
 protected:
 

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Ernesto Mainegra-Hing
 #
 ###############################################################################
 */
@@ -54,6 +55,16 @@ void EGS_UnionGeometry::setRelativeRho(int start, int end, EGS_Float rho) {
 void EGS_UnionGeometry::setRelativeRho(EGS_Input *) {
     egsWarning("EGS_UnionGeometry::setRelativeRho(): don't use this method. "
                "Use the\n setRelativeRho() methods of the geometry objects that make "
+               "up this geometry\n");
+}
+
+void EGS_UnionGeometry::setBScaling(int start, int end, EGS_Float bf) {
+    setBScaling(0);
+}
+
+void EGS_UnionGeometry::setBScaling(EGS_Input *) {
+    egsWarning("EGS_UnionGeometry::setBScaling(): don't use this method. "
+               "Use the\n setBScaling() methods of the geometry objects that make "
                "up this geometry\n");
 }
 
@@ -113,6 +124,21 @@ EGS_UnionGeometry::EGS_UnionGeometry(const vector<EGS_BaseGeometry *> &geoms,
         }
         if (!has_rho_scaling) {
             has_rho_scaling = g[i]->hasRhoScaling();
+        }
+    }
+    has_B_scaling = false;
+    // now put the geometries into the array of geometries in
+    // decreasing priority order.
+    for (j=0; j<ng; j++) {
+        int i = order[j];
+        g[i] = geoms[j];
+        g[i]->ref();
+        int n = g[i]->regions();
+        if (n > nmax) {
+            nmax = n;
+        }
+        if (!has_B_scaling) {
+            has_B_scaling = g[i]->hasBScaling();
         }
     }
     delete [] order;

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
@@ -303,6 +303,16 @@ public:
     void setRelativeRho(int start, int end, EGS_Float rho);
     void setRelativeRho(EGS_Input *);
 
+    void  setBScaling(int start, int end, EGS_Float rho);
+    void  setBScaling(EGS_Input *);
+    EGS_Float getBScaling(int ireg) const {
+        if (ireg < 0 || ireg >= nreg) {
+            return 1;
+        }
+        int jg = ireg/nmax;
+        return g[jg]->getBScaling(ireg-jg*nmax);
+    };
+
     virtual void getLabelRegions(const string &str, vector<int> &regs);
 
 protected:

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/Makefile
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/Makefile
@@ -1,0 +1,44 @@
+
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build Fano source
+#  Copyright (C) 2016 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2016
+#
+#  Contributors:    Hugo Bouchard
+#
+###############################################################################
+
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_FANO_SOURCE_DLL
+
+library = egs_fano_source
+lib_files = egs_fano_source
+my_deps = $(common_source_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -1,0 +1,151 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ Fano source
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2016
+#
+#  Contributors:    Hugo Bouchard
+#
+###############################################################################
+*/
+
+
+/*! \file egs_fano_source.cpp
+ *  \brief An Fano source
+ *  \IK
+ *  The Fano option allows have uniform particles per unit mass
+ */
+
+#include "egs_fano_source.h"
+#include "egs_input.h"
+#include "egs_math.h"
+#include <sstream>
+
+EGS_FanoSource::EGS_FanoSource(EGS_Input *input,
+                               EGS_ObjectFactory *f) :
+    EGS_BaseSimpleSource(input,f), shape(0), geom(0),
+    regions(0), nrs(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
+    max_mass_density(0.0) {
+
+    vector<EGS_Float> pos;
+    EGS_Input *ishape = input->takeInputItem("shape");
+    if (ishape) {
+        egsWarning("EGS_FanoSource: trying to construct the shape\n");
+        shape = EGS_BaseShape::createShape(ishape);
+        delete ishape;
+    }
+    if (!shape) {
+        string sname;
+        int err = input->getInput("shape name",sname);
+        if (err)
+            egsWarning("EGS_FanoSource: missing/wrong inline shape "
+                       "definition and missing wrong 'shape name' input\n");
+        else {
+            shape = EGS_BaseShape::getShape(sname);
+            if (!shape) egsWarning("EGS_FanoSource: a shape named %s"
+                                       " does not exist\n");
+        }
+    }
+    string geom_name;
+    int err = input->getInput("geometry",geom_name);
+    if (!err) {
+        geom = EGS_BaseGeometry::getGeometry(geom_name);
+        if (!geom) egsFatal("EGS_FanoSource: no geometry named %s in input file!\n",
+                                geom_name.c_str());
+        else {
+            int errF = input->getInput("max mass density", max_mass_density);
+            if (errF) {
+                egsFatal("EGS_FanoSource: A Fano source requires a maximum density input.\n");
+            }
+        }
+    }
+    else {
+        egsFatal("EGS_FanoSource: A Fano source requires a valid geometry name.\n");
+    }
+
+    EGS_Float tmp_theta;
+    err = input->getInput("min theta", tmp_theta);
+    if (!err) {
+        min_theta = tmp_theta/180.0*M_PI;
+    }
+
+    err = input->getInput("max theta", tmp_theta);
+    if (!err) {
+        max_theta = tmp_theta/180.0*M_PI;
+    }
+
+    err = input->getInput("min phi", tmp_theta);
+    if (!err) {
+        min_phi = tmp_theta/180.0*M_PI;
+    }
+
+    err = input->getInput("max phi", tmp_theta);
+    if (!err) {
+        max_phi = tmp_theta/180.0*M_PI;
+    }
+
+    buf_1 = cos(min_theta);
+    buf_2 = cos(max_theta);
+
+    setUp();
+}
+
+void EGS_FanoSource::setUp() {
+    otype = "EGS_FanoSource";
+    if (!isValid()) {
+        description = "Invalid Fano source";
+    }
+    else {
+        description = "Fano source from a shape of type ";
+        description += shape->getObjectType();
+        description += " with ";
+        description += s->getType();
+        if (q == -1) {
+            description += ", electrons";
+        }
+        else if (q == 0) {
+            description += ", photons";
+        }
+        else if (q == 1) {
+            description += ", positrons";
+        }
+        else {
+            description += ", unknown particle type";
+        }
+        ostringstream str_density;
+        str_density << scientific << max_mass_density;
+        description += "\n maximum density = " + str_density.str() + "  g/cm3";
+        description += "\n Fano geometry   = " + geom->getName();
+        if (geom) {
+            geom->ref();
+        }
+    }
+}
+
+extern "C" {
+
+    EGS_FANO_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        return createSourceTemplate<EGS_FanoSource>(input, f, "fano source");
+    }
+
+}

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
@@ -1,0 +1,222 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ Fano source headers
+#  Copyright (C) 2016 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2016
+#
+#  Contributors:    Hugo Bouchard
+#
+###############################################################################
+*/
+
+
+/*! \file egs_fano_source.h
+ *  \brief A Fano source
+ *  \EMH
+ */
+
+#ifndef EGS_FANO_SOURCE_
+#define EGS_FANO_SOURCE_
+
+#include "egs_vector.h"
+#include "egs_base_source.h"
+#include "egs_rndm.h"
+#include "egs_shapes.h"
+#include "egs_base_geometry.h"
+#include "egs_math.h"
+
+
+#ifdef WIN32
+
+    #ifdef BUILD_FANO_SOURCE_DLL
+        #define EGS_FANO_SOURCE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_FANO_SOURCE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_FANO_SOURCE_LOCAL
+
+#else
+
+    #ifdef HAVE_VISIBILITY
+        #define EGS_FANO_SOURCE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_FANO_SOURCE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_FANO_SOURCE_EXPORT
+        #define EGS_FANO_SOURCE_LOCAL
+    #endif
+
+#endif
+
+/*! \brief A Fano source
+
+  \ingroup Sources
+
+An Fano source is a source that delivers particles proportional to the
+mass in the current source region with directions uniformly distributed in
+\f$4 \pi\f$ emitted from \link EGS_BaseShape any shape. \endlink
+It is defined using the following input
+\verbatim
+:start source:
+    library = egs_fano_source
+    name = some_name
+    :start shape:
+        definition of the shape
+    :stop shape:
+    :start spectrum:
+        definition of the spectrum
+    :stop spectrum:
+    charge = -1 or 0 or 1 for electrons or photons or positrons
+    max mass density = 1.2
+    geometry = some_name
+:stop source:
+\endverbatim
+*/
+
+class EGS_FANO_SOURCE_EXPORT EGS_FanoSource :
+    public EGS_BaseSimpleSource {
+
+public:
+
+    /*! \brief Constructor
+
+    Construct a Fano source with charge \a Q, spectrum \a Spec
+    and emitting particles from the shape \a Shape
+    */
+    EGS_FanoSource(int Q, EGS_BaseSpectrum *Spec, EGS_BaseShape *Shape,
+                   EGS_BaseGeometry *geometry,
+                   const string &Name="", EGS_ObjectFactory *f=0) :
+        EGS_BaseSimpleSource(Q,Spec,Name,f), shape(Shape),
+        min_theta(85.), max_theta(95.), min_phi(0), max_phi(2*M_PI),
+        buf_1(1), buf_2(-1),
+        geom(geometry), regions(0), nrs(0) {
+        setUp();
+    };
+
+    /*! \brief Constructor
+
+    Construct a Fano source from the information pointed to by \a inp.
+    */
+    EGS_FanoSource(EGS_Input *, EGS_ObjectFactory *f=0);
+    ~EGS_FanoSource() {
+        egsWarning("destructing Fano source\n");
+        EGS_Object::deleteObject(shape);
+        if (geom) {
+            if (!geom->deref()) {
+                delete geom;
+            }
+        }
+        if (nrs > 0 && regions) {
+            delete [] regions;
+        }
+    };
+
+    void getPositionDirection(EGS_RandomGenerator *rndm,
+                              EGS_Vector &x, EGS_Vector &u, EGS_Float &wt) {
+        bool ok = true, okfano = false;
+        wt = 1;
+        do {
+            do {
+                x = shape->getRandomPoint(rndm);
+                ok = geom->isInside(x);
+                if (ok) {
+                    if (rndm->getUniform()*max_mass_density > geom->getMediumRho(geom->medium(geom->isWhere(x)))) {
+                        okfano = false;
+                    }
+                    else {
+                        okfano = true;
+                    }
+
+                    /* Rather than rejecting, accept always and reduce weight accordingly */
+                    //wt = wt * geom->getMediumRho(geom->medium(geom->isWhere(x)))/max_mass_density;
+                    //real_count += wt;
+                    //okfano = true;
+                }
+            }
+            while (!ok);
+        }
+        while (!okfano);
+        u.z = rndm->getUniform()*(buf_1 - buf_2) - buf_1;
+        //u.z = 2*rndm->getUniform()-1;
+        EGS_Float sinz = 1-u.z*u.z;
+        if (sinz > 1e-15) {
+            sinz = sqrt(sinz);
+            EGS_Float cphi, sphi;
+            EGS_Float phi = min_phi + (max_phi - min_phi)*rndm->getUniform();
+            cphi = cos(phi);
+            sphi = sin(phi);
+            u.x = sinz*cphi;
+            u.y = sinz*sphi;
+        }
+        else {
+            u.x = 0;
+            u.y = 0;
+        }
+    };
+
+    EGS_Float getFluence() const {
+        return count;
+    };
+    //EGS_Float getFluence() const { return Fano_source ? real_count : count; };
+    /*
+        bool storeFluenceState(ostream & data) const {
+             if (Fano_source) data << real_count;
+             return Fano_source ? data.good() : true;
+        };
+
+        bool setFluenceState(istream & data) {
+          if (Fano_source) data >> real_count;
+          return Fano_source ? data.good() : true;
+        };
+
+        bool addFluenceData(istream &data) {
+             if (Fano_source){
+                EGS_Float tmp; data >> tmp;
+                if( !data.good() ) return false;
+                real_count += tmp;
+             }
+             return true;
+        };
+
+        void resetFluenceCounter() {real_count = 0.0; };
+    */
+    bool isValid() const {
+        return (s != 0 && shape != 0);
+    };
+
+protected:
+
+    EGS_BaseShape    *shape;    //!< The shape from which particles are emitted.
+    EGS_BaseGeometry *geom;
+    int              *regions;
+
+    void setUp();
+
+    EGS_Float min_theta, max_theta;
+    EGS_Float buf_1, buf_2;//! avoid multi-calculating cos(min_theta) and cos(max_theta)
+    EGS_Float min_phi, max_phi;
+    //EGS_Float max_mass_density, real_count;
+    EGS_Float max_mass_density;
+    int                 nrs;
+};
+
+
+#endif

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -23,8 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:    Ernesto Mainegra-Hing
-#                   Hugo Bouchard
+#  Contributors:
 #
 ###############################################################################
 */
@@ -33,18 +32,16 @@
 /*! \file egs_isotropic_source.cpp
  *  \brief An isotropic source
  *  \IK
- *  The Fano option allows have uniform particles per unit mass
  */
 
 #include "egs_isotropic_source.h"
 #include "egs_input.h"
 #include "egs_math.h"
-#include <sstream>
 
 EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f), shape(0), geom(0),
-    regions(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
-    gc(IncludeAll), Fano_source(false) {
+    regions(0), nrs(0), min_theta(0), max_theta(M_PI), min_phi(0), max_phi(2*M_PI),
+    gc(IncludeAll) {
     vector<EGS_Float> pos;
     EGS_Input *ishape = input->takeInputItem("shape");
     if (ishape) {
@@ -91,26 +88,8 @@ EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
                     regions[j] = regs[j];
                 }
             }
-            /*********************************************************************
-             * Check whether this is a Fano source requiring the maximum density
-             *
-             * The assumption is that if this is requested the whole geometry will
-             * be used ...
-             *
-             *********************************************************************/
-            max_mass_density = 0.0;
-            int errF = input->getInput("max mass density", max_mass_density);
-            if (!errF) {
-                if (gc != IncludeAll)
-                    egsFatal("EGS_IsotropicSource: A Fano source does not require a region selection input.\n"
-                             "Remove it or set it to IncludeAll!\n");
-                else {
-                    Fano_source = true; //real_count = 0.0;
-                }
-            }
         }
     }
-
     EGS_Float tmp_theta;
     err = input->getInput("min theta", tmp_theta);
     if (!err) {
@@ -144,13 +123,7 @@ void EGS_IsotropicSource::setUp() {
         description = "Invalid isotropic source";
     }
     else {
-
-        if (Fano_source) {
-            description = "Isotropic Fano source from a shape of type ";
-        }
-        else {
-            description = "Isotropic source from a shape of type ";
-        }
+        description = "Isotropic source from a shape of type ";
         description += shape->getObjectType();
         description += " with ";
         description += s->getType();
@@ -165,12 +138,6 @@ void EGS_IsotropicSource::setUp() {
         }
         else {
             description += ", unknown particle type";
-        }
-        if (Fano_source) {
-            ostringstream str_density;
-            str_density << scientific << max_mass_density;
-            description += "\n maximum density = " + str_density.str() + "  g/cm3";
-            description += "\n Fano geometry   = " + geom->getName();
         }
 
         if (geom) {

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -309,7 +309,6 @@ public:
 
         u.z = rndm->getUniform()*(buf_1 - buf_2) - buf_1;
 
-        //u.z = 2*rndm->getUniform()-1;
         EGS_Float sinz = 1-u.z*u.z;
         if (sinz > epsilon) {
             sinz = sqrt(sinz);

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -283,27 +283,14 @@ public:
                             break;
                         }
                     }
-                    else if (gc == ExcludeAll) {
-                        ok = !geom->isInside(x);
-                    }
-                    else if (gc == IncludeSelected) {
-                        ok = false;
-                        int ireg = geom->isWhere(x);
-                        for (int j=0; j<nrs; ++j) {
-                            if (ireg == regions[j]) {
-                                ok = true;
-                                break;
-                            }
-                        }
-                    }
-                    else {
-                        ok = true;
-                        int ireg = geom->isWhere(x);
-                        for (int j=0; j<nrs; ++j) {
-                            if (ireg == regions[j]) {
-                                ok = false;
-                                break;
-                            }
+                }
+                else {
+                    ok = true;
+                    int ireg = geom->isWhere(x);
+                    for (int j=0; j<nrs; ++j) {
+                        if (ireg == regions[j]) {
+                            ok = false;
+                            break;
                         }
                     }
                 }

--- a/HEN_HOUSE/interface/egs_c_interface2.macros
+++ b/HEN_HOUSE/interface/egs_c_interface2.macros
@@ -384,6 +384,7 @@ REPLACE {$start_new_particle;} WITH {
 REPLACE {$electron_region_change;} WITH {
   ir(np) = irnew; irl = irnew; rhor = rhor_new;
   medium = medium_new; ecut = ecut_new; smaxir = smax_new;
+  Bx=Bx_new;By=By_new;Bz=Bz_new;
 };
 
 REPLACE {$photon_region_change;} WITH {

--- a/HEN_HOUSE/interface/egs_interface2.h
+++ b/HEN_HOUSE/interface/egs_interface2.h
@@ -631,7 +631,8 @@ struct EGS_IO {
  */
 struct EGS_emfInputs {
     /*! Input values for static electric and magnetic fields */
-    EGS_Float ExIN, EyIN, EzIN, BxIN, ByIN, BzIN, EMLMTIN;
+    EGS_Float ExIN, EyIN, EzIN, EMLMTIN,
+    BxIN, ByIN, BzIN, Bx, By, Bz, Bx_new, By_new, Bz_new;
 };
 
 /*! \brief The address of the mortran \c STACK common block as a

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -906,7 +906,13 @@ comp_xsections = $COMP-XDATA-DEFAULT;
 photonuc_xsections = $PHOTONUC-XDATA-DEFAULT;
 "EMH:emf"
 ExIN=$ExDEF;EyIN=$EyDEF;EzIN=$EzDEF;
+" Initially set to input values, could change with regions"
+" by converting it to an array over all regions. This is  "
+" currently implemented ONLY for the C++ applications     "
 BxIN=$BxDEF;ByIN=$ByDEF;BzIN=$BzDEF; EMLMTIN=$EMLMTDEF;
+Bx=BxIN;    By=ByIN;    Bz=BzIN;
+Bx_new=Bx;  By_new=By;  Bz_new=Bz;
+
 "DO i=1,len(eii_xfile) [ eii_xfile(i:i) = ' '; ]"
 DO i=1,$MXMED [
     iraylm(i) = 0;   "Rayleigh data available?"

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -629,11 +629,16 @@ REPLACE {$COMIN-EII-INIT;} WITH {
 
 REPLACE {;COMIN/EMF-INPUTS/;} WITH {;
     common/emf_inputs/ExIN,EyIN,EzIN, "E field"
-                     BxIN,ByIN,BzIN,  "B field"
-                     EMLMTIN;         "Ekin, u, E fractional maximum change"
+                     EMLMTIN,         "Ekin, u, E fractional maximum change"
+                     BxIN, ByIN, BzIN,       "B field: initial region"
+                     Bx, By, Bz,             "B field: current region"
+                     Bx_new, By_new, Bz_new; "B field: in new region"
+
    $REAL    ExIN,EyIN,EzIN,
+            EMLMTIN,
             BxIN,ByIN,BzIN,
-            EMLMTIN;
+            Bx,By,Bz,
+            Bx_new,By_new,Bz_new;
 };
 ;  "---------- BUFFER FLUSH SEMICOLON ----------"
 " The following common block is made available to the user so that  "

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1026,6 +1026,7 @@ irold = ir(np);    "Initialize previous region
                    " stack the current particle is.)
 irl    = irold;    "region number in local variable
 
+
 $start_new_particle;
 " Default replacement for the above is medium = med(irl); "
 " This is made a macro so that it can be replaced with a call to a "

--- a/HEN_HOUSE/src/emf_macros.mortran
+++ b/HEN_HOUSE/src/emf_macros.mortran
@@ -424,7 +424,7 @@ REPLACE {$GET-EM-FIELD(#,#,#,#,#);} WITH {;
 fbtemp=  1.0/(RM*10**6);
 {P1}X0=ExIN*fbtemp;{P1}Y0=EyIN*fbtemp;{P1}Z0=EzIN*fbtemp;
 fbtemp=3.0/RM;
-{P2}X0=BxIN*fbtemp;{P2}Y0=ByIN*fbtemp;{P2}Z0=BzIN*fbtemp;
+{P2}X0=Bx*fbtemp;{P2}Y0=By*fbtemp;{P2}Z0=Bz*fbtemp;
 }
 ;
 "REPLACE {$SET-TUSTEP-EM-FIELD;} WITH {;}"

--- a/HEN_HOUSE/src/get_inputs.mortran
+++ b/HEN_HOUSE/src/get_inputs.mortran
@@ -1596,10 +1596,15 @@ IF( error_flags(num_efield) = 0 ) [
        EMLMTIN=value(num_emlmt,1);
     ]
 ]
+" Initially set to input values, could change with regions"
+" by converting it to an array over all regions. This is  "
+" currently implemented only for the C++ applications     "
 IF( error_flags(num_bfield) = 0 ) [
     BxIN = value(num_bfield,1);
     ByIN = value(num_bfield,2);
     BzIN = value(num_bfield,3);
+    Bx=BxIN;By=ByIN;Bz=BzIN;
+    Bx_new=BxIN;By_new=ByIN;Bz_new=BzIN;
     IF( error_flags(num_emlmt) = 0 )[
        EMLMTIN=value(num_emlmt,1);
     ]
@@ -1785,12 +1790,12 @@ IF( ExIN~=0 | EyIN~=0 | EzIN~=0 )[
   write(ounit,'(a,38x,3f10.2)') ' Electric Field [V/cm]',
                   ExIN,EyIN,EzIN;
 ]
-IF( BxIN~=0 | ByIN~=0 | BzIN~=0 )[
+IF( Bx~=0 | By~=0 | Bz~=0 )[
   write(ounit,'(a,41x,3f10.2)') ' Magnetic Field [T]',
-                  BxIN,ByIN,BzIN;
+                  Bx,By,Bz;
 ]
 IF( ExIN~=0 | EyIN~=0 | EzIN~=0 |
-    BxIN~=0 | ByIN~=0 | BzIN~=0 )[
+    Bx~=0 | By~=0 | Bz~=0 )[
   write(ounit,'(a,50x,f10.2)') ' EM ESTEPE',EMLMTIN;
 ]
 write(ounit,*);


### PR DESCRIPTION
The `feature-emf` branch is a cleaned up version of the `emf` branch. It was not trivial to bring this branch up to date with `develop`, because of concurrent modifications in the same files since the `emf` branching point. I checked carefully that all changes related to the Fano source and magnetic field scaling have been preserved, but I need more eyes on this, and test runs.

The Fano source was initially implemented as an option in the isotropic source, but then segregated to a separate source in its own right. I propose to leave the commits as they are and merge into `develop`, to preserve the implementation history. **Once this is merged, the older `emf` branch can be deleted as well.**

I adjusted Authors and Contributors, and fixed a few instances in the new Fano source files that were still referring to the isotropic source. I also ran the astyle filter, checked for eol spaces and formatted the commit messages. 