### PR TITLE
Fix doxygen warning about unknown alias

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -31,7 +31,7 @@
 
 /*! \file egs_fano_source.cpp
  *  \brief An Fano source
- *  \IK
+ *  \EM
  *  The Fano option allows have uniform particles per unit mass
  */
 

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
@@ -31,7 +31,7 @@
 
 /*! \file egs_fano_source.h
  *  \brief A Fano source
- *  \EMH
+ *  \EM
  */
 
 #ifndef EGS_FANO_SOURCE_


### PR DESCRIPTION
Fix doxygen warnings about an unknown alias for `EMH` in the fano source header file. Now the author is cited correctly.