### PR TITLE
Fix radionuclide source compile warnings

### DIFF
--- a/HEN_HOUSE/egs++/egs_ausgab_object.h
+++ b/HEN_HOUSE/egs++/egs_ausgab_object.h
@@ -88,7 +88,9 @@ public:
      *
      */
     virtual int processEvent(EGS_Application::AusgabCall iarg) = 0;
-    virtual int processEvent(EGS_Application::AusgabCall iarg, int ir) {};
+    virtual int processEvent(EGS_Application::AusgabCall iarg, int ir) {
+        return 0;
+    };
 
     /*! \brief Is the ausgab call \a iarg relevant for this object?
      *

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -174,14 +174,18 @@ public:
      * This method is only reimplemented by EGS_RadionuclideSource. It
      * returns the emission time of the particle that was most recently sampled.
      */
-    virtual double getTime() const {};
+    virtual double getTime() const {
+        return 0;
+    };
 
     /*! \brief Get the shower index for radionuclide emissions
      *
      * This method is only reimplemented by EGS_RadionuclideSource. It
      * gets the index of the most recent shower.
      */
-    virtual EGS_I64 getShowerIndex() const {};
+    virtual EGS_I64 getShowerIndex() const {
+        return 0;
+    };
 
     /*! \brief Prints out the sampled emissions for radionuclide spectra
      *
@@ -379,7 +383,9 @@ public:
      * returns the charge of the particle that was most recently sampled
      * using sampleEnergy().
      */
-    virtual int getCharge() const {};
+    virtual int getCharge() const {
+        return 0;
+    };
 
     /*! \brief Get the time of emission for the most recently sampled particle
      *
@@ -387,14 +393,18 @@ public:
      * returns the emission time of the particle that was most recently sampled
      * using sampleEnergy().
      */
-    virtual double getTime() const {};
+    virtual double getTime() const {
+        return 0;
+    };
 
     /*! \brief Get the shower index for radionuclide emissions
      *
      * This method is only reimplemented by EGS_RadionuclideSpectrum. It
      * gets the index of the most recent shower produced using sampleEnergy().
      */
-    virtual EGS_I64 getShowerIndex() const {};
+    virtual EGS_I64 getShowerIndex() const {
+        return 0;
+    };
 
     /*! \brief Get the spectrum weight for radionuclide spectra
      *
@@ -402,7 +412,9 @@ public:
      * gets the weight of the spectrum to balance emissions from multiple
      * spectra.
      */
-    virtual EGS_Float getSpectrumWeight() const {};
+    virtual EGS_Float getSpectrumWeight() const {
+        return 0;
+    };
 
     /*! \brief Set the spectrum weight for radionuclide spectra
      *
@@ -425,7 +437,9 @@ public:
      * This method is only reimplemented by EGS_RadionuclideSpectrum. It
      * gets the energy deposited locally during spectrum generation.
      */
-    virtual EGS_Float getEdep() const {};
+    virtual EGS_Float getEdep() const {
+        return 0;
+    };
 
     /*! \brief Get the maximum energy of this spectrum.
      *

--- a/HEN_HOUSE/egs++/egs_ensdf.cpp
+++ b/HEN_HOUSE/egs++/egs_ensdf.cpp
@@ -569,7 +569,7 @@ void EGS_Ensdf::parseEnsdf(vector<string> ensdf) {
         }
 
         double bestMatch = 1E10;
-        LevelRecord *level;
+        LevelRecord *level = 0;
         for (vector<LevelRecord * >::iterator it = myLevelRecords.begin();
                 it!=myLevelRecords.end(); it++) {
 
@@ -1083,7 +1083,7 @@ void EGS_Ensdf::getEmissionsFromComments() {
     bool gotTotal = false;
     vector<double>  multilineEnergies,
            multilineIntensities;
-    double lineTotalIntensity;
+    double lineTotalIntensity = 0;
     unsigned int countNumAfterTotal = 0;
     int lineTotalType;
 
@@ -1701,10 +1701,10 @@ BetaRecordLeaf::BetaRecordLeaf(vector<string> ensdf,
                                ParentRecord *myParent,
                                NormalizationRecord *myNormalization,
                                LevelRecord *myLevel):
+    Record(ensdf),
     ParentRecordLeaf(myParent),
     NormalizationRecordLeaf(myNormalization),
-    LevelRecordLeaf(myLevel),
-    Record(ensdf) {
+    LevelRecordLeaf(myLevel) {
 
     numSampled = 0;
 

--- a/HEN_HOUSE/egs++/egs_ensdf.h
+++ b/HEN_HOUSE/egs++/egs_ensdf.h
@@ -274,8 +274,12 @@ public:
 
     virtual double getFinalEnergy() const = 0;
     virtual double getBetaIntensity() const = 0;
-    virtual double getPositronIntensity() const {};
-    virtual double getECIntensity() const {};
+    virtual double getPositronIntensity() const {
+        return 0;
+    };
+    virtual double getECIntensity() const {
+        return 0;
+    };
     virtual void relax(int shell,
                        EGS_Float ecut, EGS_Float pcut,
                        EGS_RandomGenerator *rndm, double &edep,

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -482,10 +482,8 @@ public:
             EGS_Float *e = new EGS_Float [nbin];
             EGS_Float *spec = new EGS_Float [nbin];
             EGS_Float *spec_y = new EGS_Float [nbin];
-            EGS_Float *spec_sr = new EGS_Float [nbin];
 
-            double de, s_y, s_sr, factor, e1, e2, se_y, se_sr;
-            int isrc;
+            double de, s_y, factor, se_y;
 
             ncomps=1; // if we increase this, then we must fill the remainder
             area[0]=1.0;
@@ -511,7 +509,6 @@ public:
             // endpoint E0 up to nearest 100 keV, and dividing by NBIN to get
             // binwidth.
 
-            e1=0.001;         // may be too low for some spectra (e.g. Tl-204)
             de=((int)(etop[0]*10.0+1)/10.)/nbin; // round up to nearest 100kev;
             // /=     NBIN
             //cout << "Binwidth " << de << endl;
@@ -679,14 +676,13 @@ protected:
 
         double ff[4];
         double dfac[4]= {1.0, 3.0, 15.0, 105.0};
-        double pi,c137,az,g1,w,rad,pr,y,x1,gk,bb,cc,dd,x2;
+        double pi,c137,az,w,rad,pr,y,x1,gk,bb,cc,dd,x2;
 
         complex<double> aa;
 
         pi  = acos(-1.0);
         c137= 137.036; // 1/ fine structure constant
         az  = z/c137;
-        g1  = sqrt(1.0-az*az);
         w   = sqrt(p*p+1.0);
         rad = radf/386.159;
         pr  = p*rad;


### PR DESCRIPTION
Fix compile warnings related to the radionuclide source. The following compile options were used:

`-g -O3 -Wall -Wextra -Wno-unused-parameter -Wno-sign-compare`
