### PR TITLE
Fix isotropic emission into solid angle and egs_view alias

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -21,9 +21,10 @@
 #
 ###############################################################################
 #
-#  Author:          Ernesto Mainegra-Hing, 2016
+#  Authors:         Ernesto Mainegra-Hing, 2016
+#                   Hugo Bouchard, 2016
 #
-#  Contributors:    Hugo Bouchard
+#  Contributors:
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -23,7 +23,8 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:    Hubert Ho
+#  Contributors:    Long Zhang
+#                   Hubert Ho
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -23,7 +23,8 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:    Frederic Tessier
+#  Contributors:    Long Zhang
+#                   Frederic Tessier
 #                   Reid Townson
 #                   Ernesto Mainegra-Hing
 #                   Hugo Bouchard
@@ -298,15 +299,11 @@ public:
             }
         }
         while (!ok);
-
-        u.z = rndm->getUniform()*(buf_1 - buf_2) - buf_1;
-
+        u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
         EGS_Float sinz = 1-u.z*u.z;
         if (sinz > epsilon) {
             sinz = sqrt(sinz);
             EGS_Float cphi, sphi;
-            //rndm->getAzimuth(cphi,sphi);
-            // sample phi, slower than rndm->getAzimuth
             EGS_Float phi = min_phi +(max_phi - min_phi)*rndm->getUniform();
             cphi = cos(phi);
             sphi = sin(phi);
@@ -351,10 +348,5 @@ protected:
     int                 nrs;
     GeometryConfinement gc;
 };
-
-// change log:
-// Long, Jan 15 2008 add polar angle limitation and macro support
-//                  a word on the polar angle sampling:
-//                        cos(theta) follows a uniform distribution
 
 #endif

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -325,9 +325,7 @@ void EGS_RadionuclideSource::getPositionDirection(EGS_RandomGenerator *rndm,
         }
     }
     while (!ok);
-
-    u.z = rndm->getUniform()*(buf_1 - buf_2) - buf_1;
-
+    u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
     EGS_Float sinz = 1-u.z*u.z;
     if (sinz > epsilon) {
         sinz = sqrt(sinz);

--- a/HEN_HOUSE/scripts/egsnrc_bashrc_additions
+++ b/HEN_HOUSE/scripts/egsnrc_bashrc_additions
@@ -89,7 +89,7 @@ alias pprocess='$HEN_HOUSE/scripts/pprocess'
 # hard-coded run-time search path (no -rpath)
 #
 if test -d $HEN_HOUSE/egs++/dso/linux-static; then
-   alias egs_view='(LD_LIBRARY_PATH=${HEN_HOUSE}egs++/dso/linux-static/ ${HEN_HOUSE}pieces/linux/egs_view_64)'
+   alias egs_view='LD_LIBRARY_PATH=${HEN_HOUSE}egs++/dso/linux-static/ ${HEN_HOUSE}pieces/linux/egs_view_64'
 fi
 # OS X specific settings
 canonical_system=$( cat $EGS_CONFIG | grep "canonical_system =" | sed 's/canonical_system = //' )


### PR DESCRIPTION
This PR affects only the isotropic source (and hence the Fano source) when used to emit particles into a solid angle defined by a minimum and maximum polar angle theta.

The expression to sample **cos(theta)** between **cos(theta_min)** and **cos(theta_max)** had the terms inverted. While `1-2*rand` produces the same distribution of **cos(theta)** as `2*rand-1` when sampling between 0 and 180 degrees or any angular interval centered around 90 degrees, this is not the case in general when restricting the emission to an arbitrary angular interval between **theta_min** and **theta_max**. One should use the correct expression:

`cos(theta) =  cos(theta_min) - rand * (cos(theta_min - cos(theta_max)))`

rather than

`cos(theta) = -cos(theta_min) + rand * (cos(theta_min - cos(theta_max)))`

In the second expression, if the angular interval lies entirely in the first quadrant (0 to 90) or in the second quadrant (90 to 180) the angles sampled will always be in the opposite quadrant which is not the desired outcome.

**egs_isotropic_source:**

- Fix emission into solid angle
- Remove incomplete comment at the bottom of the header file
  referring to the addition of a solid angle restriction
  by a user back in January, 2008

**egs_fano_source:**

- Fix emission into solid angle
- Add comments referring to the rejection technique
- Change authorship to add Hugo as author rather than contributor
  since I started from his initial version
- TODO: Derive it from egs_isotropic_source rather than being an
        almost verbatim copy of it.

**egsnrc_bashrc_additions:**

- Remove parentheses from the egs_view alias as it won't take any input
  parameters