### PR TITLE
Fix #390: docs typo about muindex in dynamic CMs

### DIFF
--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/DYNJAWS.inp
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/DYNJAWS.inp
@@ -57,7 +57,7 @@
 
        NFIELDS_$DYNJAWS:  Total number of jaw settings.
        INDEX_$DYNJAWS(J):  Index of setting J. 0 <= INDEX_$DYNVMLC(J) <= 1
-                          and INDEX_$DYNVMLC(J) > INDEX_$DYNVMLC(J-1).  This
+                          and INDEX_$DYNVMLC(J) >= INDEX_$DYNVMLC(J-1).  This
                           number is compared to a random number on [0,1] at
                           the start of each history; if the random number is
                           <= INDEX_$DYNVMLC(J), then, if MODE_$DYNJAWS=2,

--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/DYNVMLC.inp
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/DYNVMLC.inp
@@ -229,7 +229,7 @@
               MLC_TITLE:  A title line
        NFIELDS_$DYNVMLC:  Total number of fields
       INDEX_$DYNVMLC(I):  Index of field I. 0 <= INDEX_$DYNVMLC(I) <= 1 and
-                          INDEX_$DYNVMLC(I) > INDEX_$DYNVMLC(I-1).  This
+                          INDEX_$DYNVMLC(I) >= INDEX_$DYNVMLC(I-1).  This
                           number is compared to a random number on (0,1) at
                           the start of each history; if the random number is
                           <= INDEX_$DYNVMLC(I), then field I is used.

--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCHDMLC.inp
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCHDMLC.inp
@@ -286,7 +286,7 @@
               MLC_TITLE:  A title line
        NFIELDS_$SYNCHDMLC:  Total number of fields
       INDEX_$SYNCHDMLC(I):  Index of field I. 0 <=INDEX_$SYNCHDMLC(I) <= 1 and
-                          INDEX_$SYNCHDMLC(I) > INDEX_$SYNCHDMLC(I-1).  This
+                          INDEX_$SYNCHDMLC(I) >= INDEX_$SYNCHDMLC(I-1).  This
                           number is compared to a random number on (0,1) at
                           the start of each history; if the random number is
                           <= INDEX_$SYNCHDMLC(I), then field I is used.

--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCMLCE.inp
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCMLCE.inp
@@ -119,7 +119,7 @@
        NFIELDS_$SYNCMLCE:  Total number of fields
     MUINDEX_$SYNCMLCE(I):  Fractional monitor unit index up to and including
                            field I. 0 <= MUINDEX_$SYNCMLCE(I) <= 1 and
-                           MUINDEX_$SYNCMLCE(I) > MUINDEX_$SYNCMLCE(I-1).
+                           MUINDEX_$SYNCMLCE(I) >= MUINDEX_$SYNCMLCE(I-1).
                            This number is compared to a random number on
                            [0,1] at the start of each history; if the random
                            number is <= MUINDEX_$SYNCMLCE(I), then field I is


### PR DESCRIPTION
Fix typos in the documentation for BEAMnrc dynamic CMs. The MUINDEX parameters were not correctly defined. For example, `INDEX(J) >= INDEX(J-1)` is the correct usage of mu indexes. Previously, the documentation stated `INDEX(J) > INDEX(J-1)`.