### PR TITLE
Fix two bugs in iaea_phsp_source

### DIFF
--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
@@ -37,6 +37,8 @@
 #ifndef IAEA_PHSP_SOURCE_
 #define IAEA_PHSP_SOURCE_
 
+#define MAXEXTRAS 10
+
 #include "egs_vector.h"
 #include "egs_base_source.h"
 #include "egs_rndm.h"


### PR DESCRIPTION
1.  Arrays extrafloat_type, extralong_types, extrainttemp,
    extrafloattemp, could be initialized with zero dimension if
    the IAEA phsp did not store any addition int (e.g. latch)
    or float (e.g. zlast) variables for each particle.  These
    arrays are now given fixed dimension MAXEXTRAS.

2.  Source had the temerity to actually assign any latch
    value read from the phsp file to the incident particle, not
    realizing that, at least in the case of egs_chamber, this
    variable is used for setting splitting no.  Now, latch is
    set to 0, similar to egs_phsp_source.  This partially fixes
    the problem that @ojalaj had in Issue #314.