### PR TITLE
Fix #334: recycle definition in egs++ phsp sources

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -64,15 +64,15 @@ void EGS_PhspSource::init() {
     description = "Invalid phase space source";
     Nread = 0;
     count = 0;
-    Nrecycle = 0;
+    Nrestart = 0;
     Npos = 0;
     Nlast = 0;
     wmin = -veryFar;
     wmax = veryFar;
-    Nreuse_g = 1;
-    Nreuse_e = 1;
-    Nreuse = 1;
-    Nuse = 2;
+    Nrecycle_g = 0;
+    Nrecycle_e = 0;
+    Nrecycle = 0;
+    Nuse = -1;
     first = true;
 }
 
@@ -260,11 +260,23 @@ EGS_PhspSource::EGS_PhspSource(EGS_Input *input, EGS_ObjectFactory *f) :
     int ntmp;
     err = input->getInput("reuse photons",ntmp);
     if (!err && ntmp > 0) {
-        Nreuse_g = ntmp;
+        Nrecycle_g = ntmp;
+    }
+    else {
+        err = input->getInput("recycle photons",ntmp);
+        if (!err && ntmp > 0) {
+            Nrecycle_g = ntmp;
+        }
     }
     err = input->getInput("reuse electrons",ntmp);
     if (!err && ntmp > 0) {
-        Nreuse_e = ntmp;
+        Nrecycle_e = ntmp;
+    }
+    else {
+        err = input->getInput("recycle electrons",ntmp);
+        if (!err && ntmp > 0) {
+            Nrecycle_e = ntmp;
+        }
     }
     description = "Phase space source from ";
     description += the_file_name;
@@ -275,11 +287,11 @@ EGS_I64 EGS_PhspSource::getNextParticle(EGS_RandomGenerator *, int &q,
     if (!recl) egsFatal("EGS_PhspSource::readParticle(): the file is not "
                             "open yet\n");
     /*
-    if( Nuse >= Nreuse ) {
+    if( Nuse >= Nrecycle ) {
         do { readParticle(); } while ( rejectParticle() );
     }
     */
-    if (Nuse >= Nreuse) {
+    if (Nuse > Nrecycle || Nuse < 0) {
         readParticle();
     }
     x.x = p.x;
@@ -348,7 +360,7 @@ void EGS_PhspSource::readParticle() {
                    "implies that uncertainty estimates will be inaccurate\n",
                    Nlast,Nfirst);
         the_file.seekg(recl,ios::beg);
-        Nrecycle++;
+        Nrestart++;
         Npos = Nfirst;
     }
     the_file.read(record,recl*sizeof(char));
@@ -399,13 +411,13 @@ void EGS_PhspSource::readParticle() {
     first = false;
     if (p.q) {
         p.E -= EGS_Application::activeApplication()->getRM();
-        Nreuse = Nreuse_e;
+        Nrecycle = Nrecycle_e;
     }
     else {
-        Nreuse = Nreuse_g;
+        Nrecycle = Nrecycle_g;
     }
     Nuse = 0;
-    p.wt /= Nreuse;
+    p.wt /= (Nrecycle+1);
 }
 
 bool EGS_PhspSource::rejectParticle() const {

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.h
@@ -83,8 +83,8 @@ A phase-space file source is defined as follows:
     particle type = one of photons, electrons, positrons, all, or charged
     cutout = x1 x2 y1 y2  (optional)
     weight window = wmin wmax, the min and max particle weights to use. If the particle weight is not in this range, it is rejected. (optional)
-    reuse photons = number of times to reuse each photon (optional)
-    reuse electrons = number of times to reuse each electron (optional)
+    recycle photons = number of times to recycle each photon (optional)
+    recycle electrons = number of times to recycle each electron (optional)
 :stop source:
 \endverbatim
 The optional \c cutout key permits to set a rectangular cutout
@@ -112,8 +112,8 @@ A simple example:
         phase space file = ../BEAM_EX16MVp/EX16MVp.egsphsp1
         particle type = all
         cutout      = -1 1 -2 2
-        reuse photons = 10
-        reuse electrons = 10
+        recycle photons = 10
+        recycle electrons = 10
     :stop source:
 
     simulation source = my_source
@@ -251,10 +251,10 @@ protected:
                 Nlast,     //!< Last record this source can use
                 count;     /*!< Particles delivered so far (may be less than
                            Nread because some particles were rejected */
-    int         Nrecycle;  //!< Number of times the file was recycled.
-    int         Nreuse_g;  //!< Number of times to reuse a photon
-    int         Nreuse_e;  //!< Number of times to reuse a charged particle
-    int         Nreuse;    //!< Number of times to reuse current particle
+    int         Nrestart;  //!< Number of times the file was restarted
+    int         Nrecycle_g;  //!< Number of times to recycle a photon
+    int         Nrecycle_e;  //!< Number of times to recycle a charged particle
+    int         Nrecycle;    //!< Number of times to recycle current particle
     int         Nuse;      //!< Number of times current particle was used so far
 
     bool        first;

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
@@ -89,8 +89,8 @@ An IAEA phase-space file source is defined as follows:
     particle type = one of photons, electrons, positrons, all, or charged
     cutout = x1 x2 y1 y2  (optional)
     weight window = wmin wmax, the min and max particle weights to use. If the particle weight is not in this range, it is rejected. (optional)
-    reuse photons = number of times to reuse each photon (optional)
-    reuse electrons = number of times to reuse each electron (optional)
+    recycle photons = number of times to recycle each photon (optional)
+    recycle electrons = number of times to recycle each electron (optional)
 :stop source:
 \endverbatim
 The optional \c cutout key permits to set a rectangular cutout
@@ -118,8 +118,8 @@ A simple example:
         iaea phase space file = your phase space file (no extension)
         particle type = all
         cutout      = -1 1 -2 2
-        reuse photons = 10
-        reuse electrons = 10
+        recycle photons = 10
+        recycle electrons = 10
     :stop source:
 
     simulation source = my_source
@@ -255,10 +255,10 @@ protected:
                 Nlast,     //!< Last record this source can use
                 count;     /*!< Particles delivered so far (may be less than
                            Nread because some particles were rejected */
-    int         Nrecycle;  //!< Number of times the file was recycled.
-    int         Nreuse_g;  //!< Number of times to reuse a photon
-    int         Nreuse_e;  //!< Number of times to reuse a charged particle
-    int         Nreuse;    //!< Number of times to reuse current particle
+    int         Nrestart;  //!< Number of times the file was restarted
+    int         Nrecycle_g;  //!< Number of times to recycle a photon
+    int         Nrecycle_e;  //!< Number of times to recycle a charged particle
+    int         Nrecycle;    //!< Number of times to recycle current particle
     int         Nuse;      //!< Number of times current particle was used so far
     int         iaea_iostat; //!< iostat on read/write of iaea phsp file
     int         iaea_fileid; //!< phsp file unit no.


### PR DESCRIPTION
Fixes the use of the term `reuse` in the `egs++` phsp sources, instead replacing it with `recycle`. Also fixes the implementation of recycling, so that 1 recycling means that the particle is used twice. 

**Previously, `reuse=1` actually meant that the particle was used once.**