### PR TITLE
Option: output sparse binary dose file instead of 3ddose in DOSXYZnrc

### DIFF
--- a/HEN_HOUSE/doc/src/pirs794-dosxyznrc/inputs/dosxyznrc.inp
+++ b/HEN_HOUSE/doc/src/pirs794-dosxyznrc/inputs/dosxyznrc.inp
@@ -842,7 +842,7 @@ Record SC1-20a and SC1-21a (required for sources 20 and 21)
    Record 13 (9 if NMED=0)
             NCASE, IWATCH, TIMMAX, INSEED1, INSEED2,
        BEAM_SIZE, ISMOOTH,IRESTART,IDAT,IREJECT,ESAVE_GLOBAL,NRCYCL,IPARALLEL,
-       PARNUM,n_split,ihowfarless,i_phsp_out
+       PARNUM,n_split,ihowfarless,i_phsp_out,i_bindos
 
             NCASE     Number of histories
             IWATCH    0=>no tracking output, 1=>list every interaction
@@ -1013,6 +1013,11 @@ Record SC1-20a and SC1-21a (required for sources 20 and 21)
                       output.  If you are using source 20 or source 21
                       (synchronized sources) then you also have the option of
                       storing frMU_indx in the file (see source inputs).
+
+          i_bindos    For outputting sparse binary dose data instead of the
+                      dense ASCII .3ddose format. If i_bindos=0, then the
+                      dose will be output in .3ddose format. Any other value
+                      will output a .bindos file instead.
 
 ----------------------------------------------------------------------------
 ----------------------------------------------------------------------------

--- a/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
+++ b/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
@@ -26,6 +26,7 @@
 %                   Dave Rogers, 2001
 %
 %  Contributors:    Frederic Tessier
+%                   Marc-Andre Renaud
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
@@ -3499,6 +3500,12 @@ the full path), and then recompiling DOSXYZnrc.
 
 For more information on the IAEA phase space file format, see the BEAMnrc Users Manual\cite{Ro09}.
 
+\subsection{{\tt i\_bindos}}
+\indexm{i\_bindos}
+If {\tt i\_bindos} is set to 1, DOSXYZnrc outputs a sparse binary dose file instead of a dense ASCII dose file.
+The resulting file typically has a much smaller memory footprint than the default {\tt .3ddose} format.
+See section~\ref{subsec:bindos_format} for a description of the format.
+
 \subsection{ECUTIN}
 \indexm{ECUTIN}
 \label{ECUTIN}
@@ -4316,11 +4323,13 @@ artifacts (see section~\ref{zeroairdose}).
 
 \indexm{.egslst}
 The dose distributions calculated by DOSXYZnrc can be found in the output
-files, ``{\tt .egslst}'', ``{\tt .3ddose}'' and ``{\tt .pardose}''.
+files, ``{\tt .egslst}'', ``{\tt .3ddose}'', ``{\tt .bindos}'' and ``{\tt .pardose}''.
 The file ``{\tt .egslst}''
 \indexm{.pardose}
 \indexm{.3ddose}
+\indexm{.bindos}
 \indexm{files!.3ddose}
+\indexm{files!.bindos}
 \indexm{files!.pardose}
 contains not only the dose (when asked for) and statistical data but also the information
 about simulation geometry, number of histories run, CPU time used, etc.
@@ -4422,6 +4431,35 @@ Number &  1 &        2 &         3       & 4      &  5 \\ \hline
 \normalsize
 
 \lfoot[]{}
+
+\subsection{{\tt .bindos} Files}
+\label{subsec:bindos_format}
+\indexm{.bindos}
+\indexm{files!.bindos}
+A ``{\tt .bindos}'' file is output instead of a ``{\tt .3ddose}'' file if the
+flag ``{\tt i\_bindos}'' is set to 1. The same dose content is contained in each file,
+but ``{\tt .bindos}'' is a sparse format, hence only information about non-zero dose
+voxels is included. The linearized start and end indices for blocks of contiguous non-zero
+doses are stored. Both integers and floats are stored as 4 bytes each.
+
+\begin{enumerate}
+\item Number of voxels in the x, y, z direction (e.g., $n_x$, $n_y$, $n_z$, 3 ints)
+\item Voxel boundaries (cm) in x direction($ n_x$ +1 floats)
+\item Voxel boundaries (cm) in y direction($ n_y$ +1 floats)
+\item Voxel boundaries (cm) in z direction($ n_z$ +1 floats)
+\item Number of non-zero dose voxels ($n_{nz}$, 1 int)
+\item Number of voxel index pairs ($n_{b}$, 1 int)
+\item Linearized voxel index pairs indicating the [start, end) of contiguous non-zero
+      voxel doses. ($2 \times n_{b}$ ints)
+\item Nonzero voxel doses ($n_{nz}$ floats)
+\item Nonzero voxel uncertainties ($n_{nz}$ floats)
+\end{enumerate}
+
+The linearization formula is as follows:
+\begin{equation}
+v_{lin} = (n_x \times n_y) \cdot v_z + (v_x) \cdot v_y + v_x
+\end{equation}
+where $v_x$, $v_y$, $v_z$ are the voxel indices in the x, y, z axes, respectively.
 
 \subsection{{\tt .pardose} Files}
 \indexm{files!.pardose}

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/create_file_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/create_file_nrc.tcl
@@ -27,6 +27,7 @@
 #                   Iwan Kawrakow
 #                   Ernesto Mainegra-Hing
 #                   Frederic Tessier
+#                   Marc-Andre Renaud
 #
 ###############################################################################
 #
@@ -68,7 +69,7 @@ proc create_file { file } {
     global grouping nrow izrow enflag numsrcopts izopts ncpu dflag parnum
     global numthphi angfixed ang1 ang2 nang pang ivary thphidef
     global numsets iso1 iso2 iso3 ang1 ang2 ang3 dsource muI
-    global iphant iphspout imuphspout calflag
+    global iphant iphspout imuphspout calflag ibindos
     global level ibcmp_min ibcmp_max iphter_min iphter_max
     global iraylr_min iraylr_max iedgfl_min iedgfl_max
     global i_dbs r_dbs ssd_dbs z_dbs the_beam_code the_input_file the_pegs_file
@@ -446,7 +447,13 @@ set str "$ivary($i), $angfixed($i), $ang1($i), $ang2($i), $nang($i), $pang($i)"
     } else {
       set val 0
     }
-    set str "$str$val, $iphspout"
+    set str "$str$val, $iphspout, "
+    if { [string compare $values(ibindos) $options(ibindos,1)]==0 } {
+      set val 1
+    } else {
+      set val 0
+    }
+    set str "$str$val"
 
     puts $file $str
 
@@ -700,5 +707,3 @@ proc error_flag { text } {
     tk_dialog .edit "Bad inputs" "You haven't defined $text.  Please\
 	    fill in all options required before saving." warning 0 OK
 }
-
-

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/load_input2_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/load_input2_nrc.tcl
@@ -27,6 +27,7 @@
 #                   Iwan Kawrakow
 #                   Ernesto Mainegra-Hing
 #                   Frederic Tessier
+#                   Marc-Andre Renaud
 #
 ###############################################################################
 #
@@ -767,6 +768,14 @@ proc read_input {} {
     set data [get_val $data arr 0]
     set iphspout 0
     if {$arr(0)<=2} { set iphspout $arr(0) }
+
+    # bindos output option
+    set data [get_val $data arr 0]
+    if {$arr(0)==1} {
+       set values(ibindos) $options(ibindos,1)
+    } else {
+       set values(ibindos) $options(ibindos,0)
+    }
 
     # now get the EGSnrc inputs
     foreach i {ecut pcut smaxir estepe ximax bca_algorithm skindepth_for_bca \

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/reset_parameters_nrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/reset_parameters_nrc.tcl
@@ -26,6 +26,7 @@
 #  Contributors:    Blake Walters
 #                   Iwan Kawrakow
 #                   Frederic Tessier
+#                   Marc-Andre Renaud
 #
 ###############################################################################
 #
@@ -65,7 +66,7 @@ proc reset_parameters { } {
     global spec_file ecutin pcutin estepm smax imax ivox gvox dsurround
     global inc exc names mvox izvox PhantFileName latbit nbit1 nbit2
     global grouping nrow izrow enflag numsrcopts izopts maxvals
-    global dflag dflagopt iphspout imuphspout calflag
+    global dflag dflagopt iphspout imuphspout calflag ibindos
     global numthphi angfixed ang1 ang2 nang pang ivary thphidef
     global numsets iso1 iso2 iso3 ang1 ang2 ang3 dsource muI
     global iphant level the_beam_code the_input_file the_pegs_file
@@ -172,6 +173,7 @@ proc reset_parameters { } {
     set iphspout 0
     set imuphspout 0
     set calflag 0
+    set ibindos 0
 
     set Ein {}
     set spec_file {}

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_main_inputs_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_main_inputs_egsnrc.tcl
@@ -26,6 +26,7 @@
 #  Contributors:    Blake Walters
 #                   Iwan Kawrakow
 #                   Frederic Tessier
+#                   Marc-Andre Renaud
 #
 ###############################################################################
 #
@@ -256,7 +257,7 @@ proc edit_parameters {} {
     frame $w
     frame $w1
     frame $w2
-    foreach j { 5 6 7 8 9 10 12 ihowfarless } {
+    foreach j { 5 6 7 8 9 10 12 ihowfarless ibindos } {
 	frame $w1.inp$j -bd 4
 	button $w1.inp$j.help -text "?"	-command "help $j"
 	label $w1.inp$j.label -text $names($j) -anchor w

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/xyznrc_parameters.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/xyznrc_parameters.tcl
@@ -27,6 +27,7 @@
 #                   Iwan Kawrakow
 #                   Ernesto Mainegra-Hing
 #                   Frederic Tessier
+#                   Marc-Andre Renaud
 #
 ###############################################################################
 #
@@ -739,6 +740,18 @@ monoenergetic electron beams.
 Recommended for all homogeneous phantom calculations.
 }
 
+set ibindos {}
+set names(ibindos) "Dose output"
+set numopts(ibindos) 2
+set options(ibindos,0) "3ddose"
+set options(ibindos,1) "bindos (sparse binary format)"
+set values(ibindos) $options(ibindos,0)
+set help_text(ibindos) {
+Set to "3ddose output" to output a voxel doses in a dense ASCII file.
+Set to "sparse binary output" for a sparse binary dose file.
+See the DOSXYZnrc manual section titled "Format of Dose Outputs" for a\
+description of the file formats.
+}
 #################The following are the EGSnrc parameters#############
 
 set ecut {}

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -28,6 +28,7 @@
 "                   Blake Walters                                             "
 "                   Frederic Tessier                                          "
 "                   Reid Townson                                              "
+"                   Marc-Andre Renaud                                         "
 "                                                                             "
 "#############################################################################"
 "                                                                             "
@@ -1176,7 +1177,8 @@ integer function egs_open_file(iunit,rl,action,extension);
 " If extension is an absolute file name (including path), use extension
 " as a file name, otherwise use output_file.extension in the temporary
 " working directory as name. In both cases use status='unknown' to open the
-" file. If rl = 0, open the file for formatted sequential access, otherwise
+" file. If rl = -1, open the file with stream access to write C-style binary
+" files. If rl = 0, open the file for formatted sequential access, otherwise
 " open for unformatted direct access with record length = rl.
 "******************************************************************************
 implicit none;
@@ -1209,6 +1211,10 @@ IF( egs_is_absolute_path(extension) ) [
              ' Will not try to re-open this file, assuming it has been opened',
              ' by the .io file.');
     ]
+    ELSE IF ( rl = -1 ) [
+        open(the_unit,file=extension,status='unknown',form='unformatted',
+             access='stream');
+    ]
     ELSE IF( rl = 0 ) [
         open(the_unit,file=extension,status='unknown');
     ]
@@ -1236,6 +1242,10 @@ IF(is_open)[
              ' is already opened and connected to unit ',the_unit,
              ' Will not try to re-open this file, assuming it has been opened',
              ' by specifying it in the .io file.');
+]
+ELSE IF ( rl = -1 ) [
+    open(the_unit,file=tmp_string,status='unknown',form='unformatted',
+            access='stream');
 ]
 ELSE IF( rl = 0 ) [
     open(the_unit,file=tmp_string,status='unknown',err=:open_error:);
@@ -2319,4 +2329,3 @@ $INTEGER function ibsearch(a, nsh, b);
  ]
  ibsearch = min;
  return;end;
-

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -290,7 +290,7 @@
 "   Record 13 (9 if NMED=0)
 "            NCASE, IWATCH, TIMMAX, INSEED1, INSEED2,
 "       BEAM_SIZE, ISMOOTH,IRESTART,IDAT,IREJECT,ESAVE_GLOBAL,NRCYCL,IPARALLEL,
-"       PARNUM,n_split,ihowfarless,i_phsp_out
+"       PARNUM,n_split,ihowfarless,i_phsp_out,i_bindos
 "
 "            NCASE     Number of histories
 "            IWATCH    0=>no tracking output, 1=>list every interaction
@@ -461,6 +461,11 @@
 "                      output.  If you are using source 20 or source 21
 "                      (synchronized sources) then you also have the option of
 "                      storing frMU_indx in the file (see source inputs).
+"
+"          i_bindos    For outputting sparse binary dose data instead of the
+"                      dense ASCII .3ddose format. If i_bindos=0, then the
+"                      dose will be output in .3ddose format. Any other value
+"                      will output a .bindos file instead.
 "
 "----------------------------------------------------------------------------
 "----------------------------------------------------------------------------
@@ -1173,7 +1178,7 @@ REPLACE {;COMIN/SCORE/;} WITH {
                         "in phase space data (phsp or BEAM simulation source"
                         "only)"
             i_unit_out, "unit no. for IAEA phsp output"
-            i_bindos,  "set to 1 to output sparse binary file"
+            i_bindos,   "set to 1 to output sparse binary file"
             IWATCH,mxnp;
     $SHORT_INT endep_last;
 }
@@ -4313,9 +4318,9 @@ subroutine write_dose(iimax,jjmax,kkmax,xbnd,ybnd,zbnd,dd,ddun,unitnum,
                       writemax20,bindos);
 
 
-"Writes dose to file designated by unitnum.  Currently the subroutine only
-"writes in the .3ddose format (unitnum=3) and replaces a portion of the
-"main code.  However, this subroutine will eventually output the dose in
+"Writes dose to file designated by unitnum.  Currently the subroutine writes
+"in the .3ddose format (unitnum=3) or the .bindos format and replaces a portion
+"of the main code.  However, this subroutine will eventually output the dose in
 "other formats as well.
 
 "3 possible methods of specifying the array sizes for dd and ddun, the
@@ -4372,15 +4377,17 @@ INTEGER iimax,                     "max number of x cells"
         jjmax,                     "max number of y cells"
         kkmax,                     "max number of z cells"
         ijkmax,                    "iimax*jjmax*kkmax"
-        irtmp,                    "tmp variable to hold ir"
+        irtmp,                     "tmp variable to hold ir"
         writemax20,                "1 for summary of max 20 doses"
-        bindos,                   "1 for binary file"
+        bindos,                    "1 for binary file"
         unitnum,                   "unit number in which to write data"
         ii,jj,kk,mm,nn,            "indices"
         NUMFRAC,                   "number of voxels for av. rel. uncertainty"
         MAXI(20),MAXJ(20),MAXK(20),"indices for max 20 doses"
         num_nonzero,               "number of nonzero voxels"
-        voxel_indices($MAXDOSE),   "indices of nonzero voxels"
+        num_blocks,                "number of voxel blocks"
+        start_block,               "keep track of contiguous nonzero voxels"
+        voxel_blocks($MAXDOSE),    "indices of nonzero voxels"
         egs_open_file;
 REAL    xbnd($IMAX+1),             "voxel x boundaries"
         ybnd($JMAX+1),             "voxel y boundaries"
@@ -4392,7 +4399,7 @@ REAL    xbnd($IMAX+1),             "voxel x boundaries"
         ERR50AVG,                  "average % error of doses > 50% of max dose"
         ERR50FRAC,                 "average error of doses > 50% of max"
                                    " dose as a fraction of max dose"
-        DOSEFRAC,                "fraction for calculating av. rel. uncertainty"
+        DOSEFRAC,                  "fraction for calculating av. rel. uncertainty"
         DOSEmin,                   "DOSEFRAC*MAXDOS(1)"
         ARUFRAC;                   "average relative uncertainty on all voxels"
                                    "with dose > DOSEFRAC*Dmax"
@@ -4405,6 +4412,8 @@ REPLACE {$BINOUT#;} WITH {write(unitnum){P1};};
 REPLACE {$IRDWD(#,#,#)} WITH {({P1}+({P2}-1)*iimax+({P3}-1)*iimax*jjmax)};
 
 num_nonzero = 0;
+num_blocks = 0;
+start_block = -1;
 ijkmax=iimax*jjmax*kkmax;
 
 IF(bindos=0)[
@@ -4420,9 +4429,25 @@ IF(bindos=0)[
 ELSE[
     DO ii=1,ijkmax[
         IF(dd(ii)>0.0)[
+            IF(start_block = -1) [
+                start_block = ii;
+            ]
             num_nonzero = num_nonzero + 1;
-            voxel_indices(num_nonzero) = ii;
+        ] ELSE [
+            IF(start_block ~= -1) [
+                "First 0 dose voxel after a block of nonzero voxels"
+                num_blocks = num_blocks + 1;
+                voxel_blocks(2*num_blocks) = start_block;
+                voxel_blocks(2*num_blocks+1) = ii;
+                start_block = -1;
+            ]
         ]
+    ]
+    "Capture the final voxel block"
+    IF(start_block ~= -1) [
+        num_blocks = num_blocks + 1;
+        voxel_blocks(2*num_blocks) = start_block;
+        voxel_blocks(2*num_blocks+1) = ijkmax;
     ]
 
     "open the .bindos file for output"
@@ -4433,21 +4458,27 @@ ELSE[
     $BINOUT (zbnd(kk),kk=1,kkmax+1);
 
     $BINOUT num_nonzero;
+    $BINOUT num_blocks;
 
-    "Writing voxel indices as a zero-indexed array even though fortran arrays"
-    "are one-indexed."
-    DO ii=1,num_nonzero[
-        $BINOUT voxel_indices(ii) - 1;
+    "Writing start/end indices of contiguous non-zero voxel doses, 0-indexed"
+    "To be interpreted as [start, end)"
+    DO ii=1,num_blocks [
+        $BINOUT voxel_blocks(2*ii) - 1;
+        $BINOUT voxel_blocks(2*ii+1) - 1;
     ]
 
-    DO ii=1,num_nonzero[
-        dtemp = dd(voxel_indices(ii));
-        $BINOUT dtemp;
+    DO ii=1,num_blocks [
+        DO jj=voxel_blocks(2*ii),voxel_blocks(2*ii+1)-1 [
+            dtemp = dd(jj);
+            $BINOUT dtemp;
+        ]
     ]
 
-    DO ii=1,num_nonzero[
-        dtemp = ddun(voxel_indices(ii));
-        $BINOUT dtemp;
+    DO ii=1,num_blocks [
+        DO jj=voxel_blocks(2*ii),voxel_blocks(2*ii+1)-1 [
+            dtemp = ddun(jj);
+            $BINOUT dtemp;
+        ]
     ]
 ]
 

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -35,6 +35,7 @@
 "                   Frederic Tessier                                          "
 "                   Ernesto Mainegra-Hing                                     "
 "                   Reid Townson                                              "
+"                   Marc-Andre Renaud                                         "
 "                                                                             "
 "#############################################################################"
 "                                                                             "
@@ -1161,7 +1162,7 @@ REPLACE {;COMIN/SCORE/;} WITH {
     planarefp,planarfe,planarfp,
     nestep,
     endep_tmp($MAXDOSE),
-    i_phsp_out,i_muidx_out,i_unit_out,IWATCH,mxnp,
+    i_phsp_out,i_muidx_out,i_unit_out,IWATCH,mxnp,i_bindos,
     endep_last($MAXDOSE);
     REAL*8 endep, endep2, temp2,planarefe, planarefp, planarfe, planarfp;
     $LONG_INT nestep;
@@ -1172,6 +1173,7 @@ REPLACE {;COMIN/SCORE/;} WITH {
                         "in phase space data (phsp or BEAM simulation source"
                         "only)"
             i_unit_out, "unit no. for IAEA phsp output"
+            i_bindos,  "set to 1 to output sparse binary file"
             IWATCH,mxnp;
     $SHORT_INT endep_last;
 }
@@ -1410,6 +1412,7 @@ MAX20=0;
 IPHANT=0;
 doseprint=1; "assume we want to output doses to .egslst unless using CT"
 i_phsp_out=0; "default is to not output phsp"
+i_bindos=0;
 
 
 CALL DATETIME(1);
@@ -1806,11 +1809,12 @@ call srcinput(ieof);
 
 OUTPUT61;
 (//' NCASE,IWATCH,TIMMAX,INSEED1,INSEED2,BEAM_SIZE,ISMOOTH,IRESTART,IDAT,'/
-' IREJECT,ESAVE_GLOBAL,NRCYCL,IPARALLEL,PARNUM,n_split,ihowfarless,i_phsp_out'/
+' IREJECT,ESAVE_GLOBAL,NRCYCL,IPARALLEL,PARNUM,n_split,ihowfarless,i_phsp_out,'/
+' i_bindos '/
    ' : ',$);
-read(5,'(2I16,F15.0,2I10,F15.0,4I10,F15.0,6I10)')
+read(5,'(2I16,F15.0,2I10,F15.0,4I10,F15.0,7I10)')
 NCASE,IWATCH,TIMMAX,IXXIN,JXXIN,BEAM_SIZE,ISMOOTH,IRESTART,IDAT,IREJECT,
-ESAVE_GLOBAL,NRCYCL,IPARALLEL,PARNUM,n_split,ihowfarless,i_phsp_out;
+ESAVE_GLOBAL,NRCYCL,IPARALLEL,PARNUM,n_split,ihowfarless,i_phsp_out,i_bindos;
 
 IF(n_split<=1 & e_split>1)[
    OUTPUT;
@@ -3357,7 +3361,8 @@ IF(zerodose=1 & zerocount >0)[
 "subroutine call replaces a portion of code to write to .3ddose file"
 "do not call if we are doing a parallel run"
 IF((IPARALLEL <= 1 & n_parallel = 0) | (n_parallel > 0 & is_finished))[
-   call write_dose(IMAX,JMAX,KMAX,xbound,ybound,zbound,endep,endep2,idd,MAX20);
+   call write_dose(IMAX,JMAX,KMAX,xbound,ybound,zbound,endep,endep2,idd,MAX20
+                   ,i_bindos);
 ]
 ELSE [OUTPUT61;(//' No dose outputs since this is a parallel run '//);]
 
@@ -4305,7 +4310,7 @@ RETURN; end;
 "******************************************************************************
 
 subroutine write_dose(iimax,jjmax,kkmax,xbnd,ybnd,zbnd,dd,ddun,unitnum,
-                      writemax20);
+                      writemax20,bindos);
 
 
 "Writes dose to file designated by unitnum.  Currently the subroutine only
@@ -4369,14 +4374,18 @@ INTEGER iimax,                     "max number of x cells"
         ijkmax,                    "iimax*jjmax*kkmax"
         irtmp,                    "tmp variable to hold ir"
         writemax20,                "1 for summary of max 20 doses"
+        bindos,                   "1 for binary file"
         unitnum,                   "unit number in which to write data"
         ii,jj,kk,mm,nn,            "indices"
         NUMFRAC,                   "number of voxels for av. rel. uncertainty"
         MAXI(20),MAXJ(20),MAXK(20),"indices for max 20 doses"
+        num_nonzero,               "number of nonzero voxels"
+        voxel_indices($MAXDOSE),   "indices of nonzero voxels"
         egs_open_file;
 REAL    xbnd($IMAX+1),             "voxel x boundaries"
         ybnd($JMAX+1),             "voxel y boundaries"
         zbnd($KMAX+1),             "voxel z boundaries"
+        dtemp,                     "float version of double dose"
         MAXDOS(20),                "maximum 20 doses"
         MAXDOSAVG,                 "average of max 20 doses"
         ERRMAXDOSAVG,              "average of error of max 20 doses"
@@ -4391,22 +4400,58 @@ REAL    xbnd($IMAX+1),             "voxel x boundaries"
 REAL*8  dd($MAXDOSE),              "linear array of doses"
         ddun($MAXDOSE);            "linear array of dose uncertainties"
 
-REPLACE {$PLOTOUT#;} WITH {write(unitnum,*){P1};}
-REPLACE {$IRDWD(#,#,#)} WITH {({P1}+({P2}-1)*iimax+({P3}-1)*iimax*jjmax)}
+REPLACE {$PLOTOUT#;} WITH {write(unitnum,*){P1};};
+REPLACE {$BINOUT#;} WITH {write(unitnum){P1};};
+REPLACE {$IRDWD(#,#,#)} WITH {({P1}+({P2}-1)*iimax+({P3}-1)*iimax*jjmax)};
 
-"open the .3ddose file for output"
-unitnum=egs_open_file(unitnum,0,1,'.3ddose');
+num_nonzero = 0;
+ijkmax=iimax*jjmax*kkmax;
 
-$PLOTOUT iimax,jjmax,kkmax;
-$PLOTOUT (xbnd(ii),ii=1,iimax+1);
-$PLOTOUT (ybnd(jj),jj=1,jjmax+1);
-$PLOTOUT (zbnd(kk),kk=1,kkmax+1);
-$PLOTOUT (((dd($IRDWD(ii,jj,kk)),ii=1,iimax),jj=1,jjmax),kk=1,kkmax);
-$PLOTOUT (((ddun($IRDWD(ii,jj,kk)),ii=1,iimax),jj=1,jjmax),kk=1,kkmax);
+IF(bindos=0)[
+    "open the .3ddose file for output"
+    unitnum=egs_open_file(unitnum,0,1,'.3ddose');
+    $PLOTOUT iimax,jjmax,kkmax;
+    $PLOTOUT (xbnd(ii),ii=1,iimax+1);
+    $PLOTOUT (ybnd(jj),jj=1,jjmax+1);
+    $PLOTOUT (zbnd(kk),kk=1,kkmax+1);
+    $PLOTOUT (((dd($IRDWD(ii,jj,kk)),ii=1,iimax),jj=1,jjmax),kk=1,kkmax);
+    $PLOTOUT (((ddun($IRDWD(ii,jj,kk)),ii=1,iimax),jj=1,jjmax),kk=1,kkmax);
+]
+ELSE[
+    DO ii=1,ijkmax[
+        IF(dd(ii)>0.0)[
+            num_nonzero = num_nonzero + 1;
+            voxel_indices(num_nonzero) = ii;
+        ]
+    ]
+
+    "open the .bindos file for output"
+    unitnum=egs_open_file(unitnum,-1,1,'.bindos');
+    $BINOUT iimax,jjmax,kkmax;
+    $BINOUT (xbnd(ii),ii=1,iimax+1);
+    $BINOUT (ybnd(jj),jj=1,jjmax+1);
+    $BINOUT (zbnd(kk),kk=1,kkmax+1);
+
+    $BINOUT num_nonzero;
+
+    "Writing voxel indices as a zero-indexed array even though fortran arrays"
+    "are one-indexed."
+    DO ii=1,num_nonzero[
+        $BINOUT voxel_indices(ii) - 1;
+    ]
+
+    DO ii=1,num_nonzero[
+        dtemp = dd(voxel_indices(ii));
+        $BINOUT dtemp;
+    ]
+
+    DO ii=1,num_nonzero[
+        dtemp = ddun(voxel_indices(ii));
+        $BINOUT dtemp;
+    ]
+]
 
 close(unitnum);
-
-ijkmax=iimax*jjmax*kkmax;
 
 IF(writemax20=1)["print out maximum 20 doses"
   DO mm=1,20 [ MAXDOS(mm)=0.0; ]


### PR DESCRIPTION
# Sparse binary 3ddose output
Just throwing this pull request up here to see if there is any interest. It was a fairly simple change to make.

## Use case
As part of my research, I use DOSXYZnrc to generate electron beamlets for mixed electron-photon optimisation. A full set of electron beamlets for 5 gantry angles for a single chest wall patient (15,000 beamlets total) with 3mm^3 voxels takes up 2.1 TB of disk space when they're stored as 3ddose files. Just the process of converting beamlets to a nicer format takes a long time. When stored as sparse binary files, the same set of beamlets takes ~14 GB. Being able to output directly to binary dose saves tons of space and time.

## The format
The format is similar the 3ddose format, except that voxels with 0 dose are omitted. The binary file is constructed as:

- x_num_voxels, y_num_voxels, z_num_voxels (3 * sizeof(i32) bytes)
- Voxel coordinates in x direction ((x_num_voxels + 1) * sizeof(f32) bytes)
- Voxel coordinates in y direction ((y_num_voxels + 1) * sizeof(f32) bytes)
- Voxel coordinates in z direction ((z_num_voxels + 1) * sizeof(f32) bytes)
- Number of nonzero voxels (1 * sizeof(i32) bytes)
- 0-indexed linearized voxel indices (num_nonzero * sizeof(i32) bytes)
- Non-zero dose values (num_nonzero * sizeof(f32) bytes)
- Uncert values for non-zero voxels (num_nonzero * sizeof(f32) bytes)

The format was chosen to allow codes reading in the binary dose to avoid having to read in uncertainties if they're not needed. Dose/uncert values are stored as floats to save space since there's no accumulation of floating point errors to worry about as this is a storage format.

I added a flag to toggle between 3ddose/binary dose output in the input file. Default value is 3ddose and the input file is kept backwards compatible for people who don't specify the flag.

## Downsides
- The binary files aren't as portable as text files, though this is becoming less and less true as little-endian architecture seem to have won the endianness war?
- To output the binary dose file efficiently, I added an array to hold indices of nonzero voxels in the write_dose routine, adds $MAXDOSE * sizeof(i32) bytes to RAM usage of DOSXYZnrc. This can be avoided but the routine to output the binary dose becomes less efficient (need to do more passes through the dose arrays).
- Uses ```access='stream'``` in fortran to write C-style binary files. Apparently this was added with fortran2003 so there could be compatibility issues with older compilers.
- May not really be needed by anyone else?

Let me know if there is interest to include this in the official distribution. I can fill in the gaps in the documentation and add a checkbox to the GUI. Otherwise I'll just keep this on my branch.

Cheers,
Marc