### PR TITLE
Fix radiative splitting csplit initialization

### DIFF
--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
@@ -548,7 +548,7 @@ public:
 	cgeoms(0), nsubgeoms(0), check_for_subreg(0), is_subgeomreg(0), subgeoms(0),
 	container(0), container2(0), container3(0), save_dose(0), silent(0) ,
         iso_pu_flag(0), cav_pu_flag(0), iso_pu_do_shift(0), cav_pu_do_shift(0),pu_flag(0),
-        McasePerPos(0), NposPerSample(0), onegeom(0) {  };
+        McasePerPos(0), NposPerSample(0), onegeom(0), csplit(1) {  };
 
     /*! Destructor.  */
     ~EGS_ChamberApplication() {
@@ -940,7 +940,6 @@ int EGS_ChamberApplication::initScoring() {
         //
         // ******** radiative event splitting
         //
-        csplit=1;
         if( !vr->getInput("radiative splitting", csplit) && csplit > 1) {
             egsInformation("\n => initScoring: splitting radiative events %d times ...\n", csplit);
            the_egsvr->nbr_split = csplit;


### PR DESCRIPTION
Initialize the `csplit` variable to 1 by default in the egs_chamber
application constructor; `csplit` is used to read in the radiative
splitting number from the input file.

Previously, `csplit` was only initialized if the input contained a
variance reduction input block. This caused a serious bug to be
introduced in commit 50e0d33, whereby `the_egsvr->nbr_split` was set to
the arbitrary (uninitialized) `csplit` number in the shower loop when
there was no variance reduction input block. If this number happened to
be a large positive integer (about half the time), any radiative event
immediately exceeded the stack size and aborted the simulation.

This probably went unnoticed for so long because one rarely runs
egs_chamber without variance reduction.
