### PR TITLE
Fix #321: Add getCharge method to EGS_BaseSimpleSource

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -715,6 +715,14 @@ public:
      */
     virtual EGS_Float getEmax() const {
         return s->maxEnergy();
+    };
+
+    /*! \brief Get the charge of the source.
+     *
+     * Simply returns the value of the (protected) attribute q.
+     */
+    virtual int getCharge() const {
+        return q;
     };
 
     /*! \brief Store the fluence state of this source to the data stream

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Frederic Tessier
 #                   Hubert Ho
+#                   Reid Townson
 #
 ###############################################################################
 */


### PR DESCRIPTION
Add a method to get the charge of an `EGS_BaseSimpleSource`.