### PR TITLE
Fix variable declaration in subroutine replace_env

### DIFF
--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -1408,6 +1408,9 @@ subroutine replace_env(fname);
 "full names or ~ with the full name of $HOME"
 "Assumes environment variable or ~ appears only at the beginning of the"
 "file name"
+
+;COMIN/EGS-IO/;
+
 character*(*) fname;
 character*256 dirname;
 integer indsep,ind1,ind2;


### PR DESCRIPTION
Declared common block EGS-IO at top of subroutine replace_env--
the subroutine which allows $ and ~ to be used
at the beginning of file path names--so that i_log is declared for
output.  Don't know why this compiled with no complaints, but the
symptom was actually an incorrect "Job failed" output from
EXphantom runs, first noticed at the EGS/BEAM Workshop in Trieste, 2017.