### PR TITLE
Fix #296: SYNCHDMLC not available in BEAMnrc create_accel

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/beamnrc/create_accel.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/create_accel.tcl
@@ -188,7 +188,7 @@ proc create_accel {} {
     # add listbox, scrollbar, insert all availabel CM names
     listbox $top.l.list -height 10 -yscrollcommand "$top.l.scrl set" \
 	    -bg white
-    for {set i 1} {$i <= 24} {incr i} {
+    for {set i 1} {$i <= [array size cm_names]} {incr i} {
 	$top.l.list insert end $cm_names($i)
     }
     scrollbar $top.l.scrl -command "$top.l.list yview"
@@ -282,7 +282,7 @@ proc add_cm {} {
 	return
     }
 
-    for {set i 1} {$i<=24} {incr i} {
+    for {set i 1} {$i <= [array size cm_names]} {incr i} {
 	if [string compare $new_cm_name $cm_names($i)]==0 {
 	    set index [incr i -1]
 	    break


### PR DESCRIPTION
Fix a bug where SYNCHDMLC was not available as an option when creating a new accelerator in the BEAMnrc gui. This was due to the number of CMs being hard-coded in create_accel.tcl. Now the length of the cm_names array is determined correctly.