### PR TITLE
Add EGS_DynamicSource class

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -56,7 +56,7 @@ geometry_libs = egs_planes egs_cd_geometry egs_gtransformed egs_nd_geometry \
 source_libs = egs_collimated_source egs_isotropic_source egs_parallel_beam \
               egs_point_source egs_source_collection egs_transformed_source \
               egs_beam_source egs_phsp_source egs_angular_spread \
-              iaea_phsp_source egs_radionuclide_source
+              iaea_phsp_source egs_radionuclide_source egs_dynamic_source
 
 shape_libs = egs_circle egs_ellipse egs_extended_shape egs_gaussian_shape \
              egs_line_shape egs_polygon_shape egs_rectangle egs_shape_collection \

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -178,6 +178,15 @@ public:
         return 0;
     };
 
+    /* A virtual function which can be implemented in derived classes
+    * to return a fractional monitor unit associated with each source
+    * particle.  Currently only makes sense for IAEA_PhspSource and
+    * EGS_BeamSource.
+    */
+    virtual EGS_Float getMu() {
+        return -1;
+    };
+
     /*! \brief Get the shower index for radionuclide emissions
      *
      * This method is only reimplemented by EGS_RadionuclideSource. It

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.h
@@ -76,6 +76,9 @@ typedef void (*FinishFunction)();
 typedef void (*SampleFunction)(EGS_Float *, EGS_Float *, EGS_Float *,
                                EGS_Float *, EGS_Float *, EGS_Float *, EGS_Float *, EGS_Float *,
                                EGS_I32 *, EGS_I32 *, EGS_I64 *, EGS_I32 *);
+typedef void (*MotionSampleFunction)(EGS_Float *, EGS_Float *, EGS_Float *,
+                                     EGS_Float *, EGS_Float *, EGS_Float *, EGS_Float *, EGS_Float *,
+                                     EGS_I32 *, EGS_I32 *, EGS_I64 *, EGS_I32 *, EGS_Float *);
 typedef void (*MaxEnergyFunction)(EGS_Float *);
 
 /*! \brief A BEAM simulation source
@@ -148,6 +151,14 @@ public:
     EGS_Float getFluence() const {
         return count;
     };
+    EGS_Float getMu() {
+        if (mu_stored) {
+            return mu;
+        }
+        else {
+            return -1.0;
+        }
+    };
     bool storeState(ostream &data) const {
         return egsStoreI64(data,count);
     };
@@ -182,11 +193,15 @@ protected:
     FinishFunction finish;  /*!< The function to be called at the end of the
                                  simulation */
     SampleFunction sample;  //!< The function that returns the next particle
+    MotionSampleFunction motionsample; //< Use this instead because we may want
+    //< to synchronize dynamic source with this
 
     bool        is_valid;
+    bool        mu_stored;  //!< true if mu index stored
     string      the_file_name;
     ifstream    the_file;
     EGS_Float   Emax;
+    EGS_Float   mu;
     EGS_I64     count;
 
     // filters
@@ -196,12 +211,21 @@ protected:
 
     // temporary particle storage
     int         q_save, latch_save;
-    EGS_Float   E_save, wt_save;
+    EGS_Float   E_save, wt_save, mu_save;
     EGS_Vector  x_save, u_save;
 
     // reusing particles
     int         n_reuse_photon, n_reuse_electron;
     int         i_reuse_photon, i_reuse_electron;
+
+    // stored info for first particle read in
+    // need this because we now query the data to see
+    // if mu index is passed by the source
+    EGS_Float tei,txi,tyi,tzi,tui,tvi,twi,twti,tmui;
+    int tqi,tlatchi,tiphati;
+    EGS_I64     counti;
+    bool  use_iparticle; // true if we want to use the above data instead
+    // of calling motionsample
 
 };
 

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/Makefile
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/Makefile
@@ -1,0 +1,44 @@
+
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build dynamic source
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Iwan Kawrakow, 2005
+#
+#  Contributors:    Blake Walters
+#
+###############################################################################
+
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_DYNAMIC_SOURCE_DLL
+
+library = egs_dynamic_source
+lib_files = egs_dynamic_source
+my_deps = $(common_source_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
@@ -1,0 +1,189 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ dynamic source
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:         Blake Walters, 2017
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+
+/*! \file egs_dynamic_source.cpp
+ *  \brief A dynamic source
+ *  \BW
+ */
+
+#include "egs_dynamic_source.h"
+#include "egs_input.h"
+
+EGS_DynamicSource::EGS_DynamicSource(EGS_Input *input,
+                                     EGS_ObjectFactory *f) : EGS_BaseSource(input,f), source(0), valid(true) {
+    EGS_Input *isource = input->takeInputItem("source",false);
+    if (isource) {
+        source = EGS_BaseSource::createSource(isource);
+        delete isource;
+    }
+    if (!source) {
+        string sname;
+        int err = input->getInput("source name",sname);
+        if (err)
+            egsWarning("EGS_DynamicSource: missing/wrong inline source "
+                       "definition and missing wrong 'source name' input\n");
+        else {
+            source = EGS_BaseSource::getSource(sname);
+            if (!source) egsWarning("EGS_DynamicSource: a source named %s"
+                                        " does not exist\n",sname.c_str());
+        }
+    }
+    //now read inputs relevant to dynamic source
+    //see if user wants to synchronize source with mu read from
+    //iaea phsp or beam simulation source
+    vector<string> sync_options;
+    sync_options.push_back("no");
+    sync_options.push_back("yes");
+    sync = input->getInput("synchronize motion",sync_options,0);
+    if (sync && source->getObjectType()!="IAEA_PhspSource" &&
+            source->getObjectType()!="EGS_BeamSource") {
+        egsWarning("EGS_DynamicSource: source motion can only be synchronized with a source of type iaea_phsp_source or egs_beam_source.\n  Will not synchronize.\n");
+        sync = false;
+    }
+
+    //get control points
+    EGS_Input *dyninp = input->takeInputItem("motion");
+    if (dyninp) {
+        //get control points
+        ncpts=0;
+        vector<EGS_Float> point;
+        EGS_ControlPoint cpt;
+        stringstream itos;
+        int err;
+        int icpts=1;
+        itos << icpts;
+        string sstring = "control point " + itos.str();
+        while (!(err = dyninp->getInput(sstring,point))) {
+            if (point.size()!=8) {
+                egsWarning("EGS_DynamicSource: control point %i does not specify 8 values.\n",icpts);
+                valid = false;
+            }
+            else {
+                if (ncpts>0 && point[7] < cpts[ncpts-1].mu) {
+                    egsWarning("EGS_DynamicSource: mu index of control point %i < mu index of control point %i\n",icpts,ncpts);
+                    valid = false;
+                }
+                else if (point[7] < 0.) {
+                    egsWarning("EGS_DynamicSource: mu index of control point %i < 0.0\n",icpts);
+                    valid = false;
+                }
+                else {
+                    ncpts++;
+                    if (ncpts ==1 && point[7] > 0.0) {
+                        egsWarning("EGS_DynamicSource: mu index of control point 1 > 0.0.  This will generate many warning messages.\n");
+                    }
+                    //set cpt values
+                    cpt.iso = EGS_Vector(point[0],point[1],point[2]);
+                    cpt.dsource = point[3];
+                    cpt.theta = point[4];
+                    cpt.phi = point[5];
+                    cpt.phicol = point[6];
+                    cpt.mu = point[7];
+                    //add it to the vector of control points
+                    cpts.push_back(cpt);
+                    icpts++;
+                    itos.str("");
+                    itos << icpts;
+                    sstring = "control point " + itos.str();
+                }
+            }
+        }
+        if (ncpts<=1) {
+            egsWarning("EGS_DynamicSource: not enough or missing control points.\n");
+            valid = false;
+        }
+        if (cpts[ncpts-1].mu == 0.0) {
+            egsWarning("EGS_DynamicSource: mu index of last control point = 0.  Something's wrong.\n");
+            valid = false;
+        }
+        else {
+            //normalize mu index to max. value
+            for (int i=0; i<ncpts-1; i++) {
+                cpts[i].mu /= cpts[ncpts-1].mu;
+            }
+        }
+    }
+    else {
+        egsWarning("EGS_DynamicSource: no control points input.\n");
+        valid = false;
+    }
+    setUp();
+}
+
+void EGS_DynamicSource::setUp() {
+    //most setup done in constructor
+    otype="EGS_DynamicSource";
+    if (!isValid()) {
+        description = "Invalid dynamic source";
+    }
+    else {
+        description = "Dynamic source based on\n";
+        description += source->getSourceDescription();
+        if (sync) {
+            description += "\n Source will be synched with mu values read in (if available).";
+        }
+    }
+}
+
+//actually select the rotation coordinates for the incident particle
+int EGS_DynamicSource::getCoord(EGS_Float rand, EGS_ControlPoint &ipt) {
+    int iindex=0;
+    int i;
+    for (i=0; i<ncpts; i++) {
+        if (rand < cpts[i].mu) {
+            iindex =i;
+            break;
+        }
+    }
+    if (i==ncpts) {
+        egsWarning("EGS_DynamicSource: could not locate control point.\n");
+        return 1;
+    }
+    EGS_Float factor = (rand-cpts[iindex-1].mu)/(cpts[iindex].mu-cpts[iindex-1].mu);
+    ipt.iso.x=cpts[iindex-1].iso.x+ (cpts[iindex].iso.x-cpts[iindex-1].iso.x)*factor;
+    ipt.iso.y=cpts[iindex-1].iso.y+ (cpts[iindex].iso.y-cpts[iindex-1].iso.y)*factor;
+    ipt.iso.z=cpts[iindex-1].iso.z+ (cpts[iindex].iso.z-cpts[iindex-1].iso.z)*factor;
+    ipt.dsource=cpts[iindex-1].dsource+ (cpts[iindex].dsource-cpts[iindex-1].dsource)*factor;
+    ipt.theta=cpts[iindex-1].theta+ (cpts[iindex].theta-cpts[iindex-1].theta)*factor;
+    ipt.phi=cpts[iindex-1].phi+ (cpts[iindex].phi-cpts[iindex-1].phi)*factor;
+    ipt.phicol=cpts[iindex-1].phicol+ (cpts[iindex].phicol-cpts[iindex-1].phicol)*factor;
+    return 0;
+};
+
+extern "C" {
+
+    EGS_DYNAMIC_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        return
+            createSourceTemplate<EGS_DynamicSource>(input,f,"dynamic source");
+    }
+
+}

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
@@ -1,0 +1,307 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ dynamic source headers
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Blake Walters, 2017
+#
+#  Contributors:    Reid Townson
+#
+###############################################################################
+*/
+
+
+/*! \file egs_dynamic_source.h
+ *  \brief A source with simulated time-varying rotations/translations
+ *  \BW
+ */
+
+#ifndef EGS_DYNAMIC_SOURCE_
+#define EGS_DYNAMIC_SOURCE_
+
+#include "egs_vector.h"
+#include "egs_base_source.h"
+#include "egs_rndm.h"
+#include "egs_shapes.h"
+#include <string>
+#include <sstream>
+
+
+#ifdef WIN32
+
+    #ifdef BUILD_DYNAMIC_SOURCE_DLL
+        #define EGS_DYNAMIC_SOURCE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_DYNAMIC_SOURCE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_DYNAMIC_SOURCE_LOCAL
+
+#else
+
+    #ifdef HAVE_VISIBILITY
+        #define EGS_DYNAMIC_SOURCE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_DYNAMIC_SOURCE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_DYNAMIC_SOURCE_EXPORT
+        #define EGS_DYNAMIC_SOURCE_LOCAL
+    #endif
+
+#endif
+
+/*! \brief A source with time-varying rotations/translations
+
+  \ingroup Sources
+
+The dynamic source allows the user to simulate dynamic motion of
+any other source.  The user specifies a number of control points,
+where each control point comprises a set of incident polar coordinates
+plus a monitor unit index.  The polar coordinates are:
+(xiso,yiso,ziso) = coordinates of isocentre of rotation (cm)
+dsource = length of vector from isocentre to source origin (cm).
+          With no rotations, +ve dsource is along the -Z axis.
+theta = angle of rotation of dsource about the Y-axis (deg).
+        +ve values define clockwise rotations.  Angle is
+        defined relative to the -Z axis.
+phi = angle of rotation of dsource about Z-axis (deg).
+      +ve values define clockwise rotations.  Angle is defined
+      relative to the +X-axis.
+phicol = angle of rotation of source about -dsource (deg).  +ve
+         value defines clockwise rotations.
+The monitor unit index, mu, controls dynamic motion as described
+below.
+The generic input is:
+\verbatim
+:start source:
+    library = egs_dynamic_source
+    name = some_name
+    source name = the name of a previously defined source
+    synchronize motion = yes or no (default)
+    :start motion:
+       control point 1 = xiso(1) yiso(1) ziso(1) dsource(1) theta(1) phi(1) phicol(1) mu(1)
+       control point 2 = xiso(2) yiso(2) ziso(2) dsource(2) theta(2) phi(2) phicol(2) mu(2)
+       .
+       .
+       .
+       control point N = xiso(N) yiso(N) ziso(N) dsource(N) theta(N) phi(N) phicol(N) mu(N)
+    :stop motion:
+:stop source:
+\endverbatim
+Control points must be defined such that mu(i+1)>=mu(i), where mu(i)
+is the value of mu for control point i.  The mu(i) are automatically
+normalized by mu(N), where N is the number of control points.
+Continuous, dynamic motion between control points is simulated by choosing a random
+number, R, on (0,1] and, for mu(i)<R<=mu(i+1), setting incident source
+coordinate, P, where P is one of xiso, yiso, ziso, dsource, theta,
+phi, or phicol, using:
+P=P(i)+[P(i+1)-P(i)]/[mu(i+1)-mu(i)]*[R-mu(i)]
+Note that this scheme for generating incident source coordinates really
+only makes sense if mu(1)=0.0.  However, the source can function
+with mu(1)>0.0, in the case where a user desires to eliminate particles
+associated with a range of mu values, but there will be a lot of
+warning messages.
+
+A simple example is shown below.  This first defines a monoenergetic
+(1 MV) photon source in the Z-direction collimated to a 2x2 field
+centred on the Z-axis.  The control points place the source a
+distance, dsource, of 100 cm above the isocentre at (0,0,0).  Control
+points 1 and 2 rotate the source clockwise around the Y-axis (phi=0)
+through theta=0-360 degrees, while control points 3 and 4 rotate
+the source clockwise around the Z-axis (phi=90 degrees) through
+phi=0-360 degrees.  Note that mu(2)-mu(1)=mu(4)-mu(3), so the rotations
+around Z and Y are carried out for an equal number of incident photons.
+If the source being made to move dynamically supplies its own monitor
+unit index (iaea_phsp_source and egs_beam_source only), then the dynamic
+motion can be synchronized with the motion of component modules
+(MLC's, jaws) within the source by setting "synchronize motion"
+to "yes".
+\verbatim
+:start source definition:
+    :start source:
+        library = egs_parallel_beam
+        name = my_parallel_source
+        :start shape:
+            library = egs_rectangle
+            rectangle = -.1 -.1 .1 .1
+        :stop shape:
+        direction = 0 0 1
+        charge = 0
+        :start spectrum:
+            type = monoenergetic
+            energy = 1.0
+        :stop spectrum:
+    :stop source:
+    :start source:
+        library = egs_dynamic_source
+        name = my_source
+        source name = my_parallel_source
+        :start motion:
+            control point 1 = 0 0 0 100 0 0 0 0
+            control point 2 = 0 0 0 100 360 0 0 0.5
+            control point 3 = 0 0 0 100 90 0 0 0.5
+            control point 4 = 0 0 0 100 90 360 0 1.0
+        :stop motion:
+    :stop source:
+
+    simulation source = my_source
+
+:stop source definition:
+\endverbatim
+*/
+
+class EGS_DYNAMIC_SOURCE_EXPORT EGS_DynamicSource :
+    public EGS_BaseSource {
+
+public:
+
+
+    struct EGS_ControlPoint {
+
+        EGS_Vector iso; //isocentre position
+        EGS_Float dsource; //source-isocentre distance
+        EGS_Float theta; //angle of rotation about Y-axis
+        EGS_Float phi;  //angle of rotation about Z-axis
+        EGS_Float phicol; //angle of rotation in source plane
+        EGS_Float mu; //monitor unit index for control point
+    };
+
+    /*! \brief Construct a dynamic source using \a Source as the
+    source and cpts as the control points.  Not sure if this
+    will ever be used but here just in case.
+    */
+    EGS_DynamicSource(EGS_BaseSource *Source, vector<EGS_ControlPoint> cpts,
+                      const string &Name="", EGS_ObjectFactory *f=0) :
+        EGS_BaseSource(Name,f), source(Source), valid(true) {
+        //do some checks on cpts
+        if (cpts.size()<2) {
+            egsWarning("EGS_DynamicSource: not enough or missing control points.\n");
+            valid = false;
+        }
+        else {
+            if (cpts[0].mu > 0.0) {
+                egsWarning("EGS_DynamicSource: mu index of control point 1 > 0.0.  This will generate many warning messages.\n");
+            }
+            int npts = cpts.size();
+            for (int i=0; i<npts; i++) {
+                if (i>0 && cpts[i].mu < cpts[i-1].mu) {
+                    egsWarning("EGS_DynamicSource: mu index of control point %i < mu index of control point %i\n",i,i-1);
+                    valid = false;
+                }
+                if (cpts[i].mu<0.0) {
+                    egsWarning("EGS_DynamicSource: mu index of control point %i < 0.0\n",i);
+                    valid = false;
+                }
+            }
+            //normalize mu values
+            for (int i=0; i<npts-1; i++) {
+                cpts[i].mu /= cpts[npts-1].mu;
+            }
+        }
+        setUp();
+    };
+
+    /*! \brief Construct a dynamic source from the user input */
+    EGS_DynamicSource(EGS_Input *, EGS_ObjectFactory *f=0);
+
+    ~EGS_DynamicSource() {
+        EGS_Object::deleteObject(source);
+    };
+
+    EGS_I64 getNextParticle(EGS_RandomGenerator *rndm,
+                            int &q, int &latch, EGS_Float &E, EGS_Float &wt,
+                            EGS_Vector &x, EGS_Vector &u) {
+        int err = 1;
+        EGS_ControlPoint ipt;  //the actual rotation coords
+        EGS_Float rand;
+        EGS_I64 c;
+        while (err) {
+            c = source->getNextParticle(rndm,q,latch,E,wt,x,u);
+            if (sync) {
+                rand = source->getMu();
+                if (rand<0) {
+                    egsWarning("EGS_DynamicSource: You have selected synchronization of dynamic source with %s\n",source->getObjectName().c_str());
+                    egsWarning("However, this source does not return mu values for each particle.  Will turn off synchronization.\n");
+                    sync = false;
+                }
+            }
+            if (!sync) {
+                rand = rndm->getUniform();
+            }
+            err = getCoord(rand,ipt);
+        }
+
+        //translate source in Z
+        x.z=x.z-ipt.dsource;
+        //get the rotation matrices
+        ipt.phicol *= M_PI/180;
+        ipt.theta *= M_PI/180;
+        ipt.phi *= M_PI/180;
+        EGS_RotationMatrix Rcol(EGS_RotationMatrix::rotZ(ipt.phicol));
+        EGS_RotationMatrix Rtheta(EGS_RotationMatrix::rotY(ipt.theta));
+        EGS_RotationMatrix Rphi(EGS_RotationMatrix::rotZ(ipt.phi));
+        //apply rotations in specific order and then translate relative
+        //to the isocentre
+        u=Rphi*Rtheta*Rcol*u;
+        x=Rphi*Rtheta*Rcol*x + ipt.iso;
+        return c;
+    };
+    EGS_Float getEmax() const {
+        return source->getEmax();
+    };
+    EGS_Float getFluence() const {
+        return source->getFluence();
+    };
+    bool storeState(ostream &data) const {
+        return source->storeState(data);
+    };
+    bool setState(istream &data) {
+        return source->setState(data);
+    };
+    bool addState(istream &data_in) {
+        return source->addState(data_in);
+    };
+    void resetCounter() {
+        source->resetCounter();
+    };
+
+    bool isValid() const {
+        return (valid && source != 0);
+    };
+
+protected:
+
+    EGS_BaseSource *source; //!< The source being rotated
+
+    vector<EGS_ControlPoint> cpts;  //control point
+
+    int ncpts;  //no. of control points
+
+    bool valid; //is this a valid source
+
+    bool sync; //set to true if source motion synched with mu read from
+    //iaea phsp or beam simulation source
+
+    int getCoord(EGS_Float rand, EGS_ControlPoint &ipt);
+
+    void setUp();
+
+};
+
+#endif

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
@@ -229,22 +229,21 @@ public:
                             EGS_Vector &x, EGS_Vector &u) {
         int err = 1;
         EGS_ControlPoint ipt;  //the actual rotation coords
-        EGS_Float rand;
         EGS_I64 c;
         while (err) {
             c = source->getNextParticle(rndm,q,latch,E,wt,x,u);
             if (sync) {
-                rand = source->getMu();
-                if (rand<0) {
+                pmu = source->getMu();
+                if (pmu<0) {
                     egsWarning("EGS_DynamicSource: You have selected synchronization of dynamic source with %s\n",source->getObjectName().c_str());
                     egsWarning("However, this source does not return mu values for each particle.  Will turn off synchronization.\n");
                     sync = false;
                 }
             }
             if (!sync) {
-                rand = rndm->getUniform();
+                pmu = rndm->getUniform();
             }
-            err = getCoord(rand,ipt);
+            err = getCoord(pmu,ipt);
         }
 
         //translate source in Z
@@ -267,6 +266,9 @@ public:
     };
     EGS_Float getFluence() const {
         return source->getFluence();
+    };
+    EGS_Float getMu() {
+        return pmu;
     };
     bool storeState(ostream &data) const {
         return source->storeState(data);
@@ -298,7 +300,10 @@ protected:
     bool sync; //set to true if source motion synched with mu read from
     //iaea phsp or beam simulation source
 
-    int getCoord(EGS_Float rand, EGS_ControlPoint &ipt);
+    int getCoord(const EGS_Float rand, EGS_ControlPoint &ipt);
+
+    EGS_Float pmu; //monitor unit index corresponding to particle
+    //could just be a random number.
 
     void setUp();
 

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
@@ -287,6 +287,10 @@ public:
         return (valid && source != 0);
     };
 
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
+        source->setSimulationChunk(nstart, nrun);
+    };
+
 protected:
 
     EGS_BaseSource *source; //!< The source being rotated

--- a/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.h
@@ -186,6 +186,10 @@ public:
         return (source != 0);
     };
 
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
+        source->setSimulationChunk(nstart, nrun);
+    };
+
 protected:
 
     EGS_BaseSource *source; //!< The source being transformed

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -176,6 +176,7 @@ void IAEA_PhspSource::openFile(const string &phsp_file) {
         return;
     }
     mode2=false;
+    i_zlast = -1;
     for (int i=0; i< n_extra_floats; i++) {
         if (extrafloat_types[i]==3) {
             mode2=true;

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -183,6 +183,18 @@ void IAEA_PhspSource::openFile(const string &phsp_file) {
             break;
         }
     }
+    //now see if mu index is stored in the file
+    //assume it is the first variable stored in extra_float
+    //after zlast
+    i_mu=-1;
+    mu_stored=false;
+    if (n_extra_floats > i_zlast+1) {
+        if (extrafloat_types[i_zlast+1] == 0) {
+            i_mu=i_zlast+1;
+            mu_stored=true;
+            egsInformation("IAEA_PhspSource::openFile: Mu index included in data in %s.IAEAphsp\n",phsp_file.c_str());
+        }
+    }
 
     //determine array index of latch
     latch_stored=false;
@@ -327,6 +339,9 @@ EGS_I64 IAEA_PhspSource::getNextParticle(EGS_RandomGenerator *, int &q,
         if (mode2) {
             p.zlast = extrafloattemp[i_zlast];
         }
+        if (mu_stored) {
+            p.mu = extrafloattemp[i_mu];
+        }
         if (swap_bytes) {
             egsSwapBytes(&p.q);
             egsSwapBytes(&nstat);
@@ -340,6 +355,7 @@ EGS_I64 IAEA_PhspSource::getNextParticle(EGS_RandomGenerator *, int &q,
             egsSwapBytes(&p.u);
             egsSwapBytes(&p.v);
             egsSwapBytes(&p.w);
+            egsSwapBytes(&p.mu);
         }
         //do check here because we need the swapped version of nstat
         if (nstat<0) {

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
@@ -160,6 +160,14 @@ public:
         double aux = ((double) Nread)/((double) Nparticle);
         return Pinc*aux;
     };
+    EGS_Float getMu() {
+        if (mu_stored) {
+            return p.mu;
+        }
+        else {
+            return -1.0;
+        }
+    };
     bool storeState(ostream &data) const {
         data << endl;
         bool res = egsStoreI64(data,Nread);
@@ -243,6 +251,7 @@ protected:
     string      the_file_name; //!< The phase-space file name
     bool        mode2;         //!< \c true, if a MODE2 file (i.e. storing Zlast)
     bool        latch_stored;  //!< true if LATCH is stored in data
+    bool        mu_stored;  //!< true if mu index stored
     bool        swap_bytes;    /*!< \c true, if phase-space file was generated
                                 on a CPU with different endianness */
     EGS_Float   Emax,    //!< Maximum k.e. (obtained from the phsp file)
@@ -264,7 +273,8 @@ protected:
     int         iaea_fileid; //!< phsp file unit no.
     int         n_extra_floats; //!< no. of extra floats stored in phsp file
     int         n_extra_longs; //!< no. of extra longs stored in phsp file
-    int         i_zlast;   //!< index of zlast in extra_longs array
+    int         i_zlast;   //!< index of zlast in extra_floats array
+    int         i_mu;   //!< index of mu index in extra_floats array
     int         i_latch;   //!< index of latch in extra_floats array
 
     bool        first;
@@ -282,7 +292,7 @@ protected:
 #ifndef SKIP_DOXYGEN
     struct EGS_LOCAL BeamParticle {
         int  latch, q;
-        float E, u, v, w, x, y, z, wt, zlast;
+        float E, u, v, w, x, y, z, wt, zlast, mu;
     };
     BeamParticle  p;
 #endif


### PR DESCRIPTION
An EGS_DynamicSource allows the user to simulate dynamic (time-varying)
motion of any source during a single calculation.  Continuous motion
of the source is simulated between user-defined control points, where
each control point defines a set of incident polar coordinates and an
associated fractional monitor unit (mu) index.

If the source is an IAEA-format phase space file or a BEAM simulation
source, then, provided the source stores the value of mu for each
particle, the user has the option to use these when setting incident
source coordinates, thus synchronizing the motion of EGS_DynamicSource
with jaw and MLC opening coordinates in the upstream BEAM simulation.

For phase space and BEAM simulation sources, EGS_DynamicSource
essentially provides the same functionality as sources 20 and 21
in DOSXYZnrc, as documented by Lobo & Popescu, Phys. Med. Biol.,
55:4431-4443 (2010).

Note that implementation of this source required the implementation
of a new method, EGS_Float getMu(), in egs_base_source.  As
reimplemented in iaea_phsp_source and egs_beam_source, getMu returns
the value of mu associated with a particle.

See the source documentation for more info and an example input.