### PR TITLE
Add region labels to cavity and docs

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/cavity.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/cavity.doxy
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Ernesto Mainegra-Hing
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -589,6 +590,13 @@ in [<em>Mainegra-Hing and Kawrakow, Medical Physics, 33 (8), 2006, 2683-2690</em
 a 13 times efficiency increase was observed for a 200 kVp X-ray beam when
 combining this technique with the <em>correlated scoring</em> technique
 provided by \c cavity.
+
+\section cavity_labels Region labels
+
+It is possible to use region labels in cavity, as described in
+\ref egs_chamber_labels. Once defined in a geometry, labels can be used
+anywhere you would otherwise type a list of global region numbers in a
+<b>\c cavity </b> input file.
 
 \section cavity_usage Usage
 

--- a/HEN_HOUSE/doc/src/pirs898-egs++/egs_chamber.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/egs_chamber.doxy
@@ -24,6 +24,7 @@
 #  Author:          Ernesto Mainegra-Hing, 2009
 #
 #  Contributors:    Iwan Kawrakow
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -342,6 +343,105 @@ of the relevant geometries in the following way:
      .
      enter as many as needed to compute desired perturbation factors
 \endverbatim
+
+\section egs_chamber_labels Region labels
+
+Tired of updating your lists of region numbers every time you change the
+geometry? Those days are over! Introducing: region labels.
+
+With region labels you can set a label to point to <em>local</em> region numbers
+in a geometry. When you use the label, the corresponding <em>global</em> region
+numbers will be determined and substituted.
+
+In short, insert a <b><code>set label =</code></b> line into the geometry that
+contains your region(s) of interest. In the example below, notice that we set
+the label named <b>\c mySphere1Label </b> to the local region 0. This region
+number is what you would expect if you loaded only <b>\c sphere1 </b> as your
+<em>simulation geometry</em>. Since there is only 1 sphere, there is only a
+single local region (indexed from 0), so we set the label to 0.
+
+To include many local regions, just use a space separated list (e.g. 0 1 3 5).
+
+\verbatim
+    :start geometry:
+        name        = sphere1
+        library     = egs_spheres
+        midpoint = 0 0 1
+        radii = 0.3
+        :start media input:
+            media = AIR521ICRU
+        :stop media input:
+
+        set label = mySphere1Label 0
+
+    :stop geometry:
+\endverbatim
+
+
+If we add more geometries, the global region number for the sphere above may
+change. Loading the following geometry into <b>\c egs_view </b> shows us that
+sphere1 has the global region number 1.
+
+\verbatim
+:start geometry definition:
+    :start geometry:
+        name        = my_box
+        library     = egs_box
+        box size    = 1 2 3
+        :start media input:
+            media = H2O521ICRU
+        :stop media input:
+    :stop geometry:
+    :start geometry:
+        name        = sphere1
+        library     = egs_spheres
+        midpoint = 0 0 1
+        radii = 0.3
+        :start media input:
+            media = AIR521ICRU
+        :stop media input:
+
+        set label = mySphere1Label 0
+
+    :stop geometry:
+    :start geometry:
+        name        = sphere2
+        library     = egs_spheres
+        midpoint = 0 0 -1
+        radii = 0.3
+        :start media input:
+            media = AIR521ICRU
+        :stop media input:
+    :stop geometry:
+    :start geometry:
+        name        = my_envelope
+        library     = egs_genvelope
+        base geometry = my_box
+        inscribed geometries = sphere1 sphere2
+    :stop geometry:
+    simulation geometry = my_envelope
+:stop geometry definition:
+\endverbatim
+
+Now in the scoring regions, rather than typing the global region 1 for
+<b>\c sphere1 </b>, we can use <b>\c mySphere1Label </b>.
+
+\verbatim
+
+:start scoring options:
+    silent = 0
+    :start calculation geometry:
+        geometry name = my_envelope
+        cavity regions = mySphere1Label
+        cavity mass = 1
+        cavity geometry = my_envelope
+    :stop calculation geometry:
+:stop scoring options:
+
+\endverbatim
+
+Labels can be used anywhere you would otherwise type a list of global region
+numbers in an <b>\c egs_chamber </b> input file.
 
 \section egs_chamber_usage Usage
 

--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Ernesto Mainegra-Hing
+#                   Reid Townson
 #
 ###############################################################################
 #
@@ -2271,14 +2272,17 @@ int Cavity_Application::initScoring() {
             int err = aux->getInput("geometry name",gname);
             int errx = aux->getInput("calculation name",cname);
             if( errx ) cname = gname;
+            string cavString;
             vector<int> cav;
-            int err1 = aux->getInput("cavity regions",cav);
+            int err1 = aux->getInput("cavity regions",cavString);
+            string apertString;
             vector<int> apert;
-            int err4 = aux->getInput("aperture regions",apert);
+            int err4 = aux->getInput("aperture regions",apertString);
             EGS_Float cmass;
             int err2 = aux->getInput("cavity mass",cmass);
+            string chargeString;
             vector<int> charge;
-            int err3 = aux->getInput("charge regions",charge);
+            int err3 = aux->getInput("charge regions",chargeString);
             if( err ) egsWarning("initScoring: missing/wrong 'geometry name' "
                     "input\n");
             if( err1 ) egsWarning("initScoring: missing/wrong 'cavity regions' "
@@ -2300,6 +2304,14 @@ int Cavity_Application::initScoring() {
                 if( !g ) egsWarning("initScoring: no geometry named %s -->"
                         " input ignored\n",gname.c_str());
                 else {
+
+                    g->getNumberRegions(cavString, cav);
+                    g->getLabelRegions(cavString, cav);
+                    g->getNumberRegions(apertString, apert);
+                    g->getLabelRegions(apertString, apert);
+                    g->getNumberRegions(chargeString, charge);
+                    g->getLabelRegions(chargeString, charge);
+
                     int nreg = g->regions();
                     int *regs = new int [cav.size()];
                     int ncav = 0;


### PR DESCRIPTION
Added region labels to `cavity`, similar to what was done for `egs_chamber` previously. Now you can use region labels anywhere you would otherwise type a list of global region numbers!

Also updated the documentation for egs_chamber and cavity to include some description of how to use region labels.