### PR TITLE
Fix egs++ particle tracks crash on Windows 10

### DIFF
--- a/HEN_HOUSE/egs++/egs_particle_track.cpp
+++ b/HEN_HOUSE/egs++/egs_particle_track.cpp
@@ -187,6 +187,9 @@ void EGS_ParticleTrackContainer::addVertex(EGS_ParticleTrack::Vertex *x) {
 }
 
 void EGS_ParticleTrackContainer::addVertex(int stackIndex, EGS_ParticleTrack::Vertex *x) {
+    if (m_stackMap[stackIndex] < 0) {
+        return;
+    }
     if (!m_isScoring[m_stackMap[stackIndex]]) {
         return;
     }

--- a/HEN_HOUSE/egs++/egs_particle_track.h
+++ b/HEN_HOUSE/egs++/egs_particle_track.h
@@ -271,6 +271,9 @@ public:
 
     /*! \brief Are we still scoring the particle mapped by the stack? */
     bool isScoringParticle(int stackIndex) {
+        if (m_stackMap[stackIndex] < 0) {
+            return false;
+        }
         return m_isScoring[m_stackMap[stackIndex]];
     }
 
@@ -281,7 +284,9 @@ public:
 
     /*! \brief Stop scoring the particle mapped by the stack. */
     void stopScoringParticle(int stackIndex) {
-        m_isScoring[m_stackMap[stackIndex]] = false;
+        if (m_stackMap[stackIndex] >= 0) {
+            m_isScoring[m_stackMap[stackIndex]] = false;
+        }
         m_stackMap[stackIndex] = -1;
     }
 
@@ -302,7 +307,9 @@ public:
 
     /*! \brief Set the type of mapped particle to \a p .*/
     void setParticleInfo(int stackIndex, EGS_ParticleTrack::ParticleInfo *p) {
-        m_buffer[m_stackMap[stackIndex]]->setParticleInfo(p);
+        if (m_stackMap[stackIndex] >= 0) {
+            m_buffer[m_stackMap[stackIndex]]->setParticleInfo(p);
+        }
     }
 
     /*! \brief Set the type of the currently tracked particle to \a p .*/


### PR DESCRIPTION
Fix a crash that occurred often when using tracks on Windows 10. The crash started happening with a Windows update, and resulted in a segmentation fault when generating the first track in the simulation. The crash occurred due to accessing an array index out of bounds in the tracks generation (not sure why this didn't crash previously).

Fixes issue #385, from what I can tell.

This is an important functionality fix and should be added to master.