### PR TITLE
Fix #351: Infinite loop using beam source in egs++

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -206,7 +206,7 @@ EGS_I64 EGS_BeamSource::getNextParticle(EGS_RandomGenerator *, int &q,
             te -= EGS_Application::activeApplication()->getRM();
         }
         ok = true;
-        if (te > Emax) {
+        if (te > Emax + epsilon) {
             ok = false;
         } //egsInformation("Emax rejection\n"); }
         if (particle_type < 2 && tq != particle_type) {


### PR DESCRIPTION
Due to a floating point comparison, an infinite loop was possible in egs++ applications using a beam shared library source. This was fixed using the epsilon constant.