### PR TITLE
OpenMP support in EGSnrc

### DIFF
--- a/HEN_HOUSE/makefiles/standard_makefile
+++ b/HEN_HOUSE/makefiles/standard_makefile
@@ -27,6 +27,9 @@
 #                   Jeffrey Siebers
 #                   Ernesto Mainegra-Hing
 #
+#  OpenMP support:  Edgardo Doerner
+#                   Paola Caprile
+#
 ###############################################################################
 #
 #  The main portion of a Makefile for the EGSnrc system. This file is included
@@ -162,6 +165,10 @@ debug:
 	@$(MAKE) -s WHAT=_debug OPTLEVEL_F="$(FDEBUG)" OPTLEVEL_C="$(CDEBUG)"
 #@($(MAKE) -s WHAT=_debug OPTLEVEL_F="$(FDEBUG)" OPTLEVEL_C="$(CDEBUG)" && echo $(ok_message)) || echo $(failed_message)
 
+# OMP_EGS - Build an user code with OpenMP support
+omp:
+	@$(MAKE) -s OPTLEVEL_F="$(FOPT) -fopenmp" 
+
 # Clean-up the user code directory.
 clean:
 	@echo "$(REMOVE) mortjob.mortran $(FORTRAN_FILE).$(FEXT) $(FORTRAN_FILE).mortlst"
@@ -180,4 +187,6 @@ execlean:
 # execlean have no list of prerequisits so that make can determine whether
 # they need to be remade, we declare them as phony.
 #
-.PHONY: opt noopt debug clean execlean
+# OMP_EGS - Added omp for compilation with OpenMP support
+#
+.PHONY: opt noopt debug omp clean execlean

--- a/HEN_HOUSE/omega/progs/beamdp/Makefile
+++ b/HEN_HOUSE/omega/progs/beamdp/Makefile
@@ -26,13 +26,19 @@
 #  Contributors:    Blake Walters
 #                   Frederic Tessier
 #
+#  OpenMP support:  Edgardo Doerner
+#                   Paola Caprile
+#
 ###############################################################################
 
 
 include $(EGS_CONFIG)
 include $(SPEC_DIR)beamnrc.spec
 
-SOURCES = $(MACHINE_MACROS) $(EGS_UTILS)phsp_macros.mortran $(IAEA_PHSP_MACROS)\
+# OMP_EGS: phsp_macros.mortran contains OpenMP constructs, defined at 
+# egsnrc.macros. Therefore it is added to SOURCES.
+SOURCES = $(MACHINE_MACROS) $(EGS_SOURCEDIR)egsnrc.macros \
+	$(EGS_UTILS)phsp_macros.mortran $(IAEA_PHSP_MACROS) \
           beamdp.mortran \
           $(EGS_UTILS)xvgrplot.mortran $(EGS_SOURCEDIR)lnblnk1.mortran
 

--- a/HEN_HOUSE/omega/progs/readphsp/Makefile
+++ b/HEN_HOUSE/omega/progs/readphsp/Makefile
@@ -26,13 +26,19 @@
 #  Contributors:    Frederic Tessier
 #                   Blake Walters
 #
+#  OpenMP support:  Edgardo Doerner
+#                   Paola Caprile
+#
 ###############################################################################
 
 
 include $(EGS_CONFIG)
 include $(SPEC_DIR)beamnrc.spec
 
-SOURCES = $(MACHINE_MACROS) $(EGS_UTILS)phsp_macros.mortran readphsp.mortran \
+# OMP_EGS: phsp_macros.mortran contains OpenMP constructs, defined at 
+# egsnrc.macros. Therefore it is added to SOURCES.
+SOURCES = $(MACHINE_MACROS) $(EGS_SOURCEDIR)egsnrc.macros \
+	$(EGS_UTILS)phsp_macros.mortran readphsp.mortran \
           $(EGS_SOURCEDIR)lnblnk1.mortran
 
 # If you don't have the PAW library, you will have to use the

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -29,6 +29,9 @@
 "                   Frederic Tessier                                          "
 "                   Reid Townson                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 " Iwan Kawrakow, 2004:                                                        "
@@ -740,7 +743,11 @@ IF( ex ) [
             ]
             file_extensions(n_files) = $cstring(arg);
             tmp1_string = $cstring(tmp_string) // $cstring(arg);
-            open(u,file=tmp1_string,status='unknown');
+"*******************************************************************************
+" #OMP_EGS - Set access attribute to append in order to avoid erasing previous
+"            information on .egslst file.
+"*******************************************************************************
+            open(u,file=tmp1_string,status='unknown',access='append');
             $egs_debug('(a,a,a,i3)','connected ',$cstring(tmp1_string),
               ' to unit ',u);
         ]

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -29,6 +29,9 @@
 "                   Frederic Tessier                                          "
 "                   Reid Townson                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  Parts of the EGS code that originate from SLAC are distributed by NRC      "
@@ -58,6 +61,48 @@
 %C80        "Allow 80 columns of source/line (default is 72)
 %L          "Turn on listing
 
+"*******************************************************************************
+" #OMP_EGS - MACROS and definitions needed for OpenMP parallel implementation.
+"*******************************************************************************
+
+" MACRO TO CREATE OPENMP COMMENTS"
+REPLACE {$OMP{#,#};} WITH{;
+!INDENT F 0;
+!COMMENTS;
+"$OMP{P1}{P2}"
+!NOCOMMENTS;
+!INDENT F 2;
+}
+;
+
+" MACROS TO ADD PREPROCESSOR CONDITIONAL DIRECTIVES"
+" mortran3 gets confused by the # char => we need to pass it as an "
+" argument to the macro. "
+REPLACE {$IFDEF(#,#);} WITH {{EMIT;{P1}ifdef {P2};};}
+;
+REPLACE {$IFNDEF(#,#);} WITH {{EMIT;{P1}ifndef {P2};};}
+;
+REPLACE {$ELSEIF(#,#);} WITH {{EMIT;{P1}elif {P2};};}
+;
+REPLACE {$ELSE(#);} WITH {{EMIT;{P1}else;};}
+;
+REPLACE {$ENDIF(#);} WITH {{EMIT;{P1}endif;};}
+;
+
+"------------------------------------------------------------------"
+"*** OMP-EGS -- OPENMP ENVIRONMENT RELATED VARIABLES               "
+"------------------------------------------------------------------"
+REPLACE {;COMIN/OMP-EGS/;} WITH
+{
+    ;COMMON/OMP_EGS/omp_iam, omp_size;
+    $OMP{0,THREADPRIVATE(/OMP_EGS/)};
+        INTEGER       omp_iam,   "OpenMP thread index"
+                      omp_size;  "Number of threads in the simulation"
+}
+
+"*******************************************************************************
+" #OMP_EGS - End of MACROS and definitions for OpenMP.
+"*******************************************************************************
 
 "=================================================================="
 " Macros to implement implicit data types                          "
@@ -522,6 +567,10 @@ REPLACE {;COMIN/EDGE/;} WITH
 "        MODIFIED 1989/12/19 TO INCLUDE IUNRST,EPSTFL AND IAPRIM   "
 "        NRC DWOR                                                  "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /ELECIN/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/ELECIN/;} WITH
 {;
    COMMON/ELECIN/
@@ -537,6 +586,7 @@ REPLACE {;COMIN/ELECIN/;} WITH
    expeke1($MXMED),
    IUNRST($MXMED),EPSTFL($MXMED),IAPRIM($MXMED),
    sig_ismonotone(0:1,$MXMED);
+   $OMP{0,THREADPRIVATE(/ELECIN/)};
    $REAL    esig_e,        "maximum electron cross section per energy loss"
                            "for each medium"
             psig_e,        "maximum positron cross section per energy loss"
@@ -646,9 +696,13 @@ REPLACE {;COMIN/EMF-INPUTS/;} WITH {;
 " he/she knows which shell was being relaxed when the call to ausgab"
 " occured                                                           "
 " Added by Iwan Kawrakow, March 22 2004.                            "
-
+"*******************************************************************************
+" #OMP_EGS - Global data inside /user_relax/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/RELAX-USER/;} WITH {;
    common/user_relax/ u_relax,ish_relax,iZ_relax;
+   $OMP{0,THREADPRIVATE(/user_relax/)};
    $REAL              u_relax;
    $INTEGER           ish_relax, iZ_relax;
 };
@@ -721,6 +775,10 @@ REPLACE {;COMIN/RELAX-DATA/;} WITH {;
 };
 ;  "---------- BUFFER FLUSH SEMICOLON ----------"
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside /RELAX-FOR-USER/ COMMON block are made 
+"            private to each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/RELAX-FOR-USER/;} WITH {;
     common/relax_for_user/
      rfu_E0, "binding energy of vacancy that initiated cascade"
@@ -732,6 +790,7 @@ REPLACE {;COMIN/RELAX-FOR-USER/;} WITH {;
      rfu_j,  "shell number of current vacancy"
      rfu_n,  "same but number is shell number in the element"
      rfu_t;  "same but number is shell type according to EADL notation"
+    $OMP{0, THREADPRIVATE(/relax_for_user/)};
     $INTEGER rfu_Z,rfu_j0,rfu_n0,rfu_t0,rfu_j,rfu_n,rfu_t;
     $REAL    rfu_E0,rfu_E;
 };
@@ -887,9 +946,14 @@ REPLACE {COMIN/Spin-Data/;} WITH {
 }
 ;
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside /CH_steps/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {COMIN/CH-Steps/;} WITH
 {
   common/CH_steps/ count_pII_steps,count_all_steps,is_ch_step;
+  $OMP{0,THREADPRIVATE(/CH_steps/)};
   real*8           count_pII_steps,count_all_steps;
   $LOGICAL         is_ch_step;
 }
@@ -897,6 +961,10 @@ REPLACE {COMIN/CH-Steps/;} WITH
 "------------------------------------------------------------------"
 "*** EPCONT--ELECTRON-PHOTON CONTROL VARIABLES                     "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /EPCONT/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/EPCONT/;} WITH
 {;
   COMMON/EPCONT/EDEP,EDEP_LOCAL,TSTEP,TUSTEP,USTEP,TVSTEP,VSTEP,
@@ -904,6 +972,7 @@ REPLACE {;COMIN/EPCONT/;} WITH
                 x_final,y_final,z_final,
                 u_final,v_final,w_final,
                 IDISC,IROLD,IRNEW,IAUSFL($MXAUS);
+    $OMP{0,THREADPRIVATE(/EPCONT/)};
     $ENERGY PRECISION EDEP,   "energy deposition in MeV"
                       EDEP_LOCAL; "local energy deposition in MeV"
     $REAL             TSTEP,  "distance to a discrete interaction"
@@ -1007,6 +1076,10 @@ REPLACE {;COMIN/MISC/;} WITH
 "------------------------------------------------------------------"
 "*** PHOTIN--PHOTON TRANSPORT DATA                                 "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /PHOTIN/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/PHOTIN/;} WITH
 {;
     COMMON/PHOTIN/
@@ -1021,6 +1094,7 @@ REPLACE {;COMIN/PHOTIN/;} WITH
        DPMFP,
        MPGEM($MXSGE,$MXMED),
        NGR($MXMED);
+    $OMP{0,THREADPRIVATE(/PHOTIN/)};
     $REAL
        EBINDA,      "energy of the K-edge for a given medium"
        GE0,GE1,     "used for indexing in logarithmic interpolations"
@@ -1054,11 +1128,16 @@ REPLACE {;COMIN/PHOTIN/;} WITH
 "------------------------------------------------------------------"
 "*** STACK--INFORMATION KEPT ABOUT CURRENT PARTICLES               "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /STACK/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/STACK/;} WITH
 {;
    COMMON/STACK/
        $LGN(E,X,Y,Z,U,V,W,DNEAR,WT,IQ,IR,LATCH($MXSTACK)),
        LATCHI,NP,NPold;
+   $OMP{0,THREADPRIVATE(/STACK/)};
    $ENERGY PRECISION
        E;     "total particle energy"
    $REAL
@@ -1104,10 +1183,15 @@ REPLACE {;COMIN/UPHIIN/;} WITH
 "------------------------------------------------------------------"
 "*** UPHIOT--UPHI'S INPUT/OUTPUT WITH ITS USERS                    "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /UPHIOT/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/UPHIOT/;} WITH
 {;
    COMMON/UPHIOT/THETA,SINTHE,COSTHE,SINPHI,
                  COSPHI,PI,TWOPI,PI5D2;
+   $OMP{0,THREADPRIVATE(/UPHIOT/)};
    $REAL         THETA,  "polar scattering angle"
                  SINTHE, "sin(THETA)"
                  COSTHE, "cos(THETA)"
@@ -1119,9 +1203,14 @@ REPLACE {;COMIN/UPHIOT/;} WITH
 "------------------------------------------------------------------"
 "*** USEFUL--HEAVILY USED VARIABLES                                "
 "------------------------------------------------------------------"
+"*******************************************************************************
+" #OMP_EGS - Global data inside /USEFUL/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/USEFUL/;} WITH
 {;
    COMMON/USEFUL/PZERO,PRM,PRMT2,RM,MEDIUM,MEDOLD;
+   $OMP{0,THREADPRIVATE(/USEFUL/)};
    $ENERGY PRECISION PZERO,   "precise zero"
                      PRM,     "precise electron mass in MeV"
                      PRMT2;   "2*PRM"
@@ -3432,6 +3521,10 @@ REPLACE{$PLTDIM} WITH {300};"Unique array dimension for XVGRPLOT and PLOTSN"
 "                                                                           "
 "***************************************************************************"
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside /egs_vr/ COMMON block are made 
+"            private to each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/EGS-VARIANCE-REDUCTION/;} WITH {;
 
   common/egs_vr/
@@ -3443,6 +3536,7 @@ REPLACE {;COMIN/EGS-VARIANCE-REDUCTION/;} WITH {;
                       "eliminated by RR in this interaction"
     n_RR_warning,     "a counter for user errors"
     i_do_rr($MXREG);  "0=>no RR, region by region, 1=>there is RR"
+  $OMP{0,THREADPRIVATE(/egs_vr/)};
   $REAL          e_max_rr,prob_RR;
   $INTEGER       nbr_split,i_play_RR,i_survived_RR,n_RR_warning;
   $SHORT_INT     i_do_rr;

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -29,6 +29,9 @@
 "                   Frederic Tessier                                          "
 "                   Reid Townson                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  Parts of the EGS code that originate from SLAC are distributed by NRC      "
@@ -1013,7 +1016,12 @@ $REAL     the_range;
 
 data ierust/0/;         "To count negative ustep's"
 
+"*******************************************************************************
+" #OMP_EGS - Global variable ierust is made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 save ierust;
+$OMP{0,THREADPRIVATE(ierust)};
 
 $CALL-USER-ELECTRON;
 
@@ -2984,7 +2992,12 @@ $REAL    sprob,explambda,wsum,wprob,xi,rejf,spin_rejection,
          cosz,sinz,phi,omega2,llmbda,ai,aj,ak,a,u,du,x1,rnno;
 $INTEGER icount,i,j,k;
 
+"*******************************************************************************
+" #OMP_EGS - Global variables i,j,omega2 are made private to
+"            each thread through the THREADPRIVATE directive.
+"*******************************************************************************
 save     i,j,omega2;
+$OMP{0,THREADPRIVATE(i,j,omega2)};
 
 $TURN_OFF_SCATTERING;
 " default of above is ';' See definition in egsnrc.macros for example"
@@ -3163,7 +3176,12 @@ COMIN/Spin-Data,RANDOM/;
 $REAL      rnno,ai,qq1,aj,xi,ak;
 $INTEGER   i,j,k;
 
+"*******************************************************************************
+" #OMP_EGS - Global variables i,j are made private to
+"            each thread through the THREADPRIVATE directive.
+"*******************************************************************************
 save       i,j;
+$OMP{0,THREADPRIVATE(i,j)};
 
 IF( spin_index ) [  "Determine the energy and q1 index
     spin_index = .false.;
@@ -6751,7 +6769,14 @@ $INTEGER
               "indeces for sine table"
 
 $DEFINE-VARIABLES-FOR-SELECT-AZIMUTHAL-ANGLE;
+
+"*******************************************************************************
+" #OMP_EGS - Global variables are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 save CTHET,PHI,CPHI,A,B,C,SINPS2,SINPSI,US,VS,SINDEL,COSDEL;
+$OMP{0,THREADPRIVATE(CTHET,PHI,CPHI,A,B,C,SINPS2,SINPSI,US,VS,SINDEL)};
+$OMP{0,THREADPRIVATE(COSDEL)};
 
 $AUSCALL($UPHIAUSB);
 GO TO (:UPHI:,:UPHI2:,:NRK:),IENTRY;

--- a/HEN_HOUSE/src/ranmar.macros
+++ b/HEN_HOUSE/src/ranmar.macros
@@ -26,6 +26,9 @@
 "                                                                             "
 "  Contributors:                                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  Parts of the EGS code that originate from SLAC are distributed by NRC      "
@@ -65,10 +68,16 @@
 
 
 REPLACE {$NRANMAR} WITH {128}
+
+"*******************************************************************************
+" #OMP_EGS - Global data inside /randomm/ COMMON block are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 REPLACE {;COMIN/RANDOM/;} WITH
 {;
    common/randomm/ rng_array($NRANMAR), urndm(97), crndm, cdrndm, cmrndm,
                    i4opt, ixx, jxx, fool_optimizer, twom24, rng_seed;
+   $OMP{0,THREADPRIVATE(/randomm/)};
    integer*4       urndm, crndm, cdrndm, cmrndm, i4opt,
                    ixx, jxx, fool_optimizer,rng_seed,rng_array;
    real*4          twom24;

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -36,6 +36,9 @@
 "                   Ernesto Mainegra-Hing                                     "
 "                   Reid Townson                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  The contributors named above are only those who could be identified from   "
@@ -625,7 +628,7 @@
 "                        equations (Phys. Rev. 85, p 231--1952).  Requires
 "                        a change to the user codes Makefile to include
 "                        $(EGS_SOURCEDIR)rad_compton1.mortran in the
-"                        SOURCES (just before
+"                        SOURCES (just before 
 "                        $(EGS_SOURCEDIR)get_inputs.mortran).
 "                        [ radc_flag ]
 "       Pair angular sampling= Off, Simple or KM
@@ -1017,10 +1020,6 @@ REPLACE {$AUSCALL(#);} WITH
 REPLACE {$IBRDST-DEFAULT} WITH {0}
 ;
 
-"Rayleigh scattering= Off"
-REPLACE {$IRAYLR-DEFAULT} WITH {0}
-;
-
 "Bound Compton scattering= Off"
 REPLACE {$IBCMP-DEFAULT} WITH {0}
 ;
@@ -1115,7 +1114,7 @@ REPLACE {;COMIN/TIMEINFO/;} WITH {
 REPLACE {$CTUnitNumber} WITH {45} "assign a unit number for the CT data"
 
 REPLACE {$MXDATA}       WITH {1}  "To get over nrccaux(p).mortran definition
-REPLACE {$NBATCH}       WITH {10} "Use 10 batches for restart features, etc.
+REPLACE {$NBATCH}       WITH {1} "Use 10 batches for restart features, etc.
 REPLACE {$MXDOS}        WITH {7}  "Max number of groups of regions to analyse
 
 "Some macros for facilitating access to boundaries and regions
@@ -1154,6 +1153,10 @@ REPLACE {$CALL-HOWNEAR(#);} WITH {
     CALL HOWNEAR({P1},X(NP),Y(NP),Z(NP),IR(NP));
 }
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside /score/ COMMON block are made private to 
+"            each thread through the THREADPRIVATE directive. 
+"*******************************************************************************
 REPLACE {;COMIN/SCORE/;} WITH {
     ;common/score/endep($MAXDOSE), endep2($MAXDOSE), temp2, planarefe,
     planarefp,planarfe,planarfp,
@@ -1161,6 +1164,7 @@ REPLACE {;COMIN/SCORE/;} WITH {
     endep_tmp($MAXDOSE),
     i_phsp_out,i_muidx_out,i_unit_out,IWATCH,mxnp,
     endep_last($MAXDOSE);
+    $OMP{0,THREADPRIVATE(/score/)};
     REAL*8 endep, endep2, temp2,planarefe, planarefp, planarfe, planarfp;
     $LONG_INT nestep;
     real endep_tmp;
@@ -1247,7 +1251,26 @@ $LONG_INT nnphsp_max, nnphsp_min; } TO
 
 "  start of coding                 ""toc:
 
+"*******************************************************************************
+" #OMP_EGS - At this point the main program begins. PROGRAM statement added to 
+"            clearly define the start of the program.
+"*******************************************************************************
+PROGRAM dosxyznrc;
+
+"*******************************************************************************
+" #OMP_EGS - Include the OMP_LIB module to access OpenMP runtime functions. It 
+"            is used only if the user code is compiled with OpenMP translation.
+"*******************************************************************************
+$IFDEF(#,_OPENMP);
+  USE OMP_LIB;
+$ENDIF(#);
+
 $IMPLICIT-NONE;
+
+"*******************************************************************************
+" #OMP_EGS - Variables needed for OpenMP execution.
+"*******************************************************************************
+;COMIN/OMP-EGS,EGS-VARIANCE-REDUCTION,PHOTIN,RELAX-FOR-USER,UPHIOT,RELAX-USER/;
 
 ;COMIN/ BOUNDS,BREMPR,ELECIN,GEOM,MEDIA,MISC,PHSPFILE,SCORE,SOURCE,
 STACK,THRESH,USEFUL,RANDOM,TIMEINFO,ET-Control,CH-Steps,USER,EPCONT,EGS-IO,
@@ -1458,8 +1481,6 @@ IF(NMED = 0)[ "Input data from CT data file as processed by the code ctcreate"
      ' : ',$);
     read(5,'(A256)') PhantFileName;
     OUTPUT61 PhantFileName(:lnblnk1(PhantFileName));(A);
-
-    call replace_env(PhantFileName);
 
     Open($CTUnitNumber,file=PhantFileName,status='old',access='sequential',
           iostat=ios);
@@ -1952,7 +1973,10 @@ ELSEIF(i_phsp_out~=0)[
 IF(i_phsp_out=1 | i_phsp_out=2) iausfl(6)=1;
 "call ausgab after particle transport to score particles"
 
-$INITIALIZE RNG USING IXXIN AND JXXIN;
+"*******************************************************************************
+" #OMP_EGS - Initialization of RNG is moved to the first parallel region.
+"*******************************************************************************
+"$INITIALIZE RNG USING IXXIN AND JXXIN;
 
 
 "=========================================================================="
@@ -2508,6 +2532,46 @@ IF(IDAT=0 | IDAT=2)[
 
 IF(IWATCH ~= 0)[call watch(-99,IWATCH);] "Set up for watch routine if needed
 
+"*******************************************************************************
+" #OMP_EGS - One-time initializations needed for OpenMP parallel processing. On 
+"            this step the values on COMMON blocks with the THREADPRIVATE 
+"            directive are initialized through the COPYIN clause.
+"*******************************************************************************
+$OMP{0,PARALLEL DEFAULT(SHARED) FIRSTPRIVATE(IXXIN,JXXIN)};
+$OMP{*,COPYIN(/CH_steps/,/egs_vr/,/ELECIN/,/EPCONT/,/PHOTIN/)};
+$OMP{*,COPYIN(/relax_for_user/,/RWPHSP/,/score/,/source/)};
+$OMP{*,COPYIN(/UPHIOT/,/USEFUL/,/user_relax/)};
+    " First obtain the runtime thread number and number of threads.
+    $IFDEF(#,_OPENMP);
+        omp_iam = omp_get_thread_num();
+        omp_size = omp_get_num_threads();
+    $ELSE(#);
+        omp_iam = 0;
+        omp_size = 1;
+    $ENDIF(#);
+    
+    " Initialize RNG for each thread.
+    IXXIN = IXXIN;
+    JXXIN = JXXIN + omp_iam;
+    $INITIALIZE RNG USING IXXIN AND JXXIN;
+
+    " Initializations needed for phsp processing
+    IF(enflag = 2)[
+        nnphsp = INT(omp_iam*nshist/omp_size)+1;
+    ]
+
+    " Finally print to console some information about OpenMP configuration.
+    $IFDEF(#,_OPENMP);
+	  	$OMP{0,SINGLE};  			
+	  		OUTPUT61;(//' **************************************************');
+	  		OUTPUT61 omp_size;
+	  		(/'  Number of threads in OpenMP parallel execution: ',I4);
+	  		OUTPUT61;(/' *************************************************');
+	  	$OMP{0,END SINGLE};
+  	$ENDIF(#);
+
+$OMP{0,END PARALLEL};
+
 $SET_ELAPSED_TOTAL_TIME(TIMEB);
 OUTPUT61 TIMEB;('   Elapsed wall clock time to this point=',f12.3,' s'/);
 $INITIALIZE_ELAPSED_TOTAL_TIME; "reset to get elapsed time during run only"
@@ -2626,12 +2690,23 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
         "analysis data for beam characterization models"
     ]
 
+"*******************************************************************************
+" #OMP_EGS - The shower loop is divided among the team of threads through the 
+"            PARALLEL DO directive. 
+"*******************************************************************************
+$OMP{0,PARALLEL DO SCHEDULE(runtime) DEFAULT(SHARED)};
+$OMP{*,FIRSTPRIVATE(xin,yin,zin,uin,vin,win,irin,etotin,weight)};
+$OMP{*,FIRSTPRIVATE(nhist_old)};
+$OMP{*,PRIVATE(irl,i_repeat)};
     DO ihist = 1,jcase[
-
+       
         nhist_old=nhist;
 
-        IHSTRY=IHSTRY+1;
-
+"*******************************************************************************
+" #OMP_EGS - IHSTRY is only accumulated for the MASTER thread.  
+"*******************************************************************************
+        IF(omp_iam = 0)[IHSTRY=IHSTRY+1;]
+        
         IF(isource=21 & more_in_cont=0)[
             frMU_indx = -1.0; "initialize frMU_indx to -1.0. It will either be"
                          " changed in BEAM or in dosxyznrc after srchst"
@@ -2645,37 +2720,37 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
         "       space file, it returns nhist, the total no. of primary"
         "       histories used that scored particles in the phsp file."
 
-	 "IF(((isource=20)|(isource=21 ))& weight=0)["
-	 "This check has been removed and the blocked particles are now counted"
-	 "as nsblocked in srcxyznrc.mortran (JL)"
-	            "this happens if a particle "
-			   "is blocked by shared library modules (only source 20 or 21)"
-	 "	IHSTRY=IHSTRY-1;""do not count this particle as one"
-				    "that contributed"
-	 "]"
-	 "ELSE["
-        "increment esrc, the kinetic+Q energy incident on the phantom"
-        "-----------------------------------------------------------------"
-        IF(enflag = 1)["Particle energy sampled from a spectrum"
-        "-----------------------------------------------------------------"
-           "esrc_sp is the kinetic energy"
-           esrc = esrc + weight*esrc_sp;"we only count the kinetic E for the "
-                      "electrons and photons in the total incident E"
-           IF(iqin =1)[ esrc = esrc +  weight*1.0220068;
-            "we include 2 0.511 MeV photons from e+ - e- annihilation"]
-           IF(iqin ~= 0)[ etotin = esrc_sp + prm;"particle total E"]
-           ELSE[etotin = esrc_sp;]
-        ]
-        "-----------------------------------------------------------------"
-        ELSEIF(enflag = 2 | enflag = 3)["phase-space input or BEAM sim."
-        "-----------------------------------------------------------------"
-           etotin = einsrc;   "einsrc is the total energy of the particle"
-           IF(iqin = -1)   [esrc = esrc + weight*(etotin - prm);
-                            "remove e- rest mass"]
-           ELSEIF(iqin = 0)[esrc = esrc + weight*etotin; ]
-           ELSEIF(iqin = 1)[esrc = esrc + weight*(etotin + prm);
-                      "add 0.511 for the positron but was - till June 97"
-           ]
+        "IF(((isource=20)|(isource=21 ))& weight=0)["
+        "This check has been removed and the blocked particles are now counted"
+        "as nsblocked in srcxyznrc.mortran (JL)"
+                    "this happens if a particle "
+                "is blocked by shared library modules (only source 20 or 21)"
+        "	IHSTRY=IHSTRY-1;""do not count this particle as one"
+                        "that contributed"
+        "]"
+        "ELSE["
+            "increment esrc, the kinetic+Q energy incident on the phantom"
+            "-----------------------------------------------------------------"
+            IF(enflag = 1)["Particle energy sampled from a spectrum"
+            "-----------------------------------------------------------------"
+            "esrc_sp is the kinetic energy"
+            esrc = esrc + weight*esrc_sp;"we only count the kinetic E for the "
+                        "electrons and photons in the total incident E"
+            IF(iqin =1)[ esrc = esrc +  weight*1.0220068;
+                "we include 2 0.511 MeV photons from e+ - e- annihilation"]
+            IF(iqin ~= 0)[ etotin = esrc_sp + prm;"particle total E"]
+            ELSE[etotin = esrc_sp;]
+            ]
+            "-----------------------------------------------------------------"
+            ELSEIF(enflag = 2 | enflag = 3)["phase-space input or BEAM sim."
+            "-----------------------------------------------------------------"
+            etotin = einsrc;   "einsrc is the total energy of the particle"
+            IF(iqin = -1)   [esrc = esrc + weight*(etotin - prm);
+                                "remove e- rest mass"]
+            ELSEIF(iqin = 0)[esrc = esrc + weight*etotin; ]
+            ELSEIF(iqin = 1)[esrc = esrc + weight*(etotin + prm);
+                        "add 0.511 for the positron but was - till June 97"
+            ]
         ]
         "-----------------------------------------------------------------"
         ELSEIF(enflag = 4)[ ;$BEAMMODEL-SOURCE4-ENERGY; ]
@@ -2752,6 +2827,9 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
     $DOSXYZ_SET_OUT_PHSP_HEADER;
   ]
 
+  " The data stored in the following section comes from the MASTER thread only.
+  " Further analysis and combination of results are carried out below in the 
+  " program.
   IF(IDAT = 0 | (IDAT = 2 & ibatch = $NBATCH) ) ["store data"
      rewind(iorstrt); "overwrite previous data"
      DO irl=1,irmax[
@@ -2807,7 +2885,10 @@ ELSEIF (IRESTART = 3)["just data analysis"
        F12.0,' hist/hr'/T3,' On  '$MACHINE' ');
 ]
 
-
+"*******************************************************************************
+" #OMP_EGS - The following output information is only relevant for the MASTER 
+"            thread. 
+"*******************************************************************************
 IF(isource = 2 | isource = 8 )[ "Full phase-space source"
 OUTPUT61 nnread,nhist,nsrjct,nsoutside,ndbsrjct,nsmiss,
      float((NRCYCL+1)*(nnread-nsrjct-nsoutside-ndbsrjct)-nsmiss)/float(nnread),
@@ -2891,123 +2972,157 @@ ELSEIF(isource =4 )[ ;$BEAMMODEL-SOURCE4-SUMMARY; ]
 "Step 9 Analyse and output results                        ""toc:
 "=================================
 
-etot=0.;
+"*******************************************************************************
+" #OMP_EGS - Each thread carries out analysis of its own results. Any output to 
+"            console/list file will be done only for MASTER thread.
+"*******************************************************************************
+$OMP{0,PARALLEL DEFAULT(SHARED) PRIVATE(amass,etot,temp,irl,i,j,k)};
+$OMP{*,PRIVATE(parname)};
+    etot=0.;
 
-"Correlated sampling no longer supported with history by history statistics"
-"$Corr_Dump;mah 09/05/95 To store DOSEIS to file. ";
+    "Correlated sampling no longer supported with history by history statistics"
+    "$Corr_Dump;mah 09/05/95 To store DOSEIS to file. ";
 
-"sum energy deposition in phantom"
-"Note that dose is still really just an energy deposition"
-DO irl=1,irmax-1[etot=etot+endep(irl);]
+    "sum energy deposition in phantom"
+    "Note that dose is still really just an energy deposition"
+    DO irl=1,irmax-1[etot=etot+endep(irl);]
 
-IF (enflag = 0)[
-   "Known Bug - this doesn't handle positrons correctly yet"
-   OUTPUT61 etot/(dble(IHSTRY+ncaseold)*ein);
-   (/' Fraction of incident energy deposited in the phantom =',f12.4/);
-]
-ELSEIF((enflag=1)|(enflag=2)|(enflag=3)|(enflag=4))[ ;OUTPUT61 etot/esrc;
-   (/' Fraction of incident energy deposited in the phantom =',f12.4/);
-   IF ((enflag > 1))[ OUTPUT61 endep(irl)/esrc;
-   (/' Fraction of incident energy deposited in the region surrounding'/
-     ' the phantom when incident particles go through it   =',f12.4/);
-   ]
-]
-
-"Calculate incident fluence
-IF(isource = 0 | isource = 1 | isource = 3 | isource = 7)[
-   temp2=dble(IHSTRY+ncaseold+nsmiss+nmissm);
-   IF(beamarea = 0)[ ainflu=dble(IHSTRY+ncaseold+nsmiss+nmissm);]
-   ELSE[             ainflu=dble(IHSTRY+ncaseold+nsmiss+nmissm)/beamarea;]
-]
-ELSEIF(isource = 2 | isource = 8 )[
-   ainflu=dble(IHSTRY+ncaseold+nsmiss+
+    " Output of results at this point is only done for MASTER thread. Therefore,
+    " the following information is valid only for this thread.
+    $OMP{0,MASTER};
+        IF (enflag = 0)[
+            "Known Bug - this doesn't handle positrons correctly yet"
+            OUTPUT61 etot/(dble(IHSTRY+ncaseold)*ein);
+            (/' Fraction of incident energy deposited in the phantom =',f12.4/);
+        ]
+        ELSEIF((enflag=1)|(enflag=2)|(enflag=3)|(enflag=4))[;OUTPUT61 etot/esrc;
+            (/' Fraction of incident energy deposited in the phantom =',f12.4/);
+            IF ((enflag > 1))[ OUTPUT61 endep(irl)/esrc;
+                (/' Fraction of incident energy deposited in the region'/
+                ' surrounding the phantom when incident particles go'/
+                ' through it   =',f12.4/);
+            ]
+        ]
+    $OMP{0,END MASTER};
+    
+    "Calculate incident fluence
+    IF(isource = 0 | isource = 1 | isource = 3 | isource = 7)[
+        temp2=dble(IHSTRY+ncaseold+nsmiss+nmissm);
+        IF(beamarea = 0)[
+            ainflu=dble(IHSTRY+ncaseold+nsmiss+nmissm);
+        ]
+        ELSE[
+            ainflu=dble(IHSTRY+ncaseold+nsmiss+nmissm)/beamarea;
+        ]
+    ]
+    ELSEIF(isource = 2 | isource = 8 )[
+        ainflu=dble(IHSTRY+ncaseold+nsmiss+
                 (NRCYCL+1)*(nsrjct+nsoutside+ndbsrjct))/float(nshist)*NINCSRC;
-   "IHSTRY+ncaseold is the number of particles"
-   "actually simulated from the phase space source"
-   "We then add nsmiss+(NRCYCL+1)*(nsrjct+nsoutside+ndbsrjct), an estimate of"
-   "the total number of particles rejected based on charge, LATCH, W,"
-   "being a multiple passer, being outside BEAM_SIZE, falling beyond the"
-   "directional bremsstrahlung splitting (DBS) radius, or missing the geometry"
-   "The result is an estimate of the total number of particles read from the"
-   "phase space source.  This number is then divided by nshist, the total"
-   "number of particles in the phase space source, to give the number"
-   "of times that the phase space source has been used (this could be <1)"
-   "Finally, we multiply this by NINCSRC, the number of particles"
-   "incident from the original (non-phase space) source that were used to"
-   "obtain the phase space source.  The result is an estimate of the number"
-   "of particles incident from the original (non-phase space) source for"
-   "this simulation."
-   temp2=ainflu;
-]
-ELSEIF(isource=4)[
-    ainflu=dble(IHSTRY+ncaseold-nsmiss);
+        "IHSTRY+ncaseold is the number of particles"
+        "actually simulated from the phase space source"
+        "We then add nsmiss+(NRCYCL+1)*(nsrjct+nsoutside+ndbsrjct), an estimate 
+        "of"
+        "the total number of particles rejected based on charge, LATCH, W,"
+        "being a multiple passer, being outside BEAM_SIZE, falling beyond the"
+        "directional bremsstrahlung splitting (DBS) radius, or missing the 
+        "geometry"
+        "The result is an estimate of the total number of particles read from 
+        "the"
+        "phase space source.  This number is then divided by nshist, the total"
+        "number of particles in the phase space source, to give the number"
+        "of times that the phase space source has been used (this could be <1)"
+        "Finally, we multiply this by NINCSRC, the number of particles"
+        "incident from the original (non-phase space) source that were used to"
+        "obtain the phase space source.  The result is an estimate of the 
+        "number"
+        "of particles incident from the original (non-phase space) source for"
+        "this simulation."
+        temp2=ainflu;
+    ]
+    ELSEIF(isource=4)[
+        ainflu=dble(IHSTRY+ncaseold-nsmiss);
+        temp2=ainflu;
+    ]
+    ELSEIF(isource=6)[
+        ainflu=dble(IHSTRY+ncaseold);
+        temp2=ainflu;
+    ]
+    ELSEIF(isource=9|isource=10|isource=21)[
+                    "full BEAM simulation, here we can just read nhist"
+                    "the no. of primary histories"
+        ainflu=dble(nhist);
+        temp2=ainflu;
+    ]
+    ELSEIF(isource=20)["full VCU simulation"
+
+    "ainflu=dble(IHSTRY+ncaseold+nsmiss+nsblocked+"
+                "(NRCYCL+1)*(nsrjct+nsoutside+ndbsrjct))/float(nshist)*NINCSRC;"
+
+    ainflu = dble((NRCYCL+1)*(nnread))/dble(nshist)*NINCSRC;
+
     temp2=ainflu;
-]
-ELSEIF(isource=6)[
-    ainflu=dble(IHSTRY+ncaseold);
-    temp2=ainflu;
-]
-ELSEIF(isource=9|isource=10|isource=21)[
-                  "full BEAM simulation, here we can just read nhist"
-                  "the no. of primary histories"
-    ainflu=dble(nhist);
-    temp2=ainflu;
-]
-ELSEIF(isource=20)["full VCU simulation"
+    ]
 
-   "ainflu=dble(IHSTRY+ncaseold+nsmiss+nsblocked+"
-            "(NRCYCL+1)*(nsrjct+nsoutside+ndbsrjct))/float(nshist)*NINCSRC;"
+    $OMP{0,MASTER};
+        OUTPUT61 nestep,dble(nestep)/ainflu,count_pII_steps/dble(nestep);
+        (/' Number of charged particle steps simulated,   N_step       =',I15/
+        ' Number of charged particle steps/incident fluence          =',1PE15.5/
+    ' No. of PRESTA-II steps/total no. of charged particle steps =',0PF15.5/);
 
-   ainflu = dble((NRCYCL+1)*(nnread))/dble(nshist)*NINCSRC;
+        "Now calculate dose uncertainties"
+        IF(dose_stat=1)[
+        OUTPUT61;(//' ***WARNING***'/
+            ' Could not read no. of primary (non-phsp) histories from ph-sp'/
+            ' file. Dose analyzed assuming each particle read from the ph-sp'/
+            ' file is an independent history.  May result in an underestimate'/
+            ' of the uncertainty.'//);
+        ]
+        ELSEIF(OUTCNT>0)[
+        OUTPUT61;(//' ***WARNING***'/
+            ' The ph-sp source was restarted at least once.  This may lead'/
+            ' to an underestimate of uncertainty, especially if restarted'/
+            ' many times.  If restarted many times, try re-running with'/
+            ' NRCYCL recalculated as described at top of dosxyznrc.mortran'//);
+        ]
+    $OMP{0,END MASTER};
 
-   temp2=ainflu;
-]
-OUTPUT61 nestep,dble(nestep)/ainflu,count_pII_steps/dble(nestep);
- (/' Number of charged particle steps simulated,   N_step       =',I15/
-   ' Number of charged particle steps/incident fluence          =',1PE15.5/
-   ' No. of PRESTA-II steps/total no. of charged particle steps =',0PF15.5/);
-
-"Now calculate dose uncertainties"
-IF(dose_stat=1)[
-   OUTPUT61;(//' ***WARNING***'/
-       ' Could not read no. of primary (non-phsp) histories from ph-sp file.'/
-       ' Dose analyzed assuming each particle read from the ph-sp'/
-       ' file is an independent history.  May result in an underestimate'/
-       ' of the uncertainty.'//);
-]
-ELSEIF(OUTCNT>0)[
-   OUTPUT61;(//' ***WARNING***'/
-       ' The ph-sp source was restarted at least once.  This may lead'/
-       ' to an underestimate of uncertainty, especially if restarted'/
-       ' many times.  If restarted many times, try re-running with'/
-       ' NRCYCL recalculated as described at top of dosxyznrc.mortran'//);
-]
-DO irl = 1,irmax-1 [
-   IF(IDAT=1)[
-     "add unscored portion of endep_tmp(irl) first"
-     endep(irl)=endep(irl)+endep_tmp(irl);
-     endep2(irl)=endep2(irl)+endep_tmp(irl)*endep_tmp(irl);
-   ]
-   "divide by rhor so that we do not have to store rhor in the .pardose"
-   "file during parallel runs."
-   endep(irl)=endep(irl)/rhor(irl+1);
-   endep2(irl)=endep2(irl)/(rhor(irl+1)*rhor(irl+1));
-]
+    DO irl = 1,irmax-1 [
+        IF(IDAT=1)[
+            "add unscored portion of endep_tmp(irl) first"
+            endep(irl)=endep(irl)+endep_tmp(irl);
+            endep2(irl)=endep2(irl)+endep_tmp(irl)*endep_tmp(irl);
+        ]
+        "divide by rhor so that we do not have to store rhor in the .pardose"
+        "file during parallel runs."
+        endep(irl)=endep(irl)/rhor(irl+1);
+        endep2(irl)=endep2(irl)/(rhor(irl+1)*rhor(irl+1));
+    ]
 
 #ifdef HAVE_C_COMPILER;
 
+"*******************************************************************************
+" #OMP_EGS - We use the existing handling of parallel runs in order to combine
+"            the obtained results. The condition omp_size>1 added indicates a 
+"            parallel execution using OpenMP.
+"*******************************************************************************
 "store endep and endep2 before analysis for a parallel run"
-IF(IPARALLEL>1 | n_parallel>0)[
+IF(IPARALLEL>1 | n_parallel>0 | omp_size>1)[
 
    "now determine the full file name with the proper _w addition"
    "this file is written directly into the user code directory"
    parname=$cstring(egs_home) // $cstring(user_code) // $file_sep //
              $cstring(work_dir) // $cstring(output_file);
-   IF(n_parallel>0)[
+
+   IF(n_parallel>0 | omp_size>1)[
       "have to add _w[iparallel] if not controlled by script"
       parname=$cstring(parname)//'_w';
-      call egs_itostring(parname,i_parallel,.false.);
+    $IFDEF(#,_OPENMP);
+        call egs_itostring(parname,omp_iam+1,.false.);
+    $ELSE(#);
+        call egs_itostring(parname,i_parallel,.false.);
+    $ENDIF(#);      
    ]
+
    parname=$cstring(parname)//'.pardose';
    "name must be null terminated"
    parname(lnblnk1(parname)+1:lnblnk1(parname)+1)=char(0);
@@ -3017,45 +3132,61 @@ IF(IPARALLEL>1 | n_parallel>0)[
 
 #endif;
 
+" Print RNG state for each thread"
+"$IFDEF(#,_OPENMP);
+"$OMP{0,CRITICAL};
+"OUTPUT61 omp_iam;(/' RNG state for thread ',I3,':');
+"    $SHOW-RNG-STATE(6);
+"    $SHOW-RNG-STATE(1);
+"$OMP{0,END CRITICAL};
+"$ELSE(#);
+"OUTPUT61; (/' Final RNG state :');
+"    $SHOW-RNG-STATE(6);
+"    $SHOW-RNG-STATE(1);
+"$ENDIF(#);
+
+$OMP{0,END PARALLEL};
+
 :ANALYZE-PARALLEL:;
 
-"Now analyze uncertainty and convert
-"to dose per unit incident fluence gray-cm**2
-DO i=1,IMAX [
-        DO j=1,JMAX [
-            DO k=1,KMAX [
+    "Now analyze uncertainty and convert
+    "to dose per unit incident fluence gray-cm**2
+    DO i=1,IMAX [
+            DO j=1,JMAX [
+                DO k=1,KMAX [
 
-               "first, estimate uncertainty"
-               irl= $IRD(i,j,k);
-               temp=endep(irl)/temp2;
-               endep2(irl)=endep2(irl)/temp2;
-               endep2(irl)=(endep2(irl)-temp*temp)/(temp2-1);
-               IF(endep2(irl)>0) endep2(irl)=sqrt(endep2(irl));
-               IF(endep(irl)~=0) endep2(irl)=endep2(irl)/(endep(irl)/temp2);
+                "first, estimate uncertainty"
+                irl= $IRD(i,j,k);
+                temp=endep(irl)/temp2;
+                endep2(irl)=endep2(irl)/temp2;
+                endep2(irl)=(endep2(irl)-temp*temp)/(temp2-1);
+                IF(endep2(irl)>0) endep2(irl)=sqrt(endep2(irl));
+                IF(endep(irl)~=0) endep2(irl)=endep2(irl)/(endep(irl)/temp2);
 
-               "amass used to store mass but now just stores volume"
-                amass=
-                    (xbound(i+1)-xbound(i))*
-                    (ybound(j+1)-ybound(j))*
-                    (zbound(k+1)-zbound(k));
-                IF (amass~=0.0) [
-                    endep(irl) = endep(irl)*1.602e-10/(amass*ainflu);
+                "amass used to store mass but now just stores volume"
+                    amass=
+                        (xbound(i+1)-xbound(i))*
+                        (ybound(j+1)-ybound(j))*
+                        (zbound(k+1)-zbound(k));
+                    IF (amass~=0.0) [
+                        endep(irl) = endep(irl)*1.602e-10/(amass*ainflu);
+                    ]
+                    ELSE[
+                        endep(irl) = 0.0;
+                        OUTPUT61 i,j,k;
+                    ('AMASS is zero in  I= ',I4,'J= ',I4,' K= ',I4);
+                    OUTPUT61;('So the dose has been set to zero.');
+                    ];
+                    IF(endep(irl)=0.) endep2(irl)=0.9999999;
                 ]
-                ELSE[
-                    endep(irl) = 0.0;
-                    OUTPUT61 i,j,k;
-                   ('AMASS is zero in  I= ',I4,'J= ',I4,' K= ',I4);
-                   OUTPUT61;('So the dose has been set to zero.');
-                ];
-                IF(endep(irl)=0.) endep2(irl)=0.9999999;
             ]
-        ]
-]
+    ]
+
 "       Output results
 "       ==============
 
 REPLACE {$PRINT-HEADER;} WITH {;
-  IF((n_parallel>0 & is_finished)|IRESTART=4 )[
+  IF(((n_parallel>0 | omp_size>1) & is_finished)|IRESTART=4 )[
                        "fluence meaningless in final analysis"
     OUTPUT1 title;
     (//,'1',80a1 //
@@ -3307,9 +3438,10 @@ ELSE[
 ]
 
 "if IPHANT is set to 1, write out a .egsphant file"
-IF(IPHANT=1 & (n_parallel=0|(n_parallel>0 & is_finished)))[
-   call write_phantom(ioutphant,nmed,media,estepm,IMAX,JMAX,KMAX,xbound,ybound,
-                        zbound,rhor,med);
+IF(IPHANT=1 & ((n_parallel=0 & omp_size=1)
+    | ((n_parallel>0|omp_size>1) & is_finished)))[
+    call write_phantom(ioutphant,nmed,media,estepm,IMAX,JMAX,KMAX,xbound,
+        ybound,zbound,rhor,med);
 ]
 
 "zero doses in air in the .3ddose file if requested"
@@ -3350,11 +3482,12 @@ IF(zerodose=1 & zerocount >0)[
 
 "subroutine call replaces a portion of code to write to .3ddose file"
 "do not call if we are doing a parallel run"
-IF((IPARALLEL <= 1 & n_parallel = 0) | (n_parallel > 0 & is_finished))[
-   call write_dose(IMAX,JMAX,KMAX,xbound,ybound,zbound,endep,endep2,idd,MAX20);
+IF((IPARALLEL <= 1 & (n_parallel = 0 & omp_size = 1)) 
+    | ((n_parallel > 0 | omp_size > 1) & is_finished) )[
+    call write_dose(IMAX,JMAX,KMAX,xbound,ybound,zbound,endep,endep2,
+        idd,MAX20);
 ]
 ELSE [OUTPUT61;(//' No dose outputs since this is a parallel run '//);]
-
 
 $SET_ELAPSED_CPUTIME(cput2);
 timcpu=$CONVERSION_TO_SECONDS*(cput2-cput0);
@@ -3363,7 +3496,7 @@ OUTPUT61 timcpu,timcpu/3600.;
 IF(IRESTART=4)[
     OUTPUT61;(/' CPU time is for combining .pardose files only.');
 ]
-ELSEIF(n_parallel>0 & is_finished)[
+ELSEIF((n_parallel>0 | omp_size>1) & is_finished)[
     OUTPUT61;(/' CPU time is for last run to finish only.');
 ]
 CALL DATETIME(1);
@@ -3375,7 +3508,22 @@ call egs_finish;     " Finish the simulation "
 
 #ifdef HAVE_C_COMPILER;
 ;
-IF( n_parallel > 0 & ~is_finished ) [
+IF( (n_parallel > 0 | omp_size > 1) & ~is_finished) [
+$IFDEF(#,_OPENMP);
+    " First we need to open again the list file. The append option was added" 
+    " in order to not erase the current information in the file."
+    call egs_open_units(.false.);
+    is_finished = .true.;
+    
+    " Now combine the results of all the threads saved on .pardose files."
+    call egs_combine_runs(combine_results,'.pardose');
+    ainflu=temp2; "need to define this because it is used to normalize dose"
+    IF((isource = 0 | isource = 1 | isource = 3 | isource = 7) &
+        beamarea>0.) ainflu=ainflu/beamarea;
+    
+    " Finally, process the combined data."
+    goto :ANALYZE-PARALLEL:;
+$ELSE(#);
     call egs_pjob_finish(n_job);
     IF( n_job = 0 ) [
         is_finished = .true.;
@@ -3385,6 +3533,7 @@ IF( n_parallel > 0 & ~is_finished ) [
            beamarea>0.) ainflu=ainflu/beamarea;
         goto :ANALYZE-PARALLEL:;
     ]
+$ENDIF(#);
 ]
 #endif;
 
@@ -3396,8 +3545,13 @@ IF((isource=20 | isource = 21) & MLCflag=1) [call finish_vcusource;]
 $CALL_EXIT(0);
 
 stop 'Normal completion in main routine';
-end;
+
+"*******************************************************************************
+" #OMP_EGS - At this point the main routine ends. 
+"*******************************************************************************
+END PROGRAM dosxyznrc;
 "  end of main routine in dosxyznrc.mortran"
+
 %E    "dosxyznrc.mortran - start of subroutine ausgab"
 "*******************************************************************************
 "
@@ -4602,6 +4756,7 @@ end;
 ;
 
 /*
+
 C**************************************************************************
 C*                                                                        *
 C*                   Function ibsearch4(a, nsh, b)                         *
@@ -4682,3 +4837,4 @@ DO medium = 1,nmed [
 ]
 
 return; end;
+

--- a/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.macros
+++ b/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.macros
@@ -32,6 +32,9 @@
 "                   Frederic Tessier                                          "
 "                   Marc-Andre Renaud                                         "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  The contributors named above are only those who could be identified from   "
@@ -96,6 +99,12 @@
 "
 "******************************************************************************
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside /source/ COMMON block are made private to 
+"            each thread through the THREADPRIVATE directive. The variable 
+"            theta for polar angle was renamed as thet in order to 
+"            declare /source/ in dosxyznrc main routine.
+"*******************************************************************************
 REPLACE {;COMIN/SOURCE/;} WITH {
     "Common used for passing information specific to sources                   "
     ;
@@ -136,7 +145,7 @@ REPLACE {;COMIN/SOURCE/;} WITH {
     yiso,    "y-coordinate of the isocenter        (isource=1,2,7,8,20,21) "
     ziso,    "z-coordinate of the isocenter        (isource=1,2,7,8,20,21) "
     phicol,  "(collimator|source plane) rotation angle(isource=1,2,7,8,20,21) "
-    theta($MXANG), "Polar angle of source center       (isource=1,2,7,8,20,21) "
+    thet($MXANG), "Polar angle of source center       (isource=1,2,7,8,20,21) "
     phi($MXANG), "Azimuthal angle of source center     (isource=1,2,7,8,20,21) "
     pang($MXANG), "Prob of particle being incident at theta-phi  (isource=7,8) "
     angfixed($MXANG), "fixed theta or phi for group i           (isource=7,8) "
@@ -233,13 +242,15 @@ REPLACE {;COMIN/SOURCE/;} WITH {
     the_vcu_code,    "name of vcu code (particleDmlc)	      (isource=21)"
     the_phsp_file;  "name of phase space file (above MLC)         (isource=20)"
     "Explicit declarations for compatibility with implicit none"
+
+    $OMP{0,THREADPRIVATE(/source/)};
     real*8    esrc,muIndex;
     $LONG_INT nhist, nnread,nshist,nphist,nnphsp;
     $REAL einsrc, xsrcold, ysrcold,usrcold,vsrcold,wsrcold,weightold,
     frMU_indx,zsrcold,mu_phspold;
     real*4    zinc, xinl, xinu, yinl, yinu, zinl, zinu, thetax, thetay, thetaz,
     uinc, vinc, winc, beamarea, xcol,ycol,xiso, yiso, ziso, phicol,
-    theta, phi, xtemp, ytemp, ztemp, phicoltemp,thetatemp, phitemp,
+    thet, phi, xtemp, ytemp, ztemp, phicoltemp,thetatemp, phitemp,
     pang,angfixed,angmin,angmax,pgang,r_11, r_12, r_13, r_21,
     r_22, r_23, r_31, r_32, r_33,dsource,dsourcetemp,
     ein, eksrcm, esrc_sp, SSD, NINCSRC,

--- a/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
@@ -33,6 +33,9 @@
 "                   Frederic Tessier                                          "
 "                   Marc-Andre Renaud                                         "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  The contributors named above are only those who could be identified from   "
@@ -125,12 +128,12 @@
 "Record SC1-1  Parallel beam incident from any direction with rectangular
 "            collimation
 "
-"       iqin,isource,xiso,yiso,ziso,theta,phi,xcol,ycol,phicol
+"       iqin,isource,xiso,yiso,ziso,thet,phi,xcol,ycol,phicol
 "
 "               iqin        Charge of the incident beam (defaults to 0)
 "               isource     = 1
 "               x|y|z|iso   x|y|z|-coordinates of the isocenter
-"               theta       angle between the +z direction and a line joining
+"               thet       angle between the +z direction and a line joining
 "                           the center of the beam to the isocenter
 "               phi         angle  between the +x direction and the
 "                           projection of the line joining the center of the
@@ -148,7 +151,7 @@
 "
 "Record SC1-2  Full phase-space source file, particles incident on front face
 "
-"       iqin,isource,xiso,yiso,ziso,theta,phi,dsource,phicol,i_dbs,r_dbs,
+"       iqin,isource,xiso,yiso,ziso,thet,phi,dsource,phicol,i_dbs,r_dbs,
 "                                         ssd_dbs,z_dbs,e_split
 "
 "               iqin(iqphsp)= 0 only photons from ph-sp file will be used
@@ -158,7 +161,7 @@
 "                           internally renamed as iqphsp
 "               isource     =  2
 "               x|y|z|iso   x|y|z|-coordinates of the isocenter
-"               theta       angle between the +z direction and a line joining
+"               thet       angle between the +z direction and a line joining
 "                           the origin in the phase space plane to the
 "                           isocenter.  theta=180 degrees for a beam down
 "                           from the top.
@@ -234,7 +237,7 @@
 "                           = 2 all the particles will be simulated
 "               isource     =  4
 "               x|y|z|iso   x|y|z|-coordinates of the isocenter
-"               theta       angle between the +z direction and a line joining
+"               thet       angle between the +z direction and a line joining
 "                           the origin in the phase space plane to the isocenter
 "               phi         angle  between the +x direction and the
 "                           projection of the line joining the origin in the
@@ -376,7 +379,7 @@
 "  your EGS_HOME/bin/config directory.  See the DOSXYZnrc Manual for more
 "  details.
 "
-"       iqin,isource,xiso,yiso,ziso,theta,phi,dsource,phicol,i_dbs,e_split
+"       iqin,isource,xiso,yiso,ziso,thet,phi,dsource,phicol,i_dbs,e_split
 "
 "               iqin(iqinc)= 0 only photons from BEAM simulation will be used
 "                           = 1 only positrons will be used
@@ -385,7 +388,7 @@
 "                           internally renamed as iqinc
 "               isource     = 9
 "               x|y|z|iso   x|y|z|-coordinates of the isocenter.
-"               theta       angle between the +z direction and a vector
+"               thet       angle between the +z direction and a vector
 "                           joining the isocentre to the origin of the source
 "                           plane (the plane where the particles are sampled
 "                           from the BEAM simulation--which is the
@@ -557,9 +560,9 @@
 "------------------------------------------------------------------------------
 "Record SC1-7a, SC1-8a and SC1-10a (required for sources 7, 8 and 10 only)
 "        if nang>0:
-"         (theta(i),phi(i),pang(i),i=1,nang)
+"         (thet(i),phi(i),pang(i),i=1,nang)
 "
-"               theta(i)    incident theta i
+"               thet(i)    incident theta i
 "               phi(i)      incident phi i.
 "               pang(i)     probability of a particle being incident at
 "                           theta(i)-phi(i) (probabilities are automatically
@@ -584,10 +587,10 @@
 "-------------------------------------------------------------------------------
 "Record SC1-20a and SC1-21a (required for sources 20 and 21)
 "
-"  (|x|y|ziso(i),theta(i),phi(i),phicol(i),dsource(i),muIndex(i),i=1,nset)
+"  (|x|y|ziso(i),thet(i),phi(i),phicol(i),dsource(i),muIndex(i),i=1,nset)
 "
 "           |x|y|ziso(i)    x,y,z of isocentre for control point i
-"               theta(i)    incident theta for control point i
+"               thet(i)    incident theta for control point i
 "               phi(i)      incident phi for control point i
 "               phicol(i)   incident phicol for control point i
 "               dsource(i)  distance from isocentre to origin of BEAM
@@ -1042,9 +1045,9 @@ IF(isource = 0) [ "Frontal parallel beam directed along z-axis"
 ELSEIF(isource = 1) [ "Parallel beam directed in any direction"
 "------------------------------------------------------------------------"
     xiso   = temp(1);     yiso   = temp(2);     ziso   = temp(3);
-    theta(1)  = temp(4);     phi(1)  = temp(5);     xcol   = temp(6);
+    thet(1)  = temp(4);     phi(1)  = temp(5);     xcol   = temp(6);
     ycol   = temp(7);     phicol = temp(8);
-    OUTPUT iqin,xiso,yiso,ziso,theta(1),phi(1),xcol,ycol,phicol;
+    OUTPUT iqin,xiso,yiso,ziso,thet(1),phi(1),xcol,ycol,phicol;
     ( / ' Parallel beam incident from an arbitrary direction'/
         ' Electric charge of the source:'       ,t40,i12     /
         ' x-coordinate of the isocenter:'       ,t40,f10.4   /
@@ -1060,11 +1063,11 @@ ELSEIF(isource = 1) [ "Parallel beam directed in any direction"
 ELSEIF(isource = 2)[ "Full phase space for each particle"
 "------------------------------------------------------------------------"
     xiso    = temp(1);     yiso    = temp(2);     ziso    = temp(3);
-    theta(1)   = temp(4);     phi(1)     = temp(5);     dsource = temp(6);
+    thet(1)   = temp(4);     phi(1)     = temp(5);     dsource = temp(6);
     phicol  = temp(7);     iqphsp=iqin;
     i_dbs=temp(8); r_dbs=temp(9); ssd_dbs=temp(10); z_dbs=temp(11);
     e_split=temp(12);
-    OUTPUT xiso,yiso,ziso,theta(1),phi(1),dsource,phicol,e_split;
+    OUTPUT xiso,yiso,ziso,thet(1),phi(1),dsource,phicol,e_split;
     ( / ' Full phase space from an arbitrary direction'/
         ' x-coordinate of the isocenter:'    ,t55,f10.4/
         ' y-coordinate of the isocenter:'    ,t55,f10.4/
@@ -1168,8 +1171,8 @@ ELSEIF(isource = 7) [ "Parallel at multiple, user-selected angles"
       DO I=1,nang["get each theta-phi and prob."
           OUTPUT I;(' Incident theta-phi pair ',I4,':'/
                     '    theta (deg.), phi (deg.), probability:',$);
-          INPUT theta(I),phi(I),pang(I); (3F15.0);
-          OUTPUT theta(I),phi(I),pang(I); (3F10.4);
+          INPUT thet(I),phi(I),pang(I); (3F15.0);
+          OUTPUT thet(I),phi(I),pang(I); (3F10.4);
           temp(1)=temp(1)+pang(I);
       ]
       DO I=1,nang["normalize probabilities + create cumulative prob distn"
@@ -1228,10 +1231,10 @@ ELSEIF(isource = 7) [ "Parallel at multiple, user-selected angles"
            ]
            IF(ivary(I)=1)["fixed phi"
              phi(K)=angfixed(I);
-             theta(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
+             thet(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            ELSE["fixed theta"
-             theta(K)=angfixed(I);
+             thet(K)=angfixed(I);
              phi(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            pang(K)=pgang(I)/ngang(I);
@@ -1296,8 +1299,8 @@ ELSEIF(isource = 8)[ "Full phase space incident from multiple angles"
       DO I=1,nang["get each theta-phi and prob."
           OUTPUT I;(' Incident theta-phi pair ',I4,':'/
                     '    theta (deg.), phi (deg.), probability:',$);
-          INPUT theta(I),phi(I),pang(I); (3F15.0);
-          OUTPUT theta(I),phi(I),pang(I); (3F10.4);
+          INPUT thet(I),phi(I),pang(I); (3F15.0);
+          OUTPUT thet(I),phi(I),pang(I); (3F10.4);
           temp(1)=temp(1)+pang(I);
       ]
       DO I=1,nang["normalize probabilities + create cumulative prob distn"
@@ -1376,10 +1379,10 @@ ELSEIF(isource = 8)[ "Full phase space incident from multiple angles"
            ]
            IF(ivary(I)=1)["fixed phi"
              phi(K)=angfixed(I);
-             theta(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
+             thet(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            ELSE["fixed theta"
-             theta(K)=angfixed(I);
+             thet(K)=angfixed(I);
              phi(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            pang(K)=pgang(I)/ngang(I);
@@ -1396,10 +1399,10 @@ ELSEIF(isource = 8)[ "Full phase space incident from multiple angles"
 ELSEIF(isource = 9)[ "BEAM simulation of treatment head"
 "------------------------------------------------------------------------"
     xiso    = temp(1);     yiso    = temp(2);     ziso    = temp(3);
-    theta(1)   = temp(4);     phi(1)     = temp(5);     dsource = temp(6);
+    thet(1)   = temp(4);     phi(1)     = temp(5);     dsource = temp(6);
     phicol  = temp(7);     iqinc=iqin;
     i_dbs=temp(8); e_split=temp(9);
-    OUTPUT xiso,yiso,ziso,theta(1),phi(1),dsource,phicol,e_split;
+    OUTPUT xiso,yiso,ziso,thet(1),phi(1),dsource,phicol,e_split;
     ( / ' BEAM simulation of treatment head incident from any direction'/
         ' x-coordinate of the isocenter:'    ,t55,f10.4/
         ' y-coordinate of the isocenter:'    ,t55,f10.4/
@@ -1477,8 +1480,8 @@ ELSEIF(isource = 10)[ "BEAM simulation source from multiple angles"
       DO I=1,nang["get each theta-phi and prob."
           OUTPUT I;(' Incident theta-phi pair ',I4,':'/
                     '    theta (deg.), phi (deg.), probability:',$);
-          INPUT theta(I),phi(I),pang(I); (3F15.0);
-          OUTPUT theta(I),phi(I),pang(I); (3F10.4);
+          INPUT thet(I),phi(I),pang(I); (3F15.0);
+          OUTPUT thet(I),phi(I),pang(I); (3F10.4);
           temp(1)=temp(1)+pang(I);
       ]
       DO I=1,nang["normalize probabilities + create cumulative prob distn"
@@ -1527,10 +1530,10 @@ ELSEIF(isource = 10)[ "BEAM simulation source from multiple angles"
            ]
            IF(ivary(I)=1)["fixed phi"
              phi(K)=angfixed(I);
-             theta(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
+             thet(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            ELSE["fixed theta"
-             theta(K)=angfixed(I);
+             thet(K)=angfixed(I);
              phi(K)=angmin(I)+(J-1)*(angmax(I)-angmin(I))/(ngang(I)-1);
            ]
            pang(K)=pgang(I)/ngang(I);
@@ -2755,7 +2758,7 @@ IF(isource >3 & isource <7)[   dsource=-dsource; ]
 IF(isource ~= 20 & isource ~= 21)["four 20 and 21 the matrices are calculated"
 "on the fly -per particle"
 "Collimator/source rotation sine's and cosine's needed locally
-costheta = cos(theta(1)*3.141593/180.); sintheta = sin(theta(1)*3.141593/180.);
+costheta = cos(thet(1)*3.141593/180.); sintheta = sin(thet(1)*3.141593/180.);
 coscol   = cos(phicol*3.141593/180.); sincol   = sin(phicol*3.141593/180.);
 cosphi   = cos(phi(1)*3.141593/180.); sinphi   = sin(phi(1)*3.141593/180.);
 
@@ -2773,8 +2776,8 @@ r_33(1) = -costheta                              ;
 IF(isource=7 | isource=8 | isource=10)[
         "calculate the rest of the rotation matrices"
   DO I=2,numang[
-    costheta = cos(theta(I)*3.141593/180.);
-    sintheta = sin(theta(I)*3.141593/180.);
+    costheta = cos(thet(I)*3.141593/180.);
+    sintheta = sin(thet(I)*3.141593/180.);
     cosphi = cos(phi(I)*3.141593/180.);
     sinphi= sin(phi(I)*3.141593/180.);
     r_11(I) =  costheta*cosphi*coscol + sinphi*sincol;
@@ -2933,7 +2936,7 @@ IF(isource = 0)[
        T25,' Angle relative to -z:',t57,f10.4,' degrees'        /);
 ]
 ELSEIF(isource = 1)[
-    OUTPUT61 iqin,xiso,yiso,ziso,theta(1),phi(1),xcol,ycol,phicol;
+    OUTPUT61 iqin,xiso,yiso,ziso,thet(1),phi(1),xcol,ycol,phicol;
     ( t15,' Parallel beam incident from an arbitrary direction'   / /
         t20,' Electric charge of the source:'  ,t62,i12             /
         t20,' x-coordinate of the isocenter,'  ,t62,f10.4,' cm'     /
@@ -2946,7 +2949,7 @@ ELSEIF(isource = 1)[
         t20,' Collimator rotation angle,'      ,t62,f10.4,' degrees'/);
 ]
 ELSEIF(isource = 2)[
-   OUTPUT61 xiso,yiso,ziso,theta(1),phi(1),dsource,phicol,nshist;
+   OUTPUT61 xiso,yiso,ziso,thet(1),phi(1),dsource,phicol,nshist;
    ( t15,' Full phase space input for each incident particle'      //
        t10,' x-coordinate of the isocenter,'    ,t62,f10.4,' cm'     /
        t10,' y-coordinate of the isocenter,'    ,t62,f10.4,' cm'     /
@@ -3025,10 +3028,10 @@ ELSEIF(isource = 7)[
         t20,'    pair        (deg.)       (deg.)      probability');
     DO I=1,nang[
       IF(I=1)[
-         OUTPUT61 I,theta(I),phi(I),pang(I); (t20,i7,f16.4,f13.4,f15.4);
+         OUTPUT61 I,thet(I),phi(I),pang(I); (t20,i7,f16.4,f13.4,f15.4);
       ]
       ELSE[
-         OUTPUT61 I,theta(I),phi(I),pang(I)-pang(I-1);
+         OUTPUT61 I,thet(I),phi(I),pang(I)-pang(I-1);
                   (t20,i7,f16.4,f13.4,f15.4);
       ]
     ]
@@ -3077,10 +3080,10 @@ ELSEIF(isource = 8)[
         t10,'    pair        (deg.)       (deg.)      probability');
     DO I=1,nang[
       IF(I=1)[
-         OUTPUT61 I,theta(I),phi(I),pang(I); (t10,i7,f16.4,f13.4,f15.4);
+         OUTPUT61 I,thet(I),phi(I),pang(I); (t10,i7,f16.4,f13.4,f15.4);
       ]
       ELSE[
-         OUTPUT61 I,theta(I),phi(I),pang(I)-pang(I-1);
+         OUTPUT61 I,thet(I),phi(I),pang(I)-pang(I-1);
                   (t10,i7,f16.4,f13.4,f15.4);
       ]
     ]
@@ -3145,7 +3148,7 @@ ELSEIF(isource = 8)[
   ]
 ]
 ELSEIF(isource=9)[
-   OUTPUT61 xiso,yiso,ziso,theta(1),phi(1),dsource,phicol,
+   OUTPUT61 xiso,yiso,ziso,thet(1),phi(1),dsource,phicol,
      $cstring(the_beam_code),$cstring(the_input_file),
      $cstring(the_pegs_file);
    ( t15,' BEAM treatment head simulation used as source:'      //
@@ -3196,10 +3199,10 @@ ELSEIF(isource=10)[
         t10,'    pair        (deg.)       (deg.)      probability');
      DO I=1,nang[
       IF(I=1)[
-         OUTPUT61 I,theta(I),phi(I),pang(I); (t10,i7,f16.4,f13.4,f15.4);
+         OUTPUT61 I,thet(I),phi(I),pang(I); (t10,i7,f16.4,f13.4,f15.4);
       ]
       ELSE[
-         OUTPUT61 I,theta(I),phi(I),pang(I)-pang(I-1);
+         OUTPUT61 I,thet(I),phi(I),pang(I)-pang(I-1);
                   (t10,i7,f16.4,f13.4,f15.4);
       ]
      ]
@@ -3359,6 +3362,12 @@ implicit none;
 ;COMIN/ENERGYSRC,SOURCE,GEOM,RANDOM,SSMDIS,BMODEL,PHSPFILE,RWPHSP,EGS-IO,
        SCORE/;
 
+"*******************************************************************************
+" #OMP_EGS - The thread id and number of threads are needed to correctly 
+"            partition the phase space file under OpenMP execution.
+"*******************************************************************************
+;COMIN/OMP-EGS/;
+
 $REAL xsrc,ysrc,zsrc, "X,Y,Z position of incident particle (isource=2,8,9)"
       xsrcp,ysrcp,zsrcp, "transformed X,Y,Z position of incident particle"
       usrc,vsrc,wsrc, "U,V,W of incident particle (isource=2,8,9)"
@@ -3388,7 +3397,12 @@ $INTEGER ix,jy,kz,i,j,k,
          ibit;
 $LONG_INT n_hist_dum;
 
+"*******************************************************************************
+" #OMP_EGS - Global variable wsrc is made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 save wsrc; "in case of phsp particle recycling"
+$OMP{0,THREADPRIVATE(wsrc)};
 
 zsrc = dsource;
 
@@ -3584,7 +3598,11 @@ ELSEIF(isource = 2 | isource=8)[ "Full phase space for each particle"
            ]
 
        ]
-       ELSEIF(IPARALLEL>1 & PARNUM>0 & nnphsp > INT(PARNUM*nshist/IPARALLEL))[
+"*******************************************************************************
+" #OMP_EGS - Now the ELSEIF condition considers the execution under OpenMP.
+"*******************************************************************************
+       ELSEIF((IPARALLEL>1 & PARNUM>0 & nnphsp > INT(PARNUM*nshist/IPARALLEL)) | 
+          (nnphsp > INT((omp_iam+1)*nshist/omp_size)))[
            NofREPEAT = NofREPEAT + 1;
            OUTCNT=OUTCNT+1;
            OUTPUT61;
@@ -3829,7 +3847,11 @@ ELSEIF( isource = 20 ) [ "Phase Space Incident from multiple settings"
                 $IAEA_SET_PHSP_RECORD(i_unit_in,nnphsp);
            ]
       ]
-      ELSEIF(IPARALLEL>1 & PARNUM>0 & nnphsp > INT(PARNUM*nshist/IPARALLEL))[
+"*******************************************************************************
+" #OMP_EGS - Now the ELSEIF condition considers the execution under OpenMP.
+"*******************************************************************************
+    ELSEIF((IPARALLEL>1 & PARNUM>0 & nnphsp > INT(PARNUM*nshist/IPARALLEL)) | 
+      (nnphsp > INT((omp_iam+1)*nshist/omp_size)))[
            NofREPEAT = NofREPEAT + 1;
            OUTCNT=OUTCNT+1;
            OUTPUT61;
@@ -4172,8 +4194,8 @@ ELSEIF(isource=20 | isource=21)[
    ]
 
    "calculate rotation matrix"
-   " get theta, phi, phicol x|y|ziso"
-   theta(1)=thetatemp(K-1)+(thetatemp(K)-thetatemp(K-1))*
+   " get thet, phi, phicol x|y|ziso"
+   thet(1)=thetatemp(K-1)+(thetatemp(K)-thetatemp(K-1))*
 		(frMU_indx-muIndex(K-1))/(muIndex(K)-muIndex(K-1));
    phi(1)=phitemp(K-1)+(phitemp(K)-phitemp(K-1))*
 		(frMU_indx-muIndex(K-1))/(muIndex(K)-muIndex(K-1));
@@ -4187,7 +4209,7 @@ ELSEIF(isource=20 | isource=21)[
 		(frMU_indx-muIndex(K-1))/(muIndex(K)-muIndex(K-1));
 
 "Collimator/source rotation sine's and cosine's needed locally
-costheta = cos(theta(1)*3.141593/180.); sintheta = sin(theta(1)*3.141593/180.);
+costheta = cos(thet(1)*3.141593/180.); sintheta = sin(thet(1)*3.141593/180.);
 coscol   = cos(phicol*3.141593/180.); sincol = sin(phicol*3.141593/180.);
 cosphi   = cos(phi(1)*3.141593/180.); sinphi   = sin(phi(1)*3.141593/180.);
 

--- a/HEN_HOUSE/utils/nrcaux.mortran
+++ b/HEN_HOUSE/utils/nrcaux.mortran
@@ -27,6 +27,9 @@
 "  Contributors:    Blake Walters                                             "
 "                   Reid Townson                                              "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  Parts of the EGS code that originate from SLAC are distributed by NRC      "
@@ -128,7 +131,13 @@ $INTEGER ku,kr,ka;
 ;COMIN/BOUNDS, STACK,EPCONT,EGS-VARIANCE-REDUCTION,USEFUL,EGS-IO/;
 
 DATA ICOUNT/0/,JHSTRY/1/ graph_unit/-1/;
+
+"*******************************************************************************
+" #OMP_EGS - Global variables ICOUNT, JHSTRY and graph_unit are made private to
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 save     ICOUNT,JHSTRY,graph_unit;
+$OMP{0,THREADPRIVATE(ICOUNT,JHSTRY,graph_unit)};
 
 ku = 13; kr = 0; ka = 1;
 IF(IARG = -99) [ "Initialize flags so we will get calls thru AUSGAB"

--- a/HEN_HOUSE/utils/phsp_macros.mortran
+++ b/HEN_HOUSE/utils/phsp_macros.mortran
@@ -25,6 +25,9 @@
 "                                                                             "
 "  Contributors:    Iwan Kawrakow                                             "
 "                                                                             "
+"  OpenMP support:  Edgardo Doerner                                           "
+"                   Paola Caprile                                             "
+"                                                                             "
 "#############################################################################"
 "                                                                             "
 "  The contributors named above are only those who could be identified from   "
@@ -77,6 +80,10 @@
 "#############################################################################"
 
 
+"*******************************************************************************
+" #OMP_EGS - Global data inside the /RWPHSP/ COMMON block is made private to 
+"            each thread through the THREADPRIVATE directive
+"*******************************************************************************
 ;
 REPLACE {;COMIN/RWPHSP/;} WITH {
 "RWPHSP must be included in the common block of main in any code that uses"
@@ -153,6 +160,7 @@ REPLACE {;COMIN/RWPHSP/;} WITH {
    dosxyz2beam_izscore, "set to 1 if Z scored for each particle (IAEA only)"
    MODE_RW;   "mode of phsp file (0 with ZLAST, 2 without), writing only"
 
+$OMP{0,THREADPRIVATE(/RWPHSP/)};
 CHARACTER*32000 STRING_TEMP_ZLAST_OUT($MAX_SC_PLANES);
 CHARACTER*28000 STRING_TEMP_OUT($MAX_SC_PLANES);
 $LONG_INT IHSTRY_PHSP($MAX_SC_PLANES),iaea_dummy_long,NHSTRY_DOS;

--- a/README.md
+++ b/README.md
@@ -1,3 +1,45 @@
+## Parallel implementation of EGSnrc using OpenMP
+
+This is a prototype for the parallelization of EGSnrc user codes using the OpenMP API.
+It is currently implemented on the DOSXYZnrc user code. An advantage of this development
+is that removes the necessity of the use of a job scheduler and/or lock-file mechanism to
+handle parallel jobs and combination of results.
+
+## Installation and usage
+
+    1a. If you start from a fresh installation just install EGSnrc as usual. All the needed files 
+    for OpenMP support are included in this fork.
+    1b. Otherwise, once all the files are downloaded to HEN_HOUSE area, copy dosxyznrc folder 
+    ($HEN_HOUSE/user_codes/dosxyznrc) to the user codes area (i.e. $EGS_HOME)
+    2. In terminal, go to the dosxyznrc folder inside $EGS_HOME.
+    3. If the provided standard_makefile is used, just type "make omp" to compile the user code
+    with OpenMP support. It essentially compiles with -fopenmp flag (for gcc only). If you want to
+    use another compiler, you must change this flag with the proper one inside standard_makefile.
+    4. Execute the code as usual. The message "Number of threads in OpenMP parallel execution ..."
+    should appear if OpenMP support was enabled
+
+Due to the use of private variables (through the OpenMP THREADPRIVATE directive) it is needed
+for some machines to increase the stack size of the OS. For example, on macOs or
+GNU/Linux simply type on terminal "ulimit -s hard". In our case, we added that command on
+the .bashrc configuration file.
+
+We have tested sources 0 (Parallel Rectangular Beam Incident from Front) and 2 (Phase-Space
+Source Incident from Any Direction), although with the notable exception of a BEAMnrc source
+model the other sources should work without problems.
+
+Also should be noted that the combination of results at the end of the simulation is
+implemented only for the *.3ddose file. Information printed on console and output to
+*.egslst file come only from the MASTER thread.
+
+## Additional information
+
+1. All relevant changes to the source files and makefiles are labeled with the #OMPEGS tag.
+2. In dosxyznrc $NBATCH was selected as 1, in order to start the parallel region inside 
+the ibatch loop just one time.
+3. If dosxyznrc is compiled without OpenMP support (i.e. typing "make" in dosxyznrc user code folder) 
+the original implementation is recovered. Therefore, it is possible to compare OpenMP execution 
+with the parallelization using a BQS, for example.
+
 ## What is EGSnrc?
 
 EGSnrc is a software toolkit to perform Monte Carlo simulation of


### PR DESCRIPTION
## Parallel implementation of EGSnrc using OpenMP

This is a prototype for the parallelization of EGSnrc user codes using the OpenMP API.
It is currently implemented on the DOSXYZnrc user code. An advantage of this development
is that removes the necessity of the use of a job scheduler and/or lock-file mechanism to
handle parallel jobs and combination of results.

## Installation and usage

    1a. If you start from a fresh installation just install EGSnrc as usual. All the needed files 
    for OpenMP support are included in this fork.
    1b. Otherwise, once all the files are downloaded to HEN_HOUSE area, copy dosxyznrc folder 
    ($HEN_HOUSE/user_codes/dosxyznrc) to the user codes area (i.e. $EGS_HOME)
    2. In terminal, go to the dosxyznrc folder inside $EGS_HOME.
    3. If the provided standard_makefile is used, just type "make omp" to compile the user code
    with OpenMP support. It essentially compiles with -fopenmp flag (for gcc only). If you want to
    use another compiler, you must change this flag with the proper one inside standard_makefile.
    4. Execute the code as usual. The message "Number of threads in OpenMP parallel execution ..."
    should appear if OpenMP support was enabled

Due to the use of private variables (through the OpenMP THREADPRIVATE directive) it is needed
for some machines to increase the stack size of the OS. For example, on macOs or
GNU/Linux simply type on terminal "ulimit -s hard". In our case, we added that command on
the .bashrc configuration file.

We have tested sources 0 (Parallel Rectangular Beam Incident from Front) and 2 (Phase-Space
Source Incident from Any Direction), although with the notable exception of a BEAMnrc source
model the other sources should work without problems.

Also should be noted that the combination of results at the end of the simulation is
implemented only for the *.3ddose file. Information printed on console and output to
*.egslst file come only from the MASTER thread.

## Additional information

1. All relevant changes to the source files and makefiles are labeled with the "#OMP_EGS" tag.
2. In dosxyznrc $NBATCH was selected as 1, in order to start the parallel region inside 
the ibatch loop just one time. You can change it to the default value of 10 if you wish, although you should expect and additional overhead.
3. If dosxyznrc is compiled without OpenMP support (i.e. typing "make" in dosxyznrc user code folder) 
the original implementation is recovered. Therefore, it is possible to compare OpenMP execution 
with the parallelization using a BQS, for example.