### PR TITLE
Fix #399: Fix bug in DYNVMLC GUI leaf cross section help figures.

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/beamnrc/misc_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/misc_egsnrc.tcl
@@ -191,9 +191,9 @@ proc help_gif { w text iconfile } {
     frame $w.f1 -bd 0 -relief sunken -bg white
     # Create the image from a gif file:
     if {$iconfile != ""} {
-	image create photo graphic -file \
+	image create photo $w.graphic -file \
 		[file join $GUI_DIR graphics $iconfile.gif]
-	label $w.f1.lbl -image graphic -bg white
+	label $w.f1.lbl -image $w.graphic -bg white
         message $w.f1.m -width 5i -text $text -font $helvfont -bg white
     } else {
 	label $w.f1.lbl -text "No graphic for this source"


### PR DESCRIPTION
Figures in all help windows switched to show cross section of most
recent leaf for which the help window was opened.  Fixed by giving
a unique name to the graphic file used in procedure help_gif in
misc_egsnrc.tcl