### PR TITLE
Fix #413: limit vacuum step size in magnetic field

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1111,6 +1111,10 @@ $start_new_particle;
                     "          direction of motion at the start of the step
                     " Note that tustep and ustep are modified below.
                     " The above provide defaults.)
+
+                    " EM field step size restriction in vacuum
+                    $SET-TUSTEP-EM-FIELD;
+                    ustep = tustep;
             ]
             ELSE
             [
@@ -1383,7 +1387,7 @@ $start_new_particle;
                          "(allows for EM field deflection
                 ] "end of vacuum step
 
-                $electron_region_change;
+                IF(irnew ~= irold) [ $electron_region_change; ];
 
                 IF(ustep ~= 0) [$AUSCALL($TRANAUSA);]
                 IF(eie <= ecut(irl)) [go to :ECUT-DISCARD:;]

--- a/HEN_HOUSE/src/emf_macros.mortran
+++ b/HEN_HOUSE/src/emf_macros.mortran
@@ -88,7 +88,7 @@ APPEND {;
             ufx,ufy,ufz,
             bdotub,bsqrd,
             ufxpar,ufypar,ufzpar,
-            ufxprp,ufyprp,ufzprp,ustepold;
+            ufxprp,ufyprp,ufzprp;
 } TO {$DEFINE-LOCAL-VARIABLES-ELECTR;};
 
 
@@ -291,14 +291,6 @@ IF(MEDIUM.EQ.0)[
 "$SET-TVSTEP-EM-FIELD;--this is for higher order corrections"
 "do first order corrections for now--BW"
 IF(ExIN~=0.0 | EyIN~=0.0 | EzIN~=0.0 | BxIN~=0.0 | ByIN~=0.0 | BzIN~=0)[
-USTEPOLD=USTEP;
-IF(USTEP>smaxir(irl)) USTEP=smaxir(irl);
-TUSTEP=USTEP;
-$SET-TUSTEP-EM-FIELD;
-TVSTEP=TUSTEP;
-VSTEP=TVSTEP;
-USTEP=VSTEP;
-IF(USTEP<USTEPOLD) irnew=irl;
 DE=0.0;
 $ADD-WORK-EM-FIELD;
 PEIE=PEIE-DE;EIE=PEIE;E(NP)=PEIE;


### PR DESCRIPTION
Adjust the charged particle step routine for transport in vacuum when
there is an electromagnetic field (emf). The existing logic failed
because the emf step size restriction was not taken into account before
the howfar call. Hence the howfar method tracked the particle in a
single straight step across the entire vacuum region, causing erroneous
region changes and discards.