### PR TITLE
Fix authorship and readme

### DIFF
--- a/HEN_HOUSE/user_codes/egs_cbct/Makefile
+++ b/HEN_HOUSE/user_codes/egs_cbct/Makefile
@@ -21,9 +21,10 @@
 #
 ###############################################################################
 #
-#  Author:          Ernesto Mainegra-Hing, 2007
+#  Authors:         Iwan Kawrakow, 2007
+#                   Ernesto Mainegra-Hing, 2007
 #
-#  Contributors:    Iwan Kawrakow
+#  Contributors:
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -21,9 +21,10 @@
 #
 ###############################################################################
 #
-#  Author:          Ernesto Mainegra-Hing, 2007
+#  Authors:         Iwan Kawrakow, 2007
+#                   Ernesto Mainegra-Hing, 2007
 #
-#  Contributors:    Iwan Kawrakow
+#  Contributors:
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.h
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.h
@@ -21,9 +21,10 @@
 #
 ###############################################################################
 #
-#  Author:          Ernesto Mainegra-Hing, 2007
+#  Authors:         Iwan Kawrakow, 2007
+#                   Ernesto Mainegra-Hing, 2007
 #
-#  Contributors:    Iwan Kawrakow
+#  Contributors:
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.macros
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.macros
@@ -21,9 +21,10 @@
 "                                                                             "
 "#############################################################################"
 "                                                                             "
-"  Author:          Ernesto Mainegra-Hing, 2007                               "
+"  Authors:         Iwan Kawrakow, 2007                                       "
+"                   Ernesto Mainegra-Hing, 2007                               "
 "                                                                             "
-"  Contributors:    Iwan Kawrakow                                             "
+"  Contributors:                                                              "
 "                                                                             "
 "#############################################################################"
 

--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
@@ -21,10 +21,10 @@
 #
 ###############################################################################
 #
-#  Author:          Joerg Wulff, 2007
+#  Authors:         Iwan Kawrakow, 2007
+#                   Joerg Wulff, 2007
 #
-#  Contributors:    Iwan Kawrakow
-#                   Ernesto Mainegra-Hing
+#  Contributors:    Ernesto Mainegra-Hing
 #                   Hugo Bouchard
 #                   Frederic Tessier
 #                   Reid Townson

--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.macros
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.macros
@@ -21,10 +21,10 @@
 "                                                                             "
 "#############################################################################"
 "                                                                             "
-"  Author:          Joerg Wulff, 2007                                         "
+"  Authors:         Iwan Kawrakow, 2007                                       "
+"                   Joerg Wulff, 2007                                         "
 "                                                                             "
-"  Contributors:    Iwan Kawrakow                                             "
-"                   Frederic Tessier                                          "
+"  Contributors:    Frederic Tessier                                          "
 "                                                                             "
 "#############################################################################"
 

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 EGSnrc is a software toolkit to perform Monte Carlo simulation of
 ionizing radiation transport through matter. It models the propagation
 of photons, electrons and positrons with kinetic energies between
-1&nbsp;keV and 10&nbsp;GeV, in homogeneous materials. EGSnrc is an
-extended and improved version of the Electron Gamma Shower (EGS)
+1&nbsp;keV and 10&nbsp;GeV, in homogeneous materials. EGSnrc was originally
+released in 2000, as a complete overhaul of the Electron Gamma Shower (EGS)
 software package originally developed at the Stanford Linear Accelerator
-Center (SLAC) in the 1970s. Most notably, it incorporates significant
+Center (SLAC) in the 1970s. Most notably, EGSnrc incorporates crucial
 refinements in charged particle transport, better low energy cross
 sections, and the egs++ class library to model elaborate geometries and
 particle sources.
@@ -57,6 +57,4 @@ corrections and improvements, feel free to
 [submit an issue](https://github.com/nrc-cnrc/EGSnrc/issues). For more extensive
 contributions, familiarize yourself with git and github, work on your own EGSnrc
 project fork and open a
-[pull request](https://github.com/nrc-cnrc/EGSnrc/issues). Note that significant
-contributions will require a transfer of copyright to the National Research
-Council of Canada before they can be merged into the EGSnrc distribution.
+[pull request](https://github.com/nrc-cnrc/EGSnrc/issues).


### PR DESCRIPTION
Add Iwan Kawrakow as an author of the egs_chamber source code (instead of a contributor).

Fix the top-level readme to state the original release date of EGSnrc, and qualify it as a complete overhaul of EGS (instead of a extended and improved version). Remove the copyright transfer requirement note from the contributing section, because we will be moving to allow external copyrights to be included in the project.

