### PR TITLE
Add beta spectrum exceptions and change radionuclide inputs

### DIFF
--- a/HEN_HOUSE/egs++/egs_ensdf.cpp
+++ b/HEN_HOUSE/egs++/egs_ensdf.cpp
@@ -193,7 +193,7 @@ unsigned short int setZ(string id) {
     return Z;
 }
 
-EGS_Ensdf::EGS_Ensdf(const string isotope, const string ensdf_filename,
+EGS_Ensdf::EGS_Ensdf(const string nuclide, const string ensdf_filename,
                      const string useFluor, int verbosity) {
 
     verbose = verbosity;
@@ -203,14 +203,14 @@ EGS_Ensdf::EGS_Ensdf(const string isotope, const string ensdf_filename,
         ensdf_file.close();
     }
 
-    radionuclide = isotope.substr(0, isotope.find_last_of("."));
+    radionuclide = nuclide.substr(0, nuclide.find_last_of("."));
 
     // The parent element
     string element = radionuclide.substr(0, radionuclide.find("-"));
     Z = setZ(element);
 
     egsInformation("EGS_Ensdf::EGS_Ensdf: Isotope: "
-                   "%s\n",isotope.c_str());
+                   "%s\n",nuclide.c_str());
     egsInformation("EGS_Ensdf::EGS_Ensdf: Now loading ensdf file: "
                    "\"%s\"\n",ensdf_filename.c_str());
 
@@ -665,7 +665,7 @@ void EGS_Ensdf::parseEnsdf(vector<string> ensdf) {
                     }
 
                     if (verbose && myMetastableGammaRecords.size() > 0) {
-                        egsInformation("EGS_Ensdf::parseEnsdf: Metastable isotope "
+                        egsInformation("EGS_Ensdf::parseEnsdf: Metastable nuclide "
                                        "detected.\n");
                     }
                 }
@@ -675,7 +675,7 @@ void EGS_Ensdf::parseEnsdf(vector<string> ensdf) {
         }
     }
     if (verbose && myMetastableGammaRecords.size() < 1) {
-        egsInformation("EGS_Ensdf::parseEnsdf: No metastable isotopes "
+        egsInformation("EGS_Ensdf::parseEnsdf: No metastable nuclides "
                        "detected.\n");
     }
 

--- a/HEN_HOUSE/egs++/egs_ensdf.h
+++ b/HEN_HOUSE/egs++/egs_ensdf.h
@@ -415,23 +415,33 @@ private:
 
 \ingroup egspp_main
 
-Reads in a decay spectrum file in ensdf format, and builds the decays into an
-object oriented tree structure. This decay structure is useful for
+Parses decay spectrum file in ensdf format, and builds the decay scheme into an
+object oriented tree-like structure. This decay structure is useful for
 \ref EGS_RadionuclideSpectrum used by \ref EGS_RadionuclideSource.
 
-Uncertainties on values are ignored! The energies and intensities for various
-emissions are taken as is. Very low probability emissions are discarded.
+Note: Uncertainties on values are ignored. The energies and intensities for various
+emissions are taken as is. Very low probability emissions (<1e-10) are discarded.
 
 When processing an ensdf file, only the following records are considered:
 Comment, Parent, Normalization, Level, Beta-, EC / Beta+, Alpha, Gamma.
 
-When the spectrum input parameter "ensdf fluorescence and auger" is set to
-"yes", the
+When the input '<code>atomic relaxations = ensdf</code>' in
+\ref EGS_RadionuclideSpectrum, the
 X-Ray fluorescence and Auger emissions are obtained from ensdf Comment records.
-If a single intensity is present for a combination of lines (but a single
-energy is not provided), then the average energy of the lines is used.
+This assumes a particular format for the data currently used by the LNHB,
+which may or may not be forward compatible. When using this option,
+be aware that fluorescent photons and Auger emissions are modeled statistically.
+In other
+words, the relaxation emissions are not correlated with specific disintegration
+events. If you are coincidence counting, use
+'<code>atomic relaxations = eadl</code>'.
+
+There are a few nuances to the data interpretation.
+If a single emission intensity value is present for a combination of lines (where
+multiple energies are provided), then the average energy of the lines is used.
 For example, in the
-case below a single line of energy 97.4527 keV would be used.
+case below a single line of energy 97.4527 keV would be used with an emission
+intensity of 0.57 per 100 disintegrations.
 \verbatim
 221FR T        96.815         |]                 XKB3
 221FR T        97.474         |]  0.57     5     XKB1
@@ -451,11 +461,7 @@ would be used.
 \endverbatim
 
 The ensdf class has been tested on radionuclide data from
-http://www.nucleide.org/DDEP_WG/DDEPdata.htm
-
-ENSDF files from other sources may contain x-ray and Auger emissions formatted
-differently. In this case, "ensdf fluorescence and auger" should be set to "no"
- (this is the default).
+<a href="http://www.nucleide.org/DDEP_WG/DDEPdata.htm">LNHB DDEP</a>.
 
 */
 
@@ -466,7 +472,7 @@ public:
     /*! \brief Construct an ensdf object.
      *
      */
-    EGS_Ensdf(const string isotope, const string ensdf_filename="",
+    EGS_Ensdf(const string nuclide, const string ensdf_filename="",
               const string useFluor="yes", int verbosity=1);
 
     /*! \brief Destructor. */
@@ -493,7 +499,6 @@ public:
 
 protected:
 
-    bool createIsotope(vector<string> ensdf);
     unsigned short int findAtomicWeight(string element);
     void parseEnsdf(vector<string> ensdf);
     void buildRecords();

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -128,34 +128,8 @@ EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
     egsInformation("EGS_RadionuclideSource: Activity [disintegrations/s]: %e\n",
                    activity);
 
-    // Calculate the duration of the experiment
-    // Based on ncase and activity
+    // Get the active application
     app = EGS_Application::activeApplication();
-    EGS_Input *inp = app->getInput();
-    EGS_Input *irc = 0;
-    double ncase_double = 0;
-    if (inp) {
-        irc = inp->getInputItem("run control");
-
-        EGS_Input *icontrol = irc->getInputItem("run control");
-        if (!icontrol) {
-            egsWarning("EGS_RadionuclideSource: no 'run control' "
-                       "input to determine 'ncase'\n");
-        }
-
-        err = icontrol->getInput("number of histories", ncase_double);
-        if (err) {
-            err = icontrol->getInput("ncase", ncase_double);
-            if (err) {
-                egsWarning("EGS_RadionuclideSource: missing/wrong 'ncase' or "
-                           "'number of histories' input\n");
-            }
-        }
-    }
-    else {
-        egsWarning("EGS_RadionuclideSource: no 'run control' "
-                   "input to determine 'ncase'\n");
-    }
 
     // Create the shape for source emissions
     vector<EGS_Float> pos;
@@ -308,7 +282,7 @@ EGS_I64 EGS_RadionuclideSource::getNextParticle(EGS_RandomGenerator *rndm, int
     EGS_Float edep = decays[i]->getEdep();
     if (edep > 0) {
         app->setEdep(edep);
-        int ireg = geom->isWhere(x);
+        int ireg = app->isWhere(x);
         app->userScoring(3, ireg);
     }
 

--- a/HEN_HOUSE/pegs4/density_corrections/compounds/water_icru90.density
+++ b/HEN_HOUSE/pegs4/density_corrections/compounds/water_icru90.density
@@ -31,4 +31,3 @@ water_icru90 calculated with ESTAR.f, I = 78 eV, rho = 0.998 g/cm3 (20 degree C)
  6.00E+03,1.516E+01  7.00E+03,1.547E+01  8.00E+03,1.574E+01  9.00E+03,1.597E+01
  1.00E+04,1.618E+01
  
-

--- a/HEN_HOUSE/specs/egspp1.spec
+++ b/HEN_HOUSE/specs/egspp1.spec
@@ -127,4 +127,4 @@ dep_user_code = $(USER_CODE).cpp array_sizes.h $(common_h_files1) \
         $(common_h_files2) $(other_dep_user_code)
 
 dep_egs_interface = $(EGS_INTERFACE)egs_interface2.c $(common_h_files1) \
-	array_sizes.h 
+	array_sizes.h


### PR DESCRIPTION
Add radionuclide beta spectrum exceptions to include some special shape factors. Affected radionuclides are Cl-36, I-129, Cs-137, Tl-204, and Bi-210.

Improve radionuclide source documentation.

Replace instances of `isotope` with `nuclide`. This includes the `EGS_RadionuclideSpectrum` input to specify the radionuclide.

Rename `EGS_RadionuclideSpectrum` input `ensdf fluorescence and auger` to `atomic relaxations` with `eadl` or `ensdf` options for improved clarity.

Also fix #313.