### PR TITLE
Add radionuclide source refinements (collimated source, experiment time ...)

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -169,15 +169,6 @@ public:
      */
     virtual EGS_Float getFluence() const = 0;
 
-    /*! \brief Get the time of emission for the most recently sampled particle
-     *
-     * This method is only reimplemented by EGS_RadionuclideSource. It
-     * returns the emission time of the particle that was most recently sampled.
-     */
-    virtual double getTime() const {
-        return 0;
-    };
-
     /* A virtual function which can be implemented in derived classes
     * to return a fractional monitor unit associated with each source
     * particle.  Currently only makes sense for IAEA_PhspSource and
@@ -186,23 +177,6 @@ public:
     virtual EGS_Float getMu() {
         return -1;
     };
-
-    /*! \brief Get the shower index for radionuclide emissions
-     *
-     * This method is only reimplemented by EGS_RadionuclideSource. It
-     * gets the index of the most recent shower.
-     */
-    virtual EGS_I64 getShowerIndex() const {
-        return 0;
-    };
-
-    /*! \brief Prints out the sampled emissions for radionuclide spectra
-     *
-     * This method is only reimplemented by EGS_RadionuclideSource. It
-     * prints the actual sampled intensity of each type of emission from
-     * the radionuclide spectra.
-     */
-    virtual void printSampledEmissions() {};
 
     /*!  \brief Store the source state into the stream \a data_out.
      *
@@ -384,70 +358,6 @@ public:
         sum_E += e;
         sum_E2 += e*e;
         return e;
-    };
-
-    /*! \brief Get the charge for the most recently sampled particle
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * returns the charge of the particle that was most recently sampled
-     * using sampleEnergy().
-     */
-    virtual int getCharge() const {
-        return 0;
-    };
-
-    /*! \brief Get the time of emission for the most recently sampled particle
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * returns the emission time of the particle that was most recently sampled
-     * using sampleEnergy().
-     */
-    virtual double getTime() const {
-        return 0;
-    };
-
-    /*! \brief Get the shower index for radionuclide emissions
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * gets the index of the most recent shower produced using sampleEnergy().
-     */
-    virtual EGS_I64 getShowerIndex() const {
-        return 0;
-    };
-
-    /*! \brief Get the spectrum weight for radionuclide spectra
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * gets the weight of the spectrum to balance emissions from multiple
-     * spectra.
-     */
-    virtual EGS_Float getSpectrumWeight() const {
-        return 0;
-    };
-
-    /*! \brief Set the spectrum weight for radionuclide spectra
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * sets the weight of the spectrum to balance emissions from multiple
-     * spectra. This allows a source to normalize the spectrum weights.
-     */
-    virtual void setSpectrumWeight(EGS_Float newWeight) {};
-
-    /*! \brief Prints out the sampled emissions for radionuclide spectra
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * prints the actual sampled intensity of each type of emission from
-     * the radionuclide spectra.
-     */
-    virtual void printSampledEmissions() {};
-
-    /*! \brief Get energy that should be deposited locally from relaxations/alphas.
-     *
-     * This method is only reimplemented by EGS_RadionuclideSpectrum. It
-     * gets the energy deposited locally during spectrum generation.
-     */
-    virtual EGS_Float getEdep() const {
-        return 0;
     };
 
     /*! \brief Get the maximum energy of this spectrum.

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -1226,7 +1226,10 @@ protected:
 
         // The energy of the sampled particle
         EGS_Float E;
+        // Local energy depositions
         edep = 0;
+        // Time delay of this particle
+        currentTime = 0;
 
         // Check for relaxation particles due to shell vacancies in the daughter
         // These are created from internal transitions or electron capture

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -40,10 +40,12 @@
 #include "egs_application.h"
 
 EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
-        EGS_ObjectFactory *f) : EGS_BaseSource(input,f), shape(0),
+        EGS_ObjectFactory *f) : EGS_BaseSource(input,f),
+    sourceType(""), shape(0),
     geom(0), regions(0), nrs(0), min_theta(0), max_theta(M_PI),
-    min_phi(0), max_phi(2*M_PI), gc(IncludeAll), q_allowed(0), decays(0),
-    activity(0) {
+    min_phi(0), max_phi(2*M_PI), gc(IncludeAll),
+    source_shape(0), target_shape(0), ctry(0), dist(1),
+    q_allowed(0), decays(0), activity(1) {
 
     int err;
     vector<int> tmp_q;
@@ -131,81 +133,157 @@ EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
     // Get the active application
     app = EGS_Application::activeApplication();
 
-    // Create the shape for source emissions
-    vector<EGS_Float> pos;
-    EGS_Input *ishape = input->takeInputItem("shape");
-    if (ishape) {
-        shape = EGS_BaseShape::createShape(ishape);
-        delete ishape;
-    }
-    if (!shape) {
-        string sname;
-        err = input->getInput("shape name",sname);
-        if (err)
-            egsWarning("EGS_RadionuclideSource: missing/wrong inline shape "
-                       "definition and missing wrong 'shape name' input\n");
-        else {
-            shape = EGS_BaseShape::getShape(sname);
-            if (!shape) egsWarning("EGS_RadionuclideSource: a shape named %s"
-                                       " does not exist\n");
+    // ==========================
+    // Source type = isotropic
+    // ==========================
+
+    err = input->getInput("source type",sourceType);
+    if (err || input->compare(sourceType,"isotropic")) {
+        sourceType = "isotropic";
+
+        egsInformation("EGS_RadionuclideSource: Source type: %s\n",sourceType.c_str());
+
+        // Create the shape for source emissions
+        vector<EGS_Float> pos;
+        EGS_Input *ishape = input->takeInputItem("shape");
+        if (ishape) {
+            shape = EGS_BaseShape::createShape(ishape);
+            delete ishape;
         }
-    }
-    string geom_name;
-    err = input->getInput("geometry",geom_name);
-    if (!err) {
-        geom = EGS_BaseGeometry::getGeometry(geom_name);
-        if (!geom) egsWarning("EGS_RadionuclideSource: no geometry named %s\n",
-                                  geom_name.c_str());
-        else {
-            vector<string> reg_options;
-            reg_options.push_back("IncludeAll");
-            reg_options.push_back("ExcludeAll");
-            reg_options.push_back("IncludeSelected");
-            reg_options.push_back("ExcludeSelected");
-            gc = (GeometryConfinement) input->getInput("region "
-                    "selection",reg_options,0);
-            if (gc == IncludeSelected || gc == ExcludeSelected) {
-                vector<int> regs;
-                err = input->getInput("selected regions",regs);
-                if (err || regs.size() < 1) {
-                    egsWarning("EGS_RadionuclideSource: region selection %d "
-                               "used  but no 'selected regions' input "
-                               "found\n",gc);
-                    gc = gc == IncludeSelected ? IncludeAll : ExcludeAll;
-                    egsWarning(" using %d\n",gc);
-                }
-                nrs = regs.size();
-                regions = new int [nrs];
-                for (int j=0; j<nrs; j++) {
-                    regions[j] = regs[j];
+        if (!shape) {
+            string sname;
+            err = input->getInput("shape name",sname);
+            if (err)
+                egsWarning("EGS_RadionuclideSource: missing/wrong inline shape "
+                           "definition and missing wrong 'shape name' input\n");
+            else {
+                shape = EGS_BaseShape::getShape(sname);
+                if (!shape) egsWarning("EGS_RadionuclideSource: a shape named %s"
+                                           " does not exist\n");
+            }
+        }
+        string geom_name;
+        err = input->getInput("geometry",geom_name);
+        if (!err) {
+            geom = EGS_BaseGeometry::getGeometry(geom_name);
+            if (!geom) egsWarning("EGS_RadionuclideSource: no geometry named %s\n",
+                                      geom_name.c_str());
+            else {
+                vector<string> reg_options;
+                reg_options.push_back("IncludeAll");
+                reg_options.push_back("ExcludeAll");
+                reg_options.push_back("IncludeSelected");
+                reg_options.push_back("ExcludeSelected");
+                gc = (GeometryConfinement) input->getInput("region "
+                        "selection",reg_options,0);
+                if (gc == IncludeSelected || gc == ExcludeSelected) {
+                    vector<int> regs;
+                    err = input->getInput("selected regions",regs);
+                    if (err || regs.size() < 1) {
+                        egsWarning("EGS_RadionuclideSource: region selection %d "
+                                   "used  but no 'selected regions' input "
+                                   "found\n",gc);
+                        gc = gc == IncludeSelected ? IncludeAll : ExcludeAll;
+                        egsWarning(" using %d\n",gc);
+                    }
+                    nrs = regs.size();
+                    regions = new int [nrs];
+                    for (int j=0; j<nrs; j++) {
+                        regions[j] = regs[j];
+                    }
                 }
             }
         }
-    }
-    EGS_Float tmp_theta;
-    err = input->getInput("min theta", tmp_theta);
-    if (!err) {
-        min_theta = tmp_theta/180.0*M_PI;
+        EGS_Float tmp_theta;
+        err = input->getInput("min theta", tmp_theta);
+        if (!err) {
+            min_theta = tmp_theta/180.0*M_PI;
+        }
+
+        err = input->getInput("max theta", tmp_theta);
+        if (!err) {
+            max_theta = tmp_theta/180.0*M_PI;
+        }
+
+        err = input->getInput("min phi", tmp_theta);
+        if (!err) {
+            min_phi = tmp_theta/180.0*M_PI;
+        }
+
+        err = input->getInput("max phi", tmp_theta);
+        if (!err) {
+            max_phi = tmp_theta/180.0*M_PI;
+        }
+
+        buf_1 = cos(min_theta);
+        buf_2 = cos(max_theta);
     }
 
-    err = input->getInput("max theta", tmp_theta);
-    if (!err) {
-        max_theta = tmp_theta/180.0*M_PI;
+    // ==========================
+    // Source type = collimated
+    // ==========================
+
+    else if (input->compare(sourceType,"collimated")) {
+        sourceType = "collimated";
+
+        egsInformation("EGS_RadionuclideSource: Source type: %s\n",sourceType.c_str());
+
+        EGS_Input *ishape = input->takeInputItem("source shape");
+        if (ishape) {
+            source_shape = EGS_BaseShape::createShape(ishape);
+            delete ishape;
+        }
+        if (!source_shape) {
+            string sname;
+            int err = input->getInput("source shape name",sname);
+            if (err)
+                egsWarning("EGS_RadionuclideSource: missing/wrong inline source "
+                           "shape definition and missing/wrong 'source shape name' input\n");
+            else {
+                source_shape = EGS_BaseShape::getShape(sname);
+                if (!source_shape)
+                    egsWarning("EGS_RadionuclideSource: a shape named %s"
+                               " does not exist\n",sname.c_str());
+            }
+        }
+        ishape = input->takeInputItem("target shape");
+        if (ishape) {
+            target_shape = EGS_BaseShape::createShape(ishape);
+            delete ishape;
+        }
+        if (!target_shape) {
+            string sname;
+            int err = input->getInput("target shape name",sname);
+            if (err)
+                egsWarning("EGS_RadionuclideSource: missing/wrong inline target"
+                           "shape definition and missing/wrong 'target shape name' input\n");
+            else {
+                target_shape = EGS_BaseShape::getShape(sname);
+                if (!target_shape)
+                    egsWarning("EGS_RadionuclideSource: a shape named %s"
+                               " does not exist\n",sname.c_str());
+            }
+        }
+        if (target_shape) {
+            if (!target_shape->supportsDirectionMethod())
+                egsWarning("EGS_RadionuclideSource: the target shape %s, which is"
+                           " of type %s, does not support the getPointSourceDirection()"
+                           " method\n",target_shape->getObjectName().c_str(),
+                           target_shape->getObjectType().c_str());
+        }
+        EGS_Float auxd;
+        int errd = input->getInput("distance",auxd);
+        if (!errd) {
+            dist = auxd;
+        }
+
+    }
+    else {
+        egsFatal("EGS_RadionuclideSource: a source type named %s"
+                 " does not exist\n",sourceType.c_str());
     }
 
-    err = input->getInput("min phi", tmp_theta);
-    if (!err) {
-        min_phi = tmp_theta/180.0*M_PI;
-    }
-
-    err = input->getInput("max phi", tmp_theta);
-    if (!err) {
-        max_phi = tmp_theta/180.0*M_PI;
-    }
-
-    buf_1 = cos(min_theta);
-    buf_2 = cos(max_theta);
-
+    // Finish
     setUp();
 }
 
@@ -292,55 +370,77 @@ EGS_I64 EGS_RadionuclideSource::getNextParticle(EGS_RandomGenerator *rndm, int
 void EGS_RadionuclideSource::getPositionDirection(EGS_RandomGenerator *rndm,
         EGS_Vector &x, EGS_Vector &u, EGS_Float &wt) {
 
-    bool ok = true;
-    do {
-        x = shape->getRandomPoint(rndm);
-        if (geom) {
-            if (gc == IncludeAll) {
-                ok = geom->isInside(x);
-            }
-            else if (gc == ExcludeAll) {
-                ok = !geom->isInside(x);
-            }
-            else if (gc == IncludeSelected) {
-                ok = false;
-                int ireg = geom->isWhere(x);
-                for (int j=0; j<nrs; ++j) {
-                    if (ireg == regions[j]) {
-                        ok = true;
-                        break;
+    if (sourceType == "isotropic") {
+        bool ok = true;
+        do {
+            x = shape->getRandomPoint(rndm);
+            if (geom) {
+                if (gc == IncludeAll) {
+                    ok = geom->isInside(x);
+                }
+                else if (gc == ExcludeAll) {
+                    ok = !geom->isInside(x);
+                }
+                else if (gc == IncludeSelected) {
+                    ok = false;
+                    int ireg = geom->isWhere(x);
+                    for (int j=0; j<nrs; ++j) {
+                        if (ireg == regions[j]) {
+                            ok = true;
+                            break;
+                        }
                     }
                 }
-            }
-            else {
-                ok = true;
-                int ireg = geom->isWhere(x);
-                for (int j=0; j<nrs; ++j) {
-                    if (ireg == regions[j]) {
-                        ok = false;
-                        break;
+                else {
+                    ok = true;
+                    int ireg = geom->isWhere(x);
+                    for (int j=0; j<nrs; ++j) {
+                        if (ireg == regions[j]) {
+                            ok = false;
+                            break;
+                        }
                     }
                 }
             }
         }
+        while (!ok);
+        u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
+        EGS_Float sinz = 1-u.z*u.z;
+        if (sinz > epsilon) {
+            sinz = sqrt(sinz);
+            EGS_Float cphi, sphi;
+            EGS_Float phi = min_phi +(max_phi - min_phi)*rndm->getUniform();
+            cphi = cos(phi);
+            sphi = sin(phi);
+            u.x = sinz*cphi;
+            u.y = sinz*sphi;
+        }
+        else {
+            u.x = 0;
+            u.y = 0;
+        }
+        wt = 1;
     }
-    while (!ok);
-    u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
-    EGS_Float sinz = 1-u.z*u.z;
-    if (sinz > epsilon) {
-        sinz = sqrt(sinz);
-        EGS_Float cphi, sphi;
-        EGS_Float phi = min_phi +(max_phi - min_phi)*rndm->getUniform();
-        cphi = cos(phi);
-        sphi = sin(phi);
-        u.x = sinz*cphi;
-        u.y = sinz*sphi;
+    else if (sourceType == "collimated") {
+        x = source_shape->getRandomPoint(rndm);
+        int ntry = 0;
+        do {
+            target_shape->getPointSourceDirection(x,rndm,u,wt);
+            ntry++;
+            if (ntry > 10000) {
+                egsFatal("EGS_RadionuclideSource::getPositionDirection:\n"
+                         "  my target shape %s, which is of type %s, failed to\n"
+                         "  return a positive weight after 10000 attempts\n",
+                         target_shape->getObjectName().c_str(),
+                         target_shape->getObjectType().c_str());
+            }
+        }
+        while (wt <= 0);
+
+        if (disintegrationOccurred) {
+            ctry += ntry-1;
+        }
     }
-    else {
-        u.x = 0;
-        u.y = 0;
-    }
-    wt = 1;
 }
 
 void EGS_RadionuclideSource::setUp() {
@@ -349,8 +449,22 @@ void EGS_RadionuclideSource::setUp() {
         description = "Invalid radionuclide source";
     }
     else {
-        description = "Radionuclide source from a shape of type ";
-        description += shape->getObjectType();
+        description = "Radionuclide source of type ";
+
+        if (sourceType == "isotropic") {
+            description += sourceType;
+            description += " and a shape of type ";
+            description += shape->getObjectType();
+
+        }
+        else if (sourceType == "collimated") {
+            description += sourceType;
+            description += " from a shape of type ";
+            description += source_shape->getObjectType();
+            description += " onto a shape of type ";
+            description += target_shape->getObjectType();
+        }
+
         description += " with:";
         if (std::find(q_allowed.begin(), q_allowed.end(), -1) !=
                 q_allowed.end()) {
@@ -366,8 +480,10 @@ void EGS_RadionuclideSource::setUp() {
             description += " alphas";
         }
 
-        if (geom) {
-            geom->ref();
+        if (sourceType == "isotropic") {
+            if (geom) {
+                geom->ref();
+            }
         }
     }
 }
@@ -378,6 +494,9 @@ bool EGS_RadionuclideSource::storeState(ostream &data_out) const {
             return false;
         }
     }
+    egsStoreI64(data_out,count);
+    egsStoreI64(data_out,ctry);
+
     return true;
 }
 
@@ -388,6 +507,12 @@ bool EGS_RadionuclideSource::addState(istream &data) {
         }
         ishower += decays[i]->getShowerIndex();
     }
+    EGS_I64 tmp_val;
+    egsGetI64(data,tmp_val);
+    count = tmp_val;
+    egsGetI64(data,tmp_val);
+    ctry = tmp_val;
+
     return true;
 }
 
@@ -397,6 +522,7 @@ void EGS_RadionuclideSource::resetCounter() {
     }
     ishower = 0;
     count = 0;
+    ctry = 0;
 }
 
 bool EGS_RadionuclideSource::setState(istream &data) {
@@ -405,6 +531,9 @@ bool EGS_RadionuclideSource::setState(istream &data) {
             return false;
         }
     }
+    egsGetI64(data,count);
+    egsGetI64(data,ctry);
+
     return true;
 }
 

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
@@ -419,7 +419,9 @@ protected:
 
     bool                q_allowAll; //!< Whether or not to allow all charges
     bool                disintegrationOccurred; //!< Whether or not a disintegration occurred while generating the most recent source particle
-    EGS_Float           time; //!< The time of emission of the most recently generated particle
+    EGS_Float           time, //!< The time of emission of the most recently generated particle
+                        experimentTime,
+                        lastDisintTime; //!< The time of emission of the last disintegration
     EGS_I64             ishower; //!< The shower index (disintegration number) of the most recently generated particle
     EGS_Vector          xOfDisintegration; //!< The position of the last disintegration
 


### PR DESCRIPTION
A number of radionuclide source refinements.

1. Adds the option for a collimated radionuclide source. This is done by setting `source type = collimated` in the radionuclide source block.

2. Reduces the scope of radionuclide source specific methods, instead of declaring them at the base source and spectrum levels. The radionuclide source now statically casts the spectrum to a radionuclide spectrum in order to access the special methods, and applications should do the same to access the radionuclide source methods.

3. Adds an `experiment time` parameter to the radionuclide source, so that emissions can be restricted according to their emission times. These emissions that would be outside the measurement time get returned by the source as zero energy particles.

4. Adds a method to query the type of radionuclide emission that just occurred. For example, what type of disintegration occurred (beta/alpha/EC) and/or what type of particle was returned (IT photon, fluorescent photon, Auger electron).