### PR TITLE
Fix a bug in cavity for non fluence calculations from PR #289

### DIFF
--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -2591,7 +2591,7 @@ int Cavity_Application::initScoring() {
                 if( !muen_data ){
                     egsFatal(
                   "\n\n***  Failed to open muen file %s\n"
-                      "     This is a fatal error\n");
+                      "     This is a fatal error\n",muen_file.c_str());
                 }
                 int ndat; muen_data >> ndat;
                 if( ndat < 2 || muen_data.fail() ) egsFatal(
@@ -2902,7 +2902,9 @@ void Cavity_Application::describeSimulation() {
                     }
                 }
             }
-            egsInformation("  density of cavity medium = %g g/cm3\n",Rho[j]);
+            if(Rho) {
+                egsInformation("  density of cavity medium = %g g/cm3\n",Rho[j]);
+            }
         }
     }
     egsInformation("=============================================\n");


### PR DESCRIPTION
Add a check to see if the array Rho has been defined. This avoids a segmentation fault that occurred for non fluence calculations. This bug was introduced in PR #289.