### PR TITLE
Fix rest mass and energy in DOSXYZ source 20

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -4480,9 +4480,9 @@ CALL SRCHST(XIN,YIN,ZIN,UIN,VIN,WIN,IRIN,WEIGHT);
 "for ISOURC=21 EIN and IQIN are passed via comin score"
 ICMNEW = ICM; "set equal to suppress full phase-space output until
               "particle crosses a scoring plane
-IF( ISOURC ~= 21 & ISOURC ~=23 & ISOURC~=24) [
+IF( ISOURC ~= 21 & ISOURC ~=23 & ISOURC~=24 & dosxyz2beam_index >= 0) [
     IF( MONOEN = 1 ) CALL EN_SAMPLE(EIN);
-    IF(IQIN =  0)[EI=EIN;]ELSE[EI=EIN+RM;]
+    IF(IQIN =  0)[EI=EIN;]ELSE[EI=EIN+PRM;]
 ] ELSE [ EI = EIN; ]
 
 "set initial energy for beam models";


### PR DESCRIPTION
If a BEAMnrc shared library geometry was interposed
between the source and the phantom and the source
in the BEAMnrc .egsinp was not a phase space or BEAM
simulation source, then the incorrect particle energy
was used to pass the particle through the shared lib.
geometry and, subsequently, on entry to the DOSXYZnrc
phantom.  Quite a dangerous bug.  Recommend patching this
as quickly as possible.