### PR TITLE
Fix #318: Bug when changing MXSTACK in array_sizes.h

### DIFF
--- a/HEN_HOUSE/specs/egspp1.spec
+++ b/HEN_HOUSE/specs/egspp1.spec
@@ -126,4 +126,5 @@ dep_user_code = $(USER_CODE).cpp array_sizes.h $(common_h_files1) \
         $(ABS_EGSPP)$(EGS_BASE_APPLICATION).h \
         $(common_h_files2) $(other_dep_user_code)
 
-dep_egs_interface = $(EGS_INTERFACE)egs_interface2.c $(common_h_files1)
+dep_egs_interface = $(EGS_INTERFACE)egs_interface2.c $(common_h_files1) \
+	array_sizes.h 


### PR DESCRIPTION
Added array_sizes.h to the compile dependencies for
egs_interface2.c in egspp1.spec.  As discovered by @ojalaj
when running egs_chamber, without this dependency, changes
to MXSTACK--the max. dimension of variables in the STACK
common block (Fortran)--were not propagated through to
the EGS_Stack definition in egs_interface2.  The result:
mismatched variable dimensions and zero results.

A temporary workaround was to type "make clean" before "make"
after changing MXSTACK.  This forced a recompilation of
egs_interface2.c.