### PR TITLE
Fix AUSCALL for relaxation vacancy cut-offs

### DIFF
--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -717,11 +717,9 @@ REPLACE {;COMIN/RELAX-DATA/;} WITH {;
     relax_state($MAXRELAX),    "final state of the transition"
     relax_prob($MAXRELAX),     "probability"
     relax_atbin($MAXRELAX),    "used for alias sampling"
-    relax_ntot,                "total number of transitions in the list"
-    relax_initiator_q;         "the charge of the particle initiating relax"
+    relax_ntot;                "total number of transitions in the list"
   $REAL     relax_prob;
-  $INTEGER  relax_first, relax_ntran, relax_state, relax_atbin, relax_ntot,
-            relax_initiator_q;
+  $INTEGER  relax_first, relax_ntran, relax_state, relax_atbin, relax_ntot;
 };
 ;  "---------- BUFFER FLUSH SEMICOLON ----------"
 

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -778,7 +778,7 @@ IF( ibcmpl = 1 | ibcmpl = 3 ) [
     " Shell vacancy "
     IF( Uj > 1e-3 ) [
         edep = pzero;
-        relax_initiator_q = 0; "particle initiating relaxations is photon"
+
         call relax(Uj,shn_array(j),iz_array(j));
         "relax will put all particles with energies above ecut,pcut on the "
         "stack, the remaining energy will be scored in edep and deposited  "
@@ -5146,7 +5146,6 @@ IF( iq(np) = -1 ) [
 "   edep = e_vac; do_relax = .false.;
 "]
 IF( do_relax ) [
-    relax_initiator_q = 0; "a photon is initiating relaxations"
     call relax(e_vac,k,iZ);
 ]
 
@@ -5271,12 +5270,11 @@ IF( energy <= min_E ) [
                         "calling RELAX "
     edep_local = energy;
 
-    "particle initiating relaxations was photon"
-    IF( relax_initiator_q = 0 ) [
-        $AUSCALL($SPHOTONA);
-    ] ELSE [ "particle initiating relaxations was electron"
-        $AUSCALL($SELECTRONA);
-    ]
+    "Assign this energy deposition to an electron."
+    "Note that this should NOT be treated as though it came from a photon,"
+    "even if a photon initiated the relaxations. Rather, energy remaining"
+    "in vacancies should be given to an electron or absorbed locally."
+    $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
 
     return;
 ]
@@ -5294,12 +5292,11 @@ e_check = 0; e_array(n_vac) = energy;
 
         edep_local = Ei;
 
-        "particle initiating relaxations was photon"
-        IF( relax_initiator_q = 0 ) [
-            $AUSCALL($SPHOTONA);
-        ] ELSE [ "particle initiating relaxations was electron"
-            $AUSCALL($SELECTRONA);
-        ]
+        "Assign this energy deposition to an electron."
+        "Note that this should NOT be treated as though it came from a photon,"
+        "even if a photon initiated the relaxations. Rather, energy remaining"
+        "in vacancies should be given to an electron or absorbed locally."
+        $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
 
         IF( n_vac > 0 ) goto :START: ;
         EXIT;
@@ -5721,13 +5718,11 @@ IF (shell_egs > 4) [
     edep = Evac;        "add energy of vacancy to edep"
     edep_local = Evac;  "set value of edep_local to energy of vacancy"
 
-    IF( relax_initiator_q = 0 ) [
-        "particle initiating relaxations was photon"
-        $AUSCALL($SPHOTONA);  "call ausgab with iarg=33"
-    ] ELSE [
-        "particle initiating relaxations was electron"
-        $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
-    ]
+    "Assign this energy deposition to an electron."
+    "Note that this should NOT be treated as though it came from a photon,"
+    "even if a photon initiated the relaxations. Rather, energy remaining"
+    "in vacancies should be given to an electron or absorbed locally."
+    $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
 
     return; "invokes $AUSCALL($PHOTXAUS) in COMPT;"
 ]
@@ -5740,13 +5735,11 @@ LOOP [ "from here to end of routine over all vacancies created"
         edep += Evac;         "add energy of vacancy to edep"
         edep_local = Evac;    "set value of edep_local to energy of vacancy"
 
-        IF( relax_initiator_q = 0 ) [
-            "particle initiating relaxations was photon"
-            $AUSCALL($SPHOTONA);  "call ausgab with iarg=33"
-        ] ELSE [
-            "particle initiating relaxations was electron"
-            $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
-        ]
+        "Assign this energy deposition to an electron."
+        "Note that this should NOT be treated as though it came from a photon,"
+        "even if a photon initiated the relaxations. Rather, energy remaining"
+        "in vacancies should be given to an electron or absorbed locally."
+        $AUSCALL($SELECTRONA); "call ausgab with iarg=34"
 
         go to :VACANCY:;      "exit loop and if Nvac still 0, exit routine"
     ]
@@ -7479,7 +7472,6 @@ IF( pese2 > ae(medium) ) [
     $AUSCALL($SELECTRONA);
 ]
 "ish ranges from 1 to 4 for K,L1,L2,L3 shells"
-relax_initiator_q = -1; "particle initiating relaxations is electron"
 call relax(Uj,ish,iZ);
 
 IF( edep > 0 ) [ $AUSCALL($PHOTXAUS); ]


### PR DESCRIPTION
Fix the `AUSCALL` related to relaxation vacancies below the cut-off energy, or in the outer shell. The `AUSCALL` was changed to always treat the energy deposition as though it came from an electron. Previously, it was differentiated based on the charge of the particle initiating the relaxation. All references to `relax_initiator_q` have been removed, since they are no longer used.

This problem was discovered by plotting `mu_en/rho` as a function of energy, using the g application. The value of `mu_en/rho` for air was underestimated, due to the assignment of energy to radiative losses in these vacancy cut-off depositions.

Only applications using `iarg=33` and `34` are affected. Namely, `g` and `dosrznrc`. This bug was introduced in PR #285, commit ba288e0, and was not present in the `master` branch.