### PR TITLE
Set egs_gui compilation flags properly

### DIFF
--- a/HEN_HOUSE/gui/egs_gui/egs_compile_page.cpp
+++ b/HEN_HOUSE/gui/egs_gui/egs_compile_page.cpp
@@ -181,7 +181,14 @@ void EGS_CompilePage::startCompilation() {
 #ifdef IK_DEBUG
   qDebug("selected button: %s",bname.toLatin1().data());
 #endif
-  if( bname != "opt" ) args << bname;//c_process->addArgument(bname);
+  if( bname != "opt" ){
+    if( bname == "noopt" )
+        args << "FOPT= " << "opt= ";
+    else if ( bname == "debug" )
+        args << "FOPT=-g" << "opt=-g";
+    else
+      args << bname;
+  }
   QString conf = "EGS_CONFIG="; conf += egsConfiguration();
   args <<conf; //c_process->addArgument(conf);
   QString ehome = "EGS_HOME="; ehome += egsHome();


### PR DESCRIPTION
Passing proper flags to `make` by setting `FOPT` and `opt` variables correctly
- RZ codes use a standard makefile which has defined the targets `opt`, `noopt`, `debug` and `clean`
- C++ Makefiles do not understand these build options. From the `egs_gui` one must adjust the flags according to the user's choice.
