### PR TITLE
Fix #398: Seg fault when pegsless material missing

### DIFF
--- a/HEN_HOUSE/src/pegs4_macros.mortran
+++ b/HEN_HOUSE/src/pegs4_macros.mortran
@@ -235,6 +235,13 @@ DO IM=1,NMED[
  ]
  TEP=AEP-RMP; THMOLLP=AEP+TEP ; "equation in pegs4.mortran"
 
+ IF (UEP.LE.AEP)[
+    write(i_log,'(a,24a1)')'  Error: Material not defined: ',
+                              (media(j,IM),j=1,24);
+    $egs_fatal(*,'Material used in the geometry was not defined in the'
+                ,' material data.');
+ ]
+
  CALL MIX; "calculates MS parameters"
 
  CALL SPINIT(inpdensity_file(IM)); "density corrections, may open density file"


### PR DESCRIPTION
Fix a segmentation fault that occurred when in pegsless mode and a material used in the geometry is missing from the material definitions. Now the code returns gracefully with a fatal error message.