### PR TITLE
Update egs_view layout

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
@@ -322,6 +322,11 @@ public:
         dose_geom= dgeom;
         file_type = ftype;
     };
+    bool getOutputFile(EGS_BaseGeometry *&dgeom, int &ftype) {
+        dgeom = dose_geom;
+        ftype = file_type;
+        return output_dose_file;
+    };
     void setUserNorm(const EGS_Float &normi) {
         norm_u=normi;
     };

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -133,7 +133,7 @@ public:
         int j = 0, iloop = 0;
         while (nnow > 0) {
             if (geoms[j]->deref() == -1) {
-                delete geoms[j];
+                removeGeometry(geoms[j]);
             }
             else {
                 geoms[j++]->ref();
@@ -144,7 +144,7 @@ public:
 
                 for(int i=0; i<nnow; ++i) {
                     if(!geoms[i]->deref()) {
-                        delete geoms[i];
+                        removeGeometry(geoms[i]);
                     }
                 }
 
@@ -465,6 +465,14 @@ void EGS_BaseGeometry::clearGeometries() {
 
 EGS_BaseGeometry *EGS_BaseGeometry::getGeometry(const string &Name) {
     return egs_geometries[active_glist].getGeometry(Name);
+}
+
+EGS_BaseGeometry **EGS_BaseGeometry::getGeometries() {
+    return egs_geometries[active_glist].geoms;
+}
+
+int EGS_BaseGeometry::getNGeometries() {
+    return egs_geometries[active_glist].nnow;
 }
 
 void EGS_BaseGeometry::setMedium(const string &Name) {

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -149,8 +149,8 @@ public:
                 }
 
                 if (iloop > 20) {
-                    egsWarning("~EGS_GeometryPrivate(): failed "
-                               "to delete all geometries after 20 loops!\n");
+//                     egsWarning("~EGS_GeometryPrivate(): failed "
+//                                "to delete all geometries after 20 loops!\n");
 
                     break;
                 }
@@ -188,12 +188,19 @@ public:
     };
 
     void removeGeometry(EGS_BaseGeometry *g) {
+        ntot--;
+        EGS_BaseGeometry **tmp = new EGS_BaseGeometry* [ntot];
+        int i=0;
         for (int j=0; j<nnow; j++) {
-            if (geoms[j] == g) {
-                geoms[j] = geoms[--nnow];
-                break;
+            if (geoms[j] != g) {
+                tmp[i++] = geoms[j];
             }
         }
+        if (geoms) {
+            delete [] geoms;
+        }
+        nnow--;
+        geoms = tmp;
     };
 
     EGS_BaseGeometry *getGeometry(const string &name) {

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -141,9 +141,19 @@ public:
             if (j >= nnow && nnow) {
                 j = 0;
                 ++iloop;
-                if (iloop > 20) egsWarning("~EGS_GeometryPrivate(): failed "
-                                               "to delete all geometries after 20 loops!\n");
-                break;
+
+                for(int i=0; i<nnow; ++i) {
+                    if(!geoms[i]->deref()) {
+                        delete geoms[i];
+                    }
+                }
+
+                if (iloop > 20) {
+                    egsWarning("~EGS_GeometryPrivate(): failed "
+                               "to delete all geometries after 20 loops!\n");
+
+                    break;
+                }
             }
         }
     };
@@ -422,7 +432,7 @@ EGS_BaseGeometry::EGS_BaseGeometry(const string &Name) : nreg(0), name(Name),
     }
     if (egs_geometries[active_glist].addGeometry(this) < 0)
         egsFatal("EGS_BaseGeometry::EGS_BaseGeometry:\n"
-                 "  a geometry with name %s alread exists\n",name.c_str());
+                 "  a geometry with name %s already exists\n",name.c_str());
 }
 
 EGS_BaseGeometry::~EGS_BaseGeometry() {

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -142,8 +142,8 @@ public:
                 j = 0;
                 ++iloop;
 
-                for(int i=0; i<nnow; ++i) {
-                    if(!geoms[i]->deref()) {
+                for (int i=0; i<nnow; ++i) {
+                    if (!geoms[i]->deref()) {
                         removeGeometry(geoms[i]);
                     }
                 }

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -568,6 +568,10 @@ public:
      */
     static EGS_BaseGeometry *getGeometry(const string &Name);
 
+    static EGS_BaseGeometry **getGeometries();
+
+    static int getNGeometries();
+
     /*! \brief Get a unique geometry name
 
       This function is used to create a unique name for a nameless

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.h
@@ -167,7 +167,7 @@ public:
         while (!okfano);
         u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
         EGS_Float sinz = 1-u.z*u.z;
-        if ( sinz > epsilon ) {
+        if (sinz > epsilon) {
             sinz = sqrt(sinz);
             EGS_Float cphi, sphi;
             EGS_Float phi = min_phi + (max_phi - min_phi)*rndm->getUniform();

--- a/HEN_HOUSE/egs++/view/clippingplanes.cpp
+++ b/HEN_HOUSE/egs++/view/clippingplanes.cpp
@@ -45,10 +45,10 @@ ClippingPlanesWidget::ClippingPlanesWidget(QWidget *parent, const char *name)
     setObjectName(name);
     setupUi(this);
 
-    planeTable->setColumnWidth(0,62);
-    planeTable->setColumnWidth(1,62);
-    planeTable->setColumnWidth(2,62);
-    planeTable->setColumnWidth(3,62);
+    planeTable->setColumnWidth(0,60);
+    planeTable->setColumnWidth(1,60);
+    planeTable->setColumnWidth(2,60);
+    planeTable->setColumnWidth(3,60);
     planeTable->setColumnWidth(4,28);
 }
 

--- a/HEN_HOUSE/egs++/view/clippingplanes.cpp
+++ b/HEN_HOUSE/egs++/view/clippingplanes.cpp
@@ -45,11 +45,11 @@ ClippingPlanesWidget::ClippingPlanesWidget(QWidget *parent, const char *name)
     setObjectName(name);
     setupUi(this);
 
-    planeTable->setColumnWidth(0,72);
-    planeTable->setColumnWidth(1,72);
-    planeTable->setColumnWidth(2,72);
-    planeTable->setColumnWidth(3,71);
-    planeTable->setColumnWidth(4,22);
+    planeTable->setColumnWidth(0,62);
+    planeTable->setColumnWidth(1,62);
+    planeTable->setColumnWidth(2,62);
+    planeTable->setColumnWidth(3,62);
+    planeTable->setColumnWidth(4,28);
 }
 
 ClippingPlanesWidget::~ClippingPlanesWidget() {

--- a/HEN_HOUSE/egs++/view/clippingplanes.cpp
+++ b/HEN_HOUSE/egs++/view/clippingplanes.cpp
@@ -45,8 +45,6 @@ ClippingPlanesWidget::ClippingPlanesWidget(QWidget *parent, const char *name)
     setObjectName(name);
     setupUi(this);
 
-    // Hide the row headers
-    planeTable->verticalHeader()->setVisible(false);
     planeTable->setColumnWidth(0,72);
     planeTable->setColumnWidth(1,72);
     planeTable->setColumnWidth(2,72);
@@ -64,6 +62,11 @@ void ClippingPlanesWidget::applyClipping() {
 
 int ClippingPlanesWidget::numPlanes() {
     return planeTable->rowCount();
+}
+
+QTableWidgetItem* ClippingPlanesWidget::getItem(int i, int j) {
+    QTableWidgetItem *item = planeTable->item(i,j);
+    return item;
 }
 
 
@@ -113,3 +116,32 @@ bool ClippingPlanesWidget::getPlane(int j, EGS_Vector &a, EGS_Float &d) {
     return true;
 }
 
+void ClippingPlanesWidget::setCell(int i, int j, EGS_Float val) {
+    QTableWidgetItem *item = planeTable->item(i,j);
+
+    if(!item) {
+        item = new QTableWidgetItem();
+        planeTable->setItem(i,j,item);
+    }
+
+    item->setText(QString::number(val));
+}
+
+void ClippingPlanesWidget::setCell(int i, int j, Qt::CheckState checked) {
+    QTableWidgetItem *item = planeTable->item(i,j);
+
+    if(!item) {
+        item = new QTableWidgetItem();
+        planeTable->setItem(i,j,item);
+    }
+
+    item->setCheckState(checked);
+}
+
+void ClippingPlanesWidget::clearCell(int i, int j) {
+    QTableWidgetItem *item = planeTable->item(i,j);
+
+    if(item) {
+        delete item;
+    }
+}

--- a/HEN_HOUSE/egs++/view/clippingplanes.cpp
+++ b/HEN_HOUSE/egs++/view/clippingplanes.cpp
@@ -64,7 +64,7 @@ int ClippingPlanesWidget::numPlanes() {
     return planeTable->rowCount();
 }
 
-QTableWidgetItem* ClippingPlanesWidget::getItem(int i, int j) {
+QTableWidgetItem *ClippingPlanesWidget::getItem(int i, int j) {
     QTableWidgetItem *item = planeTable->item(i,j);
     return item;
 }
@@ -73,10 +73,10 @@ QTableWidgetItem* ClippingPlanesWidget::getItem(int i, int j) {
 bool ClippingPlanesWidget::getPlane(int j, EGS_Vector &a, EGS_Float &d) {
     // check if all row items exist and are selected.
     QTableWidgetItem *itemAx = planeTable->item(j,0),
-                     *itemAy = planeTable->item(j,1),
-                     *itemAz = planeTable->item(j,2),
-                     *itemD = planeTable->item(j,3),
-                     *itemApplied = planeTable->item(j,4);
+                      *itemAy = planeTable->item(j,1),
+                       *itemAz = planeTable->item(j,2),
+                        *itemD = planeTable->item(j,3),
+                         *itemApplied = planeTable->item(j,4);
 
     // Make sure all parameters for a plane exist
     if (!itemAx || !itemAy || !itemAz  || !itemD || !itemApplied) {
@@ -119,7 +119,7 @@ bool ClippingPlanesWidget::getPlane(int j, EGS_Vector &a, EGS_Float &d) {
 void ClippingPlanesWidget::setCell(int i, int j, EGS_Float val) {
     QTableWidgetItem *item = planeTable->item(i,j);
 
-    if(!item) {
+    if (!item) {
         item = new QTableWidgetItem();
         planeTable->setItem(i,j,item);
     }
@@ -130,7 +130,7 @@ void ClippingPlanesWidget::setCell(int i, int j, EGS_Float val) {
 void ClippingPlanesWidget::setCell(int i, int j, Qt::CheckState checked) {
     QTableWidgetItem *item = planeTable->item(i,j);
 
-    if(!item) {
+    if (!item) {
         item = new QTableWidgetItem();
         planeTable->setItem(i,j,item);
     }
@@ -141,7 +141,7 @@ void ClippingPlanesWidget::setCell(int i, int j, Qt::CheckState checked) {
 void ClippingPlanesWidget::clearCell(int i, int j) {
     QTableWidgetItem *item = planeTable->item(i,j);
 
-    if(item) {
+    if (item) {
         delete item;
     }
 }

--- a/HEN_HOUSE/egs++/view/clippingplanes.cpp
+++ b/HEN_HOUSE/egs++/view/clippingplanes.cpp
@@ -44,25 +44,21 @@ ClippingPlanesWidget::ClippingPlanesWidget(QWidget *parent, const char *name)
     : QWidget(parent) {
     setObjectName(name);
     setupUi(this);
-#if QT_VERSION >= 0x050000
-    planeTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-#else
-    planeTable->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
-#endif
+
+    // Hide the row headers
+    planeTable->verticalHeader()->setVisible(false);
+    planeTable->setColumnWidth(0,72);
+    planeTable->setColumnWidth(1,72);
+    planeTable->setColumnWidth(2,72);
+    planeTable->setColumnWidth(3,71);
+    planeTable->setColumnWidth(4,22);
 }
 
 ClippingPlanesWidget::~ClippingPlanesWidget() {
 }
 
-void ClippingPlanesWidget::applyClicked() {
+void ClippingPlanesWidget::applyClipping() {
     emit clippingPlanesChanged();
-}
-
-
-void ClippingPlanesWidget::helpClicked() {
-#ifdef VIEW_DEBUG
-    egsWarning("In ClippingPlanesWidget::helpClicked()\n");
-#endif
 }
 
 
@@ -74,14 +70,19 @@ int ClippingPlanesWidget::numPlanes() {
 bool ClippingPlanesWidget::getPlane(int j, EGS_Vector &a, EGS_Float &d) {
     // check if all row items exist and are selected.
     QTableWidgetItem *itemAx = planeTable->item(j,0),
-                      *itemAy = planeTable->item(j,1),
-                       *itemAz = planeTable->item(j,2),
-                        *itemD = planeTable->item(j,3);
-    if (!itemAx || !itemAy || !itemAz  || !itemD) {
+                     *itemAy = planeTable->item(j,1),
+                     *itemAz = planeTable->item(j,2),
+                     *itemD = planeTable->item(j,3),
+                     *itemApplied = planeTable->item(j,4);
+
+    // Make sure all parameters for a plane exist
+    if (!itemAx || !itemAy || !itemAz  || !itemD || !itemApplied) {
         return false;
     }
-    if (!itemAx->isSelected() || !itemAy->isSelected() ||
-            !itemAz->isSelected() || !itemD->isSelected()) {
+
+    // See if the checkbox in the 4th column is checked
+    // Only use the plane if it is checked
+    if (itemApplied->checkState() == Qt::Unchecked) {
         return false;
     }
 

--- a/HEN_HOUSE/egs++/view/clippingplanes.h
+++ b/HEN_HOUSE/egs++/view/clippingplanes.h
@@ -46,10 +46,6 @@ public:
     virtual int numPlanes();
     virtual bool getPlane(int j, EGS_Vector &a, EGS_Float &d);
 
-public slots:
-
-    virtual void helpClicked();
-
 signals:
 
     void clippingPlanesChanged();
@@ -59,7 +55,7 @@ protected slots:
     virtual void languageChange() {
         retranslateUi(this);
     }
-    virtual void applyClicked();
+    virtual void applyClipping();
 
 };
 

--- a/HEN_HOUSE/egs++/view/clippingplanes.h
+++ b/HEN_HOUSE/egs++/view/clippingplanes.h
@@ -45,6 +45,10 @@ public:
 
     virtual int numPlanes();
     virtual bool getPlane(int j, EGS_Vector &a, EGS_Float &d);
+    virtual void setCell(int i, int j, EGS_Float val);
+    virtual void setCell(int i, int j, Qt::CheckState checked);
+    virtual void clearCell(int i, int j);
+    virtual QTableWidgetItem* getItem(int i, int j);
 
 signals:
 

--- a/HEN_HOUSE/egs++/view/clippingplanes.h
+++ b/HEN_HOUSE/egs++/view/clippingplanes.h
@@ -48,7 +48,7 @@ public:
     virtual void setCell(int i, int j, EGS_Float val);
     virtual void setCell(int i, int j, Qt::CheckState checked);
     virtual void clearCell(int i, int j);
-    virtual QTableWidgetItem* getItem(int i, int j);
+    virtual QTableWidgetItem *getItem(int i, int j);
 
 signals:
 

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -35,8 +35,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>415</width>
-    <height>417</height>
+    <width>304</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -45,12 +45,21 @@
     <verstretch>0</verstretch>
    </sizepolicy>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>200</width>
+    <height>400</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
   <layout class="QVBoxLayout">
    <property name="leftMargin">
     <number>1</number>
+   </property>
+   <property name="bottomMargin">
+    <number>2</number>
    </property>
    <item>
     <widget class="QGroupBox" name="groupBox1">
@@ -59,6 +68,12 @@
        <horstretch>0</horstretch>
        <verstretch>0</verstretch>
       </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>300</height>
+      </size>
      </property>
      <property name="title">
       <string>Clipping planes</string>
@@ -83,7 +98,7 @@
       <item>
        <widget class="QTableWidget" name="planeTable">
         <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
           <horstretch>0</horstretch>
           <verstretch>0</verstretch>
          </sizepolicy>

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -35,8 +35,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>388</width>
-    <height>377</height>
+    <width>415</width>
+    <height>417</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -49,6 +49,9 @@
    <string>Form1</string>
   </property>
   <layout class="QVBoxLayout">
+   <property name="leftMargin">
+    <number>1</number>
+   </property>
    <item>
     <widget class="QGroupBox" name="groupBox1">
      <property name="sizePolicy">
@@ -61,6 +64,9 @@
       <string>Clipping planes</string>
      </property>
      <layout class="QVBoxLayout">
+      <property name="leftMargin">
+       <number>9</number>
+      </property>
       <item>
        <widget class="QLabel" name="label">
         <property name="sizePolicy">

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -39,38 +39,86 @@
     <height>377</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="windowTitle">
    <string>Form1</string>
   </property>
   <layout class="QVBoxLayout">
    <item>
     <widget class="QGroupBox" name="groupBox1">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="title">
       <string>Clipping planes</string>
      </property>
      <layout class="QVBoxLayout">
       <item>
        <widget class="QLabel" name="label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
         <property name="text">
-         <string>Input the normal vector and distance from origin</string>
+         <string>Normal vector and distance from origin</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QTableWidget" name="planeTable">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>270</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="sortingEnabled">
+         <bool>true</bool>
+        </property>
         <property name="rowCount">
          <number>10</number>
         </property>
         <property name="columnCount">
          <number>5</number>
         </property>
+        <attribute name="horizontalHeaderCascadingSectionResizes">
+         <bool>true</bool>
+        </attribute>
         <attribute name="horizontalHeaderDefaultSectionSize">
-         <number>80</number>
+         <number>71</number>
         </attribute>
         <attribute name="horizontalHeaderMinimumSectionSize">
          <number>12</number>
         </attribute>
+        <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>false</bool>
+        </attribute>
         <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <attribute name="verticalHeaderCascadingSectionResizes">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderHighlightSections">
          <bool>false</bool>
         </attribute>
         <row/>

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -1,4 +1,6 @@
-<ui version="4.0"><comment>
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <comment>
 ###############################################################################
 #
 #  EGSnrc egs++ geometry viewer clipping planes user interface
@@ -48,63 +50,30 @@
      </property>
      <layout class="QVBoxLayout">
       <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Input the normal vector and distance from origin</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QTableWidget" name="planeTable">
         <property name="rowCount">
          <number>10</number>
         </property>
         <property name="columnCount">
-         <number>4</number>
+         <number>5</number>
         </property>
-        <row>
-         <property name="text">
-          <string>1</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>2</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>3</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>4</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>5</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>6</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>7</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>8</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>9</string>
-         </property>
-        </row>
-        <row>
-         <property name="text">
-          <string>10</string>
-         </property>
-        </row>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
+        <row/>
         <column>
          <property name="text">
           <string>ax</string>
@@ -125,20 +94,215 @@
           <string>d</string>
          </property>
         </column>
+        <column>
+         <property name="text">
+          <string> </string>
+         </property>
+        </column>
+        <item row="0" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="1" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="2" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="3" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="4" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="5" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="6" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="7" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="8" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
+        <item row="9" column="4">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="background">
+          <brush brushstyle="SolidPattern">
+           <color alpha="255">
+            <red>186</red>
+            <green>189</green>
+            <blue>182</blue>
+           </color>
+          </brush>
+         </property>
+         <property name="checkState">
+          <enum>Checked</enum>
+         </property>
+         <property name="flags">
+          <set>ItemIsUserCheckable|ItemIsEnabled</set>
+         </property>
+        </item>
        </widget>
       </item>
       <item>
        <layout class="QHBoxLayout">
-        <item>
-         <widget class="QPushButton" name="pushButton2">
-          <property name="text">
-           <string>&amp;Help</string>
-          </property>
-          <property name="shortcut">
-           <string>Alt+H</string>
-          </property>
-         </widget>
-        </item>
         <item>
          <spacer name="spacer1">
           <property name="orientation">
@@ -150,20 +314,10 @@
           <property name="sizeHint" stdset="0">
            <size>
             <width>211</width>
-            <height>31</height>
+            <height>108</height>
            </size>
           </property>
          </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="pushButton1">
-          <property name="text">
-           <string>&amp;Apply</string>
-          </property>
-          <property name="shortcut">
-           <string>Alt+A</string>
-          </property>
-         </widget>
         </item>
        </layout>
       </item>
@@ -179,26 +333,10 @@
  <resources/>
  <connections>
   <connection>
-   <sender>pushButton1</sender>
-   <signal>clicked()</signal>
+   <sender>planeTable</sender>
+   <signal>cellChanged(int, int)</signal>
    <receiver>ClippingPlanesWidget</receiver>
-   <slot>applyClicked()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>pushButton2</sender>
-   <signal>clicked()</signal>
-   <receiver>ClippingPlanesWidget</receiver>
-   <slot>helpClicked()</slot>
+   <slot>applyClipping()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -35,8 +35,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>475</width>
-    <height>325</height>
+    <width>388</width>
+    <height>377</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -64,6 +64,15 @@
         <property name="columnCount">
          <number>5</number>
         </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>80</number>
+        </attribute>
+        <attribute name="horizontalHeaderMinimumSectionSize">
+         <number>12</number>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
         <row/>
         <row/>
         <row/>
@@ -96,7 +105,7 @@
         </column>
         <column>
          <property name="text">
-          <string> </string>
+          <string/>
          </property>
         </column>
         <item row="0" column="4">
@@ -300,26 +309,6 @@
          </property>
         </item>
        </widget>
-      </item>
-      <item>
-       <layout class="QHBoxLayout">
-        <item>
-         <spacer name="spacer1">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeType">
-           <enum>QSizePolicy::Expanding</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>211</width>
-            <height>108</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-       </layout>
       </item>
      </layout>
     </widget>

--- a/HEN_HOUSE/egs++/view/clippingplanes.ui
+++ b/HEN_HOUSE/egs++/view/clippingplanes.ui
@@ -110,7 +110,7 @@
          <bool>true</bool>
         </attribute>
         <attribute name="horizontalHeaderStretchLastSection">
-         <bool>false</bool>
+         <bool>true</bool>
         </attribute>
         <attribute name="verticalHeaderVisible">
          <bool>false</bool>

--- a/HEN_HOUSE/egs++/view/egs_track_view.cpp
+++ b/HEN_HOUSE/egs++/view/egs_track_view.cpp
@@ -317,11 +317,12 @@ bool EGS_TrackView::renderTracks(int nx, int ny, EGS_Vector *image,
             EGS_Float color = (k+1);
 
             int min, max;
-            if(trackIndices.size()) {
+            if (trackIndices.size()) {
                 min = trackIndices[2*k];
                 // Avoid out of bounds error, max out at m_tracks
                 max = trackIndices[2*k+1] > m_tracks[k] ? m_tracks[k] : trackIndices[2*k+1];
-            } else {
+            }
+            else {
                 min = 0;
                 max = m_tracks[k];
             }
@@ -403,7 +404,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             xxx1 = r1.x;
             yyy1 = r1.y;
             dst1 = f1.length();
-            if(energyScaling) {
+            if (energyScaling) {
                 e1 = v1.e / m_maxE;
             }
         }
@@ -427,7 +428,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             xxx1 = xxx2;
             yyy1 = yyy2;
             dst1 = dst2;
-            if(energyScaling) {
+            if (energyScaling) {
                 e1 = e2;
             }
         }
@@ -436,7 +437,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
         xxx2 = r2.x;
         yyy2 = r2.y;
         dst2 = f2.length();
-        if(energyScaling) {
+        if (energyScaling) {
             e2 = v2.e / m_maxE;
         }
 
@@ -469,7 +470,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
         double gd = dst1;
         double de, ge;
 
-        if(energyScaling) {
+        if (energyScaling) {
             de = (e2 - e1);
             ge = e1;
         }
@@ -480,7 +481,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             ddy = ddy / abs(ddx);
             int di = (xxx1 > xxx2) ? -1 : 1;
             dd = dd / abs(ddx);
-            if(energyScaling) {
+            if (energyScaling) {
                 de = de / abs(ddx);
             }
 
@@ -495,13 +496,13 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
                     if (color > tmpv3.x) {
                         tmpv3.x = color; // put "important" particles in front [warning: may teleport particles through a sheet of lesser particles]
                     }
-                    if(energyScaling) {
+                    if (energyScaling) {
                         tmpv3.y += (1-tmpv3.y)*e2; // compound transparency values
                     }
                 }
                 else {
                     tmpv3.x = color;
-                    if(energyScaling) {
+                    if (energyScaling) {
                         tmpv3.y=e2;
                     }
                     tmpv3.z=-gd; // just update with current track info
@@ -510,7 +511,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
                 image[cx + ((int)(cy))*nx] = tmpv3;
                 cy += ddy;
                 gd += dd;
-                if(energyScaling) {
+                if (energyScaling) {
                     ge += de;
                 }
             }
@@ -521,7 +522,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             cx = xxx1;
             ddx = ddx / abs(ddy);
             dd = dd / abs(ddy);
-            if(energyScaling) {
+            if (energyScaling) {
                 de = de / abs(ddy);
             }
 
@@ -536,13 +537,13 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
                     if (color > tmpv3.x) {
                         tmpv3.x = color; // put "important" particles in front
                     }
-                    if(energyScaling) {
+                    if (energyScaling) {
                         tmpv3.y += (1-tmpv3.y)*e2; // compound transparency values
                     }
                 }
                 else {
                     tmpv3.x = color;
-                    if(energyScaling) {
+                    if (energyScaling) {
                         tmpv3.y=e2;
                     }
                     tmpv3.z=-gd; // just update with current track info
@@ -552,7 +553,7 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
 
                 cx += ddx;
                 gd += dd;
-                if(energyScaling) {
+                if (energyScaling) {
                     ge += de;
                 }
             }

--- a/HEN_HOUSE/egs++/view/egs_track_view.cpp
+++ b/HEN_HOUSE/egs++/view/egs_track_view.cpp
@@ -343,7 +343,7 @@ static screenpt projectToScreen(const EGS_Vector &v, double nx, double ny,
 void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EGS_Float color, int nx, int ny, EGS_Vector *image) {
     bool prev_clipped = true;
     int xxx2, yyy2;
-    double dst2, e2;
+    double dst2, e2 = 0;
     for (int k=0; k<len-1; k++) {
         int xxx1, yyy1;
         double dst1, e1;

--- a/HEN_HOUSE/egs++/view/egs_track_view.cpp
+++ b/HEN_HOUSE/egs++/view/egs_track_view.cpp
@@ -73,7 +73,7 @@ EGS_TrackView::EGS_TrackView(const char *filename) {
     typedef EGS_ParticleTrack::ParticleInfo PInfo;
 
     // zero pointers
-    for (int i=0; i<4; i++) {
+    for (int i=0; i<3; i++) {
         m_index[i] = NULL;
         m_points[i] = NULL;
     }
@@ -116,8 +116,8 @@ EGS_TrackView::EGS_TrackView(const char *filename) {
 
     char **tmp_index = new char *[tot_tracks];
 
-    int count_num[4] = {0,0,0,0};
-    int count_vert[4] = {0,0,0,0};
+    int count_num[3] = {0,0,0};
+    int count_vert[3] = {0,0,0};
     m_maxE = 0;
     // Or just -inf, if available.
     m_xmax = -10000000000000;
@@ -163,15 +163,15 @@ EGS_TrackView::EGS_TrackView(const char *filename) {
     // Copying data into a more efficient and compact representation.
     // This doubles the initial memory use but is more efficient afterwards.
 
-    for (int i=0; i<4; i++) {
+    for (int i=0; i<3; i++) {
         // In theory we could calculate above exactly how much track
         // compression saves, so overcopies aren't necessary.
         m_points[i] = new EGS_ParticleTrack::Vertex[count_vert[i]];
         m_index[i] = new int[count_num[i]+1];
     }
 
-    int mem_rcnt[4] = {0,0,0,0};
-    int ind_rcnt[4] = {0,0,0,0};
+    int mem_rcnt[3] = {0,0,0};
+    int ind_rcnt[3] = {0,0,0};
 
     // Compression routine!
     for (int i=0; i<tot_tracks; i++) {
@@ -213,7 +213,7 @@ EGS_TrackView::EGS_TrackView(const char *filename) {
         }
     }
     // Sentinel at the end; get lengths
-    for (int i=0; i<4; i++) {
+    for (int i=0; i<3; i++) {
         m_index[i][ind_rcnt[i]] = mem_rcnt[i];
         m_tracks[i] = ind_rcnt[i];
     }
@@ -222,24 +222,24 @@ EGS_TrackView::EGS_TrackView(const char *filename) {
     delete[] tmp_buffer;
     // Resize everything to fit -- a second copy :-(.
     // But it decreases runtime memory, sometimes significantly
-    for (int i=0; i<4; i++) {
+    for (int i=0; i<3; i++) {
         m_index[i] = shrink(m_index[i], count_num[i]+1, ind_rcnt[i]+1);
         m_points[i] = shrink(m_points[i], count_vert[i], mem_rcnt[i]);
     }
 
-    int csze = ind_rcnt[0] + ind_rcnt[1] + ind_rcnt[2] + ind_rcnt[3];
-    int msze = mem_rcnt[0] + mem_rcnt[1] + mem_rcnt[2] + mem_rcnt[3];
+    int csze = ind_rcnt[0] + ind_rcnt[1] + ind_rcnt[2];
+    int msze = mem_rcnt[0] + mem_rcnt[1] + mem_rcnt[2];
 
     egsInformation("%s: Compressed size : %d\n", func_name,
                    sizeof(Vert)*msze + sizeof(void *)*csze);
-    egsInformation("%s: Tracks loaded   : %d (%d %d %d %d)\n", func_name,
-                   tot_tracks, count_num[0], count_num[1], count_num[2], count_num[3]);
+    egsInformation("%s: Tracks loaded   : %d (%d %d %d)\n", func_name,
+                   tot_tracks, count_num[0], count_num[1], count_num[2]);
     m_failed = false;
 }
 
 EGS_TrackView::~EGS_TrackView() {
     // cleanup allocations to avoid memory leaks
-    for (int i=0; i<4; i++) {
+    for (int i=0; i<3; i++) {
         if (m_index[i]) {
             delete[] m_index[i];
         }
@@ -303,13 +303,12 @@ bool EGS_TrackView::renderTracks(int nx, int ny, EGS_Vector *image,
         abort_location = (int *)&zero;
     }
 
-    for (int k=0; k<4; k++) {
+    for (int k=0; k<3; k++) {
         if (m_vis_particle[k]) {
             /* set the color of this particle
                  1.0 = photon = yellow
                  2.0 = electron = red
                  3.0 = positron = blue
-                 4.0 = unknown = white
             */
             EGS_Float color = (k+1);
 
@@ -389,7 +388,9 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             xxx1 = r1.x;
             yyy1 = r1.y;
             dst1 = (f1 - xo).length();
-            e1 = v1.e / m_maxE;
+            if(energyScaling) {
+                e1 = v1.e / m_maxE;
+            }
         }
         else {
             // The first point is in the legal zone; only need the values
@@ -411,14 +412,18 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             xxx1 = xxx2;
             yyy1 = yyy2;
             dst1 = dst2;
-            e1 = e2;
+            if(energyScaling) {
+                e1 = e2;
+            }
         }
         EGS_Vector f2 = v2.x - t2 * (v2.x - v1.x);
         screenpt r2 = projectToScreen(f2,nx,ny,fromWorld,xo);
         xxx2 = r2.x;
         yyy2 = r2.y;
         dst2 = (f2 - xo).length();
-        e2 = v2.e / m_maxE;
+        if(energyScaling) {
+            e2 = v2.e / m_maxE;
+        }
 
         if (xxx1 == xxx2 && yyy1 == yyy2) {
             continue;
@@ -446,9 +451,13 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
         double ddx = (xxx2 - xxx1);
         double ddy = (yyy2 - yyy1);
         double dd = (dst2 - dst1);
-        double de = (e2 - e1);
         double gd = dst1;
-        double ge = e1;
+        double de, ge;
+
+        if(energyScaling) {
+            de = (e2 - e1);
+            ge = e1;
+        }
 
         // iterate along the longer side
         if (abs(xxx2 - xxx1) > abs(yyy2 - yyy1)) {
@@ -457,31 +466,39 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             ddy = ddy / abs(ddx);
             int di = (xxx1 > xxx2) ? -1 : 1;
             dd = dd / abs(ddx);
-            de = de / abs(ddx);
+            if(energyScaling) {
+                de = de / abs(ddx);
+            }
 
             // for each x calculate the corresponding y
             for (int cx = xxx1; cx != xxx2; cx += di) {
                 // grab what's already in the image buffer at this location
                 EGS_Vector tmpv3 = image[cx + ((int)(cy))*nx];
-                if (tmpv3.z < 0) {                                      // there is already a track there
+                if (tmpv3.z < 0) { // there is already a track there
                     if (-gd > tmpv3.z) {
-                        tmpv3.z = -gd;    // current track is closer
+                        tmpv3.z = -gd; // current track is closer
                     }
                     if (color > tmpv3.x) {
-                        tmpv3.x = color;    // put "important" particles in front [warning: may teleport particles through a sheet of lesser particles]
+                        tmpv3.x = color; // put "important" particles in front [warning: may teleport particles through a sheet of lesser particles]
                     }
-                    tmpv3.y += (1-tmpv3.y)*e2;                          // compound transparency values
+                    if(energyScaling) {
+                        tmpv3.y += (1-tmpv3.y)*e2; // compound transparency values
+                    }
                 }
                 else {
                     tmpv3.x = color;
-                    tmpv3.y=e2;
-                    tmpv3.z=-gd;         // just update with current track info
+                    if(energyScaling) {
+                        tmpv3.y=e2;
+                    }
+                    tmpv3.z=-gd; // just update with current track info
                 }
                 // write new values to image buffer
                 image[cx + ((int)(cy))*nx] = tmpv3;
                 cy += ddy;
                 gd += dd;
-                ge += de;
+                if(energyScaling) {
+                    ge += de;
+                }
             }
         }
         else {
@@ -490,32 +507,40 @@ void EGS_TrackView::renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EG
             cx = xxx1;
             ddx = ddx / abs(ddy);
             dd = dd / abs(ddy);
-            de = de / abs(ddy);
+            if(energyScaling) {
+                de = de / abs(ddy);
+            }
 
             // for each y calculate the corresponding x
             for (int cy = yyy1; cy != yyy2; cy += di) {
                 // grab what's already in the image buffer at this location
                 EGS_Vector tmpv3 = image[(int)(cx) + cy*nx];
-                if (tmpv3.z < 0) {                                      // there is already a track there
+                if (tmpv3.z < 0) { // there is already a track there
                     if (-gd > tmpv3.z) {
-                        tmpv3.z = -gd;    // current track is closer
+                        tmpv3.z = -gd; // current track is closer
                     }
                     if (color > tmpv3.x) {
-                        tmpv3.x = color;    // put "important" particles in front
+                        tmpv3.x = color; // put "important" particles in front
                     }
-                    tmpv3.y += (1-tmpv3.y)*e2;                          // compound transparency values
+                    if(energyScaling) {
+                        tmpv3.y += (1-tmpv3.y)*e2; // compound transparency values
+                    }
                 }
                 else {
                     tmpv3.x = color;
-                    tmpv3.y=e2;
-                    tmpv3.z=-gd;         // just update with current track info
+                    if(energyScaling) {
+                        tmpv3.y=e2;
+                    }
+                    tmpv3.z=-gd; // just update with current track info
                 }
                 // write new values to image buffer
                 image[(int)(cx) + cy*nx] = tmpv3;
 
                 cx += ddx;
                 gd += dd;
-                ge += de;
+                if(energyScaling) {
+                    ge += de;
+                }
             }
         }
     }

--- a/HEN_HOUSE/egs++/view/egs_track_view.h
+++ b/HEN_HOUSE/egs++/view/egs_track_view.h
@@ -93,7 +93,7 @@ class EGS_TrackView {
 
 public:
 
-    EGS_TrackView(const char *filename);
+    EGS_TrackView(const char *filename, vector<size_t> &ntracks);
 
     ~EGS_TrackView();
 
@@ -119,6 +119,10 @@ public:
         return m_maxE;
     }
 
+    void setTrackIndices(const vector<size_t> &trackInd) {
+        trackIndices = trackInd;
+    }
+
 protected:
     void renderTrack(EGS_ParticleTrack::Vertex *const vs, int len, EGS_Float color, int nx, int ny, EGS_Vector *image);
 
@@ -138,7 +142,9 @@ protected:
 
     EGS_ParticleTrack::Vertex  *m_points[3]; // Data from file
     int        *m_index[3];       // Pointers to the starts of each track set
-    int         m_tracks[3];      // Number of tracks in each index
+    size_t      m_tracks[3];      // Number of tracks in each index
+
+    vector<size_t> trackIndices;
 
     EGS_ClippingPlane m_planes[14]; // Clipping planes. 0-3 are for the viewport
     int         nplanes;          // number of planes used

--- a/HEN_HOUSE/egs++/view/egs_track_view.h
+++ b/HEN_HOUSE/egs++/view/egs_track_view.h
@@ -105,10 +105,14 @@ public:
                        EGS_Vector pv2_screen, EGS_Float psx, EGS_Float psy);
 
     void setParticleVisibility(int p, bool vis) {
-        if (p < 1 || p > 4) {
+        if (p < 1 || p > 3) {
             return;
         }
         m_vis_particle[p-1] = vis;
+    }
+
+    void setEnergyScaling(bool scaling) {
+        energyScaling = scaling;
     }
 
     EGS_Float getMaxE() {
@@ -130,11 +134,11 @@ protected:
 
     EGS_Float   m_maxE;     // the maximum energy of all the particles
 
-    bool        m_vis_particle[4];  // Extra make indices 1-4 incl.
+    bool        m_vis_particle[3];  // Extra make indices 1-3 incl.
 
-    EGS_ParticleTrack::Vertex  *m_points[4]; // Data from file
-    int        *m_index[4];       // Pointers to the starts of each track set
-    int         m_tracks[4];      // Number of tracks in each index
+    EGS_ParticleTrack::Vertex  *m_points[3]; // Data from file
+    int        *m_index[3];       // Pointers to the starts of each track set
+    int         m_tracks[3];      // Number of tracks in each index
 
     EGS_ClippingPlane m_planes[14]; // Clipping planes. 0-3 are for the viewport
     int         nplanes;          // number of planes used
@@ -142,7 +146,8 @@ protected:
     EGS_Float   m_xmin,m_ymin,m_zmin, // Bounding box for particles
                 m_xmax,m_ymax,m_zmax;
 
-    bool        m_failed;   // Load error
+    bool        m_failed,
+                energyScaling;   // Load error
 };
 
 #endif

--- a/HEN_HOUSE/egs++/view/egs_visualizer.cpp
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.cpp
@@ -168,6 +168,8 @@ public:
     int          nclip, nclip_t;      // and their number
 
     EGS_TrackView   *m_tracks;
+    vector<bool>    showReg;
+    bool            allowRegionSelection;
 };
 
 EGS_GeometryVisualizer::EGS_GeometryVisualizer() {
@@ -226,6 +228,14 @@ void EGS_GeometryVisualizer::setMaterialColor(int imed,
 void EGS_GeometryVisualizer::setMaterialColor(int imed,
         const EGS_Vector &d_color, EGS_Float Alpha) {
     p->setMaterialColor(imed,d_color,Alpha);
+}
+
+void EGS_GeometryVisualizer::setShowRegions(vector<bool> show_regions) {
+    p->showReg = show_regions;
+}
+
+void EGS_GeometryVisualizer::setAllowRegionSelection(bool allow) {
+    p->allowRegionSelection = allow;
 }
 
 void EGS_GeometryVisualizer::addClippingPlane(EGS_ClippingPlane *plane) {
@@ -449,7 +459,11 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
                     if (imed >= 0) {
-                        a1 = mat[imed].alpha;;
+                        if(!allowRegionSelection || showReg[ireg]) {
+                            a1 = mat[imed].alpha;
+                        } else {
+                            a1 = 0.;
+                        }
                         c1 = global_ambient_light.getScaled(mat[imed].d);
                         EGS_Vector n = clip[j_clip]->getNormal();
                         for (int j=0; j<nlight; j++) {
@@ -490,7 +504,11 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         if (inew >= 0) {
             xs += u*t;
             if (imed >= 0) {
-                a1 = mat[imed].alpha;;
+                if(!allowRegionSelection || showReg[inew]) {
+                    a1 = mat[imed].alpha;
+                } else {
+                    a1 = 0.;
+                }
                 c1 = global_ambient_light.getScaled(mat[imed].d);
                 for (int j=0; j<nlight; j++) {
                     c1 += lights[j]->getColor(xs,n,mat[imed].d);
@@ -538,8 +556,12 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         xs += u*t;
 
         // new region is not outside, new material is not vacuum, and there is a change in material
-        if (inew >= 0 && imed_new >= 0 && imed_new != imed) {
-            a1 = mat[imed_new].alpha;
+        if (inew >= 0 && imed_new >= 0 && (imed_new != imed || (allowRegionSelection && !showReg[ireg]))) {
+            if(!allowRegionSelection || showReg[inew]) {
+                a1 = mat[imed_new].alpha;
+            } else {
+                a1 = 0.;
+            }
             c1 = global_ambient_light.getScaled(mat[imed_new].d);
             for (int j=0; j<nlight; j++) {
                 c1 += lights[j]->getColor(xs,n,mat[imed_new].d);

--- a/HEN_HOUSE/egs++/view/egs_visualizer.cpp
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.cpp
@@ -796,7 +796,7 @@ bool EGS_PrivateVisualizer::renderImage(EGS_BaseGeometry *g, int nx, int ny, EGS
             EGS_Float xx = -sx/2 + dx*(i+0.5);
             EGS_Vector xp(xy + v1_screen*xx);
 
-            EGS_Vector bCol(0,0,0);
+            EGS_Vector bCol = displayColors[2];
 
             ttrack = -1;
             if (image) {

--- a/HEN_HOUSE/egs++/view/egs_visualizer.cpp
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.cpp
@@ -166,7 +166,7 @@ public:
     }
 
     void setTrackIndices(const vector<size_t> &trackIndices) {
-        if(m_tracks) {
+        if (m_tracks) {
             m_tracks->setTrackIndices(trackIndices);
         }
     }
@@ -382,22 +382,23 @@ void EGS_PrivateVisualizer::getRegions(const EGS_Vector &x, EGS_BaseGeometry *g,
                 t -= tclip;
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
-                    if(imed < 0) {
+                    if (imed < 0) {
                         imed = g->nMedia();
                     }
                     if (imed >= 0) {
-                        if(!allowRegionSelection || showReg[ireg]) {
+                        if (!allowRegionSelection || showReg[ireg]) {
                             c = mat[imed].d*mat[imed].alpha;
-                            if(!gotHit) {
-                                if(score.count(ireg)) {
+                            if (!gotHit) {
+                                if (score.count(ireg)) {
                                     hitScore = score.at(ireg);
                                 }
-                                if(mat[imed].alpha > 0) {
+                                if (mat[imed].alpha > 0) {
                                     hitCoord = xs;
                                     gotHit = true;
                                 }
                             }
-                        } else {
+                        }
+                        else {
                             c = displayColors[0];
                         }
                     }
@@ -429,17 +430,17 @@ void EGS_PrivateVisualizer::getRegions(const EGS_Vector &x, EGS_BaseGeometry *g,
         if (ireg >= 0) {
             tleft -= t;
             xs += u*t;
-            if(imed < 0) {
+            if (imed < 0) {
                 imed = g->nMedia();
             }
             if (imed >= 0) {
-                if(!allowRegionSelection || showReg[ireg]) {
+                if (!allowRegionSelection || showReg[ireg]) {
                     c = mat[imed].d*mat[imed].alpha;
-                    if(!gotHit) {
-                        if(score.count(ireg)) {
+                    if (!gotHit) {
+                        if (score.count(ireg)) {
                             hitScore = score.at(ireg);
                         }
-                        if(mat[imed].alpha > 0) {
+                        if (mat[imed].alpha > 0) {
                             hitCoord = xs;
                             gotHit = true;
                         }
@@ -512,12 +513,12 @@ void EGS_PrivateVisualizer::getFirstHit(const EGS_Vector &x, EGS_BaseGeometry *g
                 t -= tclip;
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
-                    if(imed < 0) {
+                    if (imed < 0) {
                         imed = g->nMedia();
                     }
                     if (imed >= 0) {
-                        if(!allowRegionSelection || showReg[ireg]) {
-                            if(mat[imed].alpha > 0) {
+                        if (!allowRegionSelection || showReg[ireg]) {
+                            if (mat[imed].alpha > 0) {
                                 hitCoord = xs;
                                 return;
                             }
@@ -542,12 +543,12 @@ void EGS_PrivateVisualizer::getFirstHit(const EGS_Vector &x, EGS_BaseGeometry *g
         if (ireg >= 0) {
             tleft -= t;
             xs += u*t;
-            if(imed < 0) {
+            if (imed < 0) {
                 imed = g->nMedia();
             }
             if (imed >= 0) {
-                if(!allowRegionSelection || showReg[ireg]) {
-                    if(mat[imed].alpha > 0) {
+                if (!allowRegionSelection || showReg[ireg]) {
+                    if (mat[imed].alpha > 0) {
                         hitCoord = xs;
                         return;
                     }
@@ -645,13 +646,14 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
                 // ray hits a region
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
-                    if(imed < 0) {
+                    if (imed < 0) {
                         imed = g->nMedia();
                     }
                     if (imed >= 0) {
-                        if(!allowRegionSelection || showReg[ireg]) {
+                        if (!allowRegionSelection || showReg[ireg]) {
                             a1 = mat[imed].alpha;
-                        } else {
+                        }
+                        else {
                             a1 = 0.;
                         }
                         c1 = global_ambient_light.getScaled(mat[imed].d);
@@ -662,7 +664,7 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
                         c += c1*a1*a;
                         a = a*(1-a1);
 
-                        if(scoreColor.count(ireg) && doseTransparency) {
+                        if (scoreColor.count(ireg) && doseTransparency) {
                             c1 = global_ambient_light.getScaled(scoreColor[ireg]);
                             for (int j=0; j<nlight; j++) {
                                 c1 += lights[j]->getColor(xs,n,scoreColor[ireg]);
@@ -681,9 +683,10 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
             }
             else {
 
-                if(!hitSomething) {
+                if (!hitSomething) {
                     c = displayColors[0];
-                } else {
+                }
+                else {
                     c += displayColors[0]*a;
                 }
                 return c;
@@ -711,13 +714,14 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         // hitting a surface
         if (inew >= 0) {
             xs += u*t;
-            if(imed < 0) {
+            if (imed < 0) {
                 imed = g->nMedia();
             }
             if (imed >= 0) {
-                if(!allowRegionSelection || showReg[inew]) {
+                if (!allowRegionSelection || showReg[inew]) {
                     a1 = mat[imed].alpha;
-                } else {
+                }
+                else {
                     a1 = 0.;
                 }
                 c1 = global_ambient_light.getScaled(mat[imed].d);
@@ -727,7 +731,7 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
                 c += c1*a1*a;
                 a = a*(1-a1);
 
-                if(scoreColor.count(inew) && doseTransparency) {
+                if (scoreColor.count(inew) && doseTransparency) {
                     c1 = global_ambient_light.getScaled(scoreColor[inew]);
                     for (int j=0; j<nlight; j++) {
                         c1 += lights[j]->getColor(xs,n,scoreColor[inew]);
@@ -750,9 +754,10 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         }
     }
     if (ireg < 0) {
-        if(!hitSomething) {
+        if (!hitSomething) {
             c = displayColors[0];
-        } else {
+        }
+        else {
             c += displayColors[0]*a;
         }
         return c;
@@ -784,16 +789,17 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         EGS_Vector c1;
         xs += u*t;
 
-        if(imed_new < 0) {
+        if (imed_new < 0) {
             imed_new = g->nMedia();
         }
 
         // new region is not outside, new material is not vacuum, and either:
         // (1) there is a change in material, or (2) the region is hidden, or (3) there is a scored value in the region
-        if(inew >= 0 && imed_new >= 0 && (imed_new != imed || (allowRegionSelection && !showReg[ireg]) || (scoreColor.count(inew) && doseTransparency && (scoreColor[inew].x > 0 || scoreColor[inew].y > 0 || scoreColor[inew].z > 0)))) {
-            if(!allowRegionSelection || showReg[inew]) {
+        if (inew >= 0 && imed_new >= 0 && (imed_new != imed || (allowRegionSelection && !showReg[ireg]) || (scoreColor.count(inew) && doseTransparency && (scoreColor[inew].x > 0 || scoreColor[inew].y > 0 || scoreColor[inew].z > 0)))) {
+            if (!allowRegionSelection || showReg[inew]) {
                 a1 = mat[imed_new].alpha;
-            } else {
+            }
+            else {
                 a1 = 0.;
             }
             c1 = global_ambient_light.getScaled(mat[imed_new].d);
@@ -803,7 +809,7 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
             c += c1*a*a1;
             a = a*(1-a1);
 
-            if(scoreColor.count(inew) && doseTransparency) {
+            if (scoreColor.count(inew) && doseTransparency) {
                 c1 = global_ambient_light.getScaled(scoreColor[inew]);
                 for (int j=0; j<nlight; j++) {
                     c1 += lights[j]->getColor(xs,n,scoreColor[inew]);
@@ -832,9 +838,10 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         return c+(cTrack)*a;    // draw the axis if not hit before
     }
 
-    if(!hitSomething) {
+    if (!hitSomething) {
         c = displayColors[0];
-    } else {
+    }
+    else {
         c += displayColors[0]*a;
     }
 
@@ -876,7 +883,7 @@ bool EGS_PrivateVisualizer::renderImage(EGS_BaseGeometry *g, int nx, int ny, EGS
                     if (((image[idx].x > 0) || (image[idx].y > 0)) && m_tracks) {
 
                         // Set the transparency based on the energy of the particle
-                        if(energyScaling) {
+                        if (energyScaling) {
                             track_alpha = 0.2+0.8*image[idx].y;
                         }
 

--- a/HEN_HOUSE/egs++/view/egs_visualizer.cpp
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.cpp
@@ -352,8 +352,15 @@ void EGS_PrivateVisualizer::getRegions(const EGS_Vector &x, EGS_BaseGeometry *g,
                 t -= tclip;
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
+                    if(imed < 0) {
+                        imed = g->nMedia();
+                    }
                     if (imed >= 0) {
-                        c = mat[imed].d*mat[imed].alpha;
+                        if(!allowRegionSelection || showReg[ireg]) {
+                            c = mat[imed].d*mat[imed].alpha;
+                        } else {
+                            c = displayColors[0];
+                        }
                     }
                     // save region
                     regions[regcount]=ireg;
@@ -383,8 +390,13 @@ void EGS_PrivateVisualizer::getRegions(const EGS_Vector &x, EGS_BaseGeometry *g,
         if (ireg >= 0) {
             tleft -= t;
             xs += u*t;
+            if(imed < 0) {
+                imed = g->nMedia();
+            }
             if (imed >= 0) {
-                c = mat[imed].d*mat[imed].alpha;
+                if(!allowRegionSelection || showReg[ireg]) {
+                    c = mat[imed].d*mat[imed].alpha;
+                }
             }
             regions[regcount]=ireg;
             colors[regcount]=c;
@@ -486,6 +498,9 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
                 // ray hits a region
                 if (ireg >= 0) {
                     imed = g->medium(ireg);
+                    if(imed < 0) {
+                        imed = g->nMedia();
+                    }
                     if (imed >= 0) {
                         if(!allowRegionSelection || showReg[ireg]) {
                             a1 = mat[imed].alpha;
@@ -538,6 +553,9 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
         // hitting a surface
         if (inew >= 0) {
             xs += u*t;
+            if(imed < 0) {
+                imed = g->nMedia();
+            }
             if (imed >= 0) {
                 if(!allowRegionSelection || showReg[inew]) {
                     a1 = mat[imed].alpha;
@@ -596,6 +614,10 @@ EGS_Vector EGS_PrivateVisualizer::getColor(const EGS_Vector &x,
 
         EGS_Vector c1;
         xs += u*t;
+
+        if(imed_new < 0) {
+            imed_new = g->nMedia();
+        }
 
         // new region is not outside, new material is not vacuum, and there is a change in material
         if (inew >= 0 && imed_new >= 0 && (imed_new != imed || (allowRegionSelection && !showReg[ireg]))) {
@@ -661,8 +683,7 @@ bool EGS_PrivateVisualizer::renderImage(EGS_BaseGeometry *g, int nx, int ny, EGS
             EGS_Float xx = -sx/2 + dx*(i+0.5);
             EGS_Vector xp(xy + v1_screen*xx);
 
-            // Set the axis color
-            EGS_Vector bCol(displayColors[2].x,displayColors[2].y,displayColors[2].z);
+            EGS_Vector bCol(0,0,0);
 
             ttrack = -1;
             if (image) {
@@ -689,6 +710,10 @@ bool EGS_PrivateVisualizer::renderImage(EGS_BaseGeometry *g, int nx, int ny, EGS
                         // Positrons
                         if (image[idx].x == 3.0) {
                             bCol = displayColors[5];
+                        }
+                        // Axis
+                        if (image[idx].x == 100.0) {
+                            bCol = displayColors[2];
                         }
                     }
                     image[idx] = EGS_Vector(0,0,0);

--- a/HEN_HOUSE/egs++/view/egs_visualizer.cpp
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.cpp
@@ -42,11 +42,13 @@ public:
         nlight(0), ntot(0), nmat(0), nclip(0), nclip_t(0),
         m_tracks(NULL) {};
     ~EGS_PrivateVisualizer();
-    void loadTracksData(const char *fname) {
+    vector<size_t> loadTracksData(const char *fname) {
         if (m_tracks) {
             delete m_tracks;
         }
-        m_tracks = new EGS_TrackView(fname);
+        vector<size_t> ntracks;
+        m_tracks = new EGS_TrackView(fname, ntracks);
+        return ntracks;
     }
     void setProjection(const EGS_Vector &camera_pos,
                        const EGS_Vector &camera_look_at, EGS_Float distance,
@@ -163,6 +165,12 @@ public:
         }
     }
 
+    void setTrackIndices(const vector<size_t> &trackIndices) {
+        if(m_tracks) {
+            m_tracks->setTrackIndices(trackIndices);
+        }
+    }
+
     EGS_Vector  xo;         // camera position
     EGS_Vector  x_screen;   // center of projected image
     EGS_Vector  v1_screen,  // 2 perpendicular vectors on the screen
@@ -198,10 +206,12 @@ EGS_GeometryVisualizer::~EGS_GeometryVisualizer() {
     delete p;
 }
 
-void EGS_GeometryVisualizer::loadTracksData(const char *fname) {
+vector<size_t> EGS_GeometryVisualizer::loadTracksData(const char *fname) {
+    vector<size_t> ntracks;
     if (p) {
-        p->loadTracksData(fname);
+        ntracks = p->loadTracksData(fname);
     }
+    return ntracks;
 }
 
 void EGS_GeometryVisualizer::setProjection(const EGS_Vector &camera_pos,
@@ -270,6 +280,10 @@ void EGS_GeometryVisualizer::setScoreColors(const unordered_map<size_t, EGS_Vect
 
 void EGS_GeometryVisualizer::setDoseTransparency(EGS_Float doseTransparency) {
     p->doseTransparency = doseTransparency;
+}
+
+void EGS_GeometryVisualizer::setTrackIndices(const vector<size_t> &trackIndices) {
+    p->setTrackIndices(trackIndices);
 }
 
 void EGS_GeometryVisualizer::addClippingPlane(EGS_ClippingPlane *plane) {

--- a/HEN_HOUSE/egs++/view/egs_visualizer.h
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.h
@@ -37,6 +37,7 @@
 #include "stddef.h"
 #include <vector>
 #include <QColor>
+#include <unordered_map>
 
 class EGS_Light;
 class EGS_MaterialColor;
@@ -110,14 +111,16 @@ public:
     void setMaterialColor(int imed, const EGS_MaterialColor &Mat);
     void setMaterialColor(int imed, const EGS_Vector &d_color,
                           EGS_Float Alpha=1);
-    void setShowRegions(vector<bool> show_regions);
+    void setShowRegions(const vector<bool> &show_regions);
     void setAllowRegionSelection(bool allow);
+    void setScoreColors(const unordered_map<size_t, EGS_Vector> &scoreColor);
+    void setDoseTransparency(EGS_Float doseTransparency);
 
     //EGS_Vector *renderImage(EGS_BaseGeometry *, int xsize, int ysize);
     bool renderImage(EGS_BaseGeometry *, int nx, int ny, EGS_Vector *image, int *abort_location=NULL);
     bool renderTracks(int nx, int ny, EGS_Vector *image, int *abort_location=NULL);
     EGS_Vector getColor(const EGS_Vector &x, EGS_BaseGeometry *g, const EGS_Float axis_distance, const EGS_Float track_alpha);
-    void getRegions(const EGS_Vector &x, EGS_BaseGeometry *g, int *regions, EGS_Vector *colors, int maxreg, EGS_Vector &hitCoord);
+    void getRegions(const EGS_Vector &x, EGS_BaseGeometry *g, int *regions, EGS_Vector *colors, int maxreg, EGS_Vector &hitCoord, const unordered_map<size_t, EGS_Float> &score, EGS_Float &hitScore);
     void getFirstHit(const EGS_Vector &x, EGS_BaseGeometry *g, EGS_Vector &hitCoord);
 
     void setDisplayColors(const vector<EGS_Vector> &displayColors);

--- a/HEN_HOUSE/egs++/view/egs_visualizer.h
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.h
@@ -115,9 +115,10 @@ public:
 
     //EGS_Vector *renderImage(EGS_BaseGeometry *, int xsize, int ysize);
     bool renderImage(EGS_BaseGeometry *, int nx, int ny, EGS_Vector *image, int *abort_location=NULL);
-    bool renderTracks(EGS_BaseGeometry *, int nx, int ny, EGS_Vector *image, int *abort_location=NULL);
-    EGS_Vector getColor(const EGS_Vector &x, EGS_BaseGeometry *g, const EGS_Float axis_distance, const EGS_Float track_alpha, const bool track_clip);
-    void getRegions(const EGS_Vector &x, EGS_BaseGeometry *g, int *regions, EGS_Vector *colors, int maxreg);
+    bool renderTracks(int nx, int ny, EGS_Vector *image, int *abort_location=NULL);
+    EGS_Vector getColor(const EGS_Vector &x, EGS_BaseGeometry *g, const EGS_Float axis_distance, const EGS_Float track_alpha);
+    void getRegions(const EGS_Vector &x, EGS_BaseGeometry *g, int *regions, EGS_Vector *colors, int maxreg, EGS_Vector &hitCoord);
+    void getFirstHit(const EGS_Vector &x, EGS_BaseGeometry *g, EGS_Vector &hitCoord);
 
     void setDisplayColors(const vector<EGS_Vector> &displayColors);
     void setEnergyScaling(const bool &scaling);

--- a/HEN_HOUSE/egs++/view/egs_visualizer.h
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.h
@@ -36,6 +36,7 @@
 #include "egs_math.h"
 #include "stddef.h"
 #include <vector>
+#include <QColor>
 
 class EGS_Light;
 class EGS_MaterialColor;
@@ -118,6 +119,8 @@ public:
     EGS_Vector getColor(const EGS_Vector &x, EGS_BaseGeometry *g, const EGS_Float axis_distance, const EGS_Float track_alpha, const bool track_clip);
     void getRegions(const EGS_Vector &x, EGS_BaseGeometry *g, int *regions, EGS_Vector *colors, int maxreg);
 
+    void setDisplayColors(const vector<EGS_Vector> &displayColors);
+    void setEnergyScaling(const bool &scaling);
 
 
     // region picking

--- a/HEN_HOUSE/egs++/view/egs_visualizer.h
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.h
@@ -35,6 +35,7 @@
 #include "egs_vector.h"
 #include "egs_math.h"
 #include "stddef.h"
+#include <vector>
 
 class EGS_Light;
 class EGS_MaterialColor;
@@ -108,6 +109,8 @@ public:
     void setMaterialColor(int imed, const EGS_MaterialColor &Mat);
     void setMaterialColor(int imed, const EGS_Vector &d_color,
                           EGS_Float Alpha=1);
+    void setShowRegions(vector<bool> show_regions);
+    void setAllowRegionSelection(bool allow);
 
     //EGS_Vector *renderImage(EGS_BaseGeometry *, int xsize, int ysize);
     bool renderImage(EGS_BaseGeometry *, int nx, int ny, EGS_Vector *image, int *abort_location=NULL);

--- a/HEN_HOUSE/egs++/view/egs_visualizer.h
+++ b/HEN_HOUSE/egs++/view/egs_visualizer.h
@@ -88,7 +88,7 @@ public:
     EGS_GeometryVisualizer();
     ~EGS_GeometryVisualizer();
 
-    void loadTracksData(const char *fname);
+    vector<size_t> loadTracksData(const char *fname);
 
     void setProjection(const EGS_Vector &camera_pos,
                        const EGS_Vector &camera_look_at, EGS_Float distance,
@@ -115,6 +115,7 @@ public:
     void setAllowRegionSelection(bool allow);
     void setScoreColors(const unordered_map<size_t, EGS_Vector> &scoreColor);
     void setDoseTransparency(EGS_Float doseTransparency);
+    void setTrackIndices(const vector<size_t> &trackIndices);
 
     //EGS_Vector *renderImage(EGS_BaseGeometry *, int xsize, int ysize);
     bool renderImage(EGS_BaseGeometry *, int nx, int ny, EGS_Vector *image, int *abort_location=NULL);

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -102,6 +102,9 @@ ImageWindow::~ImageWindow() {
 }
 
 void ImageWindow::render(EGS_BaseGeometry *geo, bool transform) {
+    if(!geo) {
+        return;
+    }
     if (transform) {
         startTransformation();
     }
@@ -109,7 +112,7 @@ void ImageWindow::render(EGS_BaseGeometry *geo, bool transform) {
 }
 
 void ImageWindow::rerender(EGS_BaseGeometry *geo) {
-    if (!thread) {
+    if (!thread || !geo) {
         // Don't bother if the thread has been disabled.
         return;
     }

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -86,6 +86,7 @@ ImageWindow::ImageWindow(QWidget *parent, const char *name) :
     // register types so they can be transfered accross thread
     qRegisterMetaType<RenderParameters>("RenderParameters");
     qRegisterMetaType<RenderResults>("RenderResults");
+    qRegisterMetaType<vector<size_t>>("vector<size_t>");
 
     // Initialize render worker and put it in a thread
     restartWorker();
@@ -249,6 +250,7 @@ void ImageWindow::restartWorker() {
             worker, SLOT(render(EGS_BaseGeometry *,RenderParameters)));
     connect(this, SIGNAL(requestLoadTracks(QString)), worker, SLOT(loadTracks(QString)));
     connect(worker, SIGNAL(rendered(RenderResults,RenderParameters)), this, SLOT(drawResults(RenderResults,RenderParameters)));
+    connect(worker, SIGNAL(tracksLoaded(vector<size_t>)), this, SLOT(trackResults(vector<size_t>)));
     connect(worker, SIGNAL(aborted()), this, SLOT(handleAbort()));
     thread->start();
     renderState = WorkerIdle;
@@ -639,6 +641,10 @@ void ImageWindow::drawResults(RenderResults r, RenderParameters q) {
     applyParameters(vis, lastRequest);
 
     repaint();
+}
+
+void ImageWindow::trackResults(vector<size_t> ntracks) {
+    emit tracksLoaded(ntracks);
 }
 
 void ImageWindow::handleAbort() {

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -352,8 +352,11 @@ void ImageWindow::paintEvent(QPaintEvent *) {
 
         // The below code is very CPU-inefficient. Please optimize!
         if (regions[0]>=0) {
-            p.fillRect(coveredRegion,QColor(0,0,0));
-            p.setPen(QColor(255,255,255));
+            // Background for the region list
+            p.fillRect(coveredRegion,QColor((int)(255*q.displayColors[0].x), (int)(255*q.displayColors[0].y), (int)(255*q.displayColors[0].z)));
+            // Text color for the region list
+            p.setPen(QColor((int)(255*q.displayColors[1].x), (int)(255*q.displayColors[1].y), (int)(255*q.displayColors[1].z)));
+
             p.drawText(x0-1,y0,"Regions");
             y0+=10;
             regionsDisplayed=true;
@@ -411,7 +414,7 @@ void ImageWindow::paintEvent(QPaintEvent *) {
             p.fillRect(x0, y0+reg*dy, s, s,
                        QColor((int)(255*colors[reg].x), (int)(255*colors[reg].y),
                               (int)(255*colors[reg].z)));
-            p.setPen(QColor(255,255,255));
+            p.setPen(QColor((int)(255*q.displayColors[1].x), (int)(255*q.displayColors[1].y), (int)(255*q.displayColors[1].z)));
             p.drawRect(x0, y0+reg*dy, s, s);
             p.drawText(x0+s+3,y0+reg*dy+s,QString::number(regions[reg]));
             if (reg+1 == maxreg) {

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -103,7 +103,7 @@ ImageWindow::~ImageWindow() {
 }
 
 void ImageWindow::render(EGS_BaseGeometry *geo, bool transform) {
-    if(!geo) {
+    if (!geo) {
         return;
     }
     if (transform) {
@@ -394,9 +394,10 @@ void ImageWindow::paintEvent(QPaintEvent *) {
         // The below code is very CPU-inefficient. Please optimize!
         if (regions[0]>=0) {
             // Background for the region list
-            if(hitScore > 0.) {
+            if (hitScore > 0.) {
                 p.fillRect(QRect(0,0,79,h),QColor((int)(255*q.displayColors[0].x), (int)(255*q.displayColors[0].y), (int)(255*q.displayColors[0].z)));
-            } else {
+            }
+            else {
                 p.fillRect(QRect(0,0,64,h),QColor((int)(255*q.displayColors[0].x), (int)(255*q.displayColors[0].y), (int)(255*q.displayColors[0].z)));
             }
             // Text color for the region list
@@ -411,37 +412,40 @@ void ImageWindow::paintEvent(QPaintEvent *) {
             QString hity = QString::number(hitCoord.y);
             QString hitz = QString::number(hitCoord.z);
             QString score;
-            if(hitScore > 0.) {
+            if (hitScore > 0.) {
                 score = QString::number(hitScore);
             }
 
             // Determine the max number of digits to calculate the background fill
             int nChar = hitx.length();
-            if(hity.length() > nChar) {
+            if (hity.length() > nChar) {
                 nChar = hity.length();
-            } else if(hitz.length() > nChar) {
+            }
+            else if (hitz.length() > nChar) {
                 nChar = hitz.length();
-            } else if(hitScore > 0. && score.length() > nChar) {
+            }
+            else if (hitScore > 0. && score.length() > nChar) {
                 nChar = score.length();
             }
-            if(nChar > 4) {
+            if (nChar > 4) {
                 nChar -= 5;
             }
 
-            if(hitScore > 0.) {
+            if (hitScore > 0.) {
                 p.fillRect(QRect(79,h-79,nChar*10,79),QColor((int)(255*q.displayColors[0].x), (int)(255*q.displayColors[0].y), (int)(255*q.displayColors[0].z)));
                 p.drawText(9,h-79,"Surface");
                 p.drawText(9,h-60,hitx);
                 p.drawText(9,h-45,hity);
                 p.drawText(9,h-30,hitz);
 
-                if(q.scoreColor.count(regions[0])) {
+                if (q.scoreColor.count(regions[0])) {
                     EGS_Vector sc = q.scoreColor.at(regions[0]);
                     p.fillRect(x0, h-15-s, s, s, QColor((int)(255*sc.x),(int)(255*sc.y),(int)(255*sc.z)));
                 }
                 p.drawRect(x0, h-15-s, s, s);
                 p.drawText(x0+s+3,h-15,score);
-            } else {
+            }
+            else {
                 p.fillRect(QRect(64,h-64,nChar*10,64),QColor((int)(255*q.displayColors[0].x), (int)(255*q.displayColors[0].y), (int)(255*q.displayColors[0].z)));
                 p.drawText(9,h-64,"Surface");
                 p.drawText(9,h-45,hitx);

--- a/HEN_HOUSE/egs++/view/image_window.h
+++ b/HEN_HOUSE/egs++/view/image_window.h
@@ -47,7 +47,7 @@ class QThread;
 class QProgressDialog;
 
 // Maximum number of regions displayed
-#define N_REG_MAX 30
+#define N_REG_MAX 26
 
 class ImageWindow : public QWidget {
 
@@ -81,6 +81,7 @@ protected:
     void resizeEvent(QResizeEvent *e);
     void paintEvent(QPaintEvent *);
 
+    void mouseDoubleClickEvent(QMouseEvent *event);
     void mouseReleaseEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void wheelEvent(QWheelEvent *event);
@@ -102,6 +103,7 @@ signals:
     void cameraHomeDefining();
     void putCameraOnAxis(char axis);
     void leftMouseClick(int x, int y);
+    void leftDoubleClick(EGS_Vector hitCoord);
     void saveComplete();
 
     // for render thread

--- a/HEN_HOUSE/egs++/view/image_window.h
+++ b/HEN_HOUSE/egs++/view/image_window.h
@@ -90,6 +90,7 @@ protected:
 protected slots:
 
     void drawResults(RenderResults,RenderParameters);
+    void trackResults(vector<size_t>);
     void handleAbort();
 
 signals:
@@ -105,6 +106,7 @@ signals:
     void leftMouseClick(int x, int y);
     void leftDoubleClick(EGS_Vector hitCoord);
     void saveComplete();
+    void tracksLoaded(vector<size_t>);
 
     // for render thread
     void requestRender(EGS_BaseGeometry *,RenderParameters);

--- a/HEN_HOUSE/egs++/view/image_window.h
+++ b/HEN_HOUSE/egs++/view/image_window.h
@@ -47,7 +47,7 @@ class QThread;
 class QProgressDialog;
 
 // Maximum number of regions displayed
-#define N_REG_MAX 26
+#define N_REG_MAX 100
 
 class ImageWindow : public QWidget {
 

--- a/HEN_HOUSE/egs++/view/main.cpp
+++ b/HEN_HOUSE/egs++/view/main.cpp
@@ -86,7 +86,6 @@ int main(int argc, char **argv) {
     QApplication a(argc, argv);
     QString input_file = argc >= 2 ? QString(argv[1]) :
                          QFileDialog::getOpenFileName(NULL,"Select geometry definition file");
-    QString tracks_file = argc >= 3 ? argv[2] : "";
 
 #ifdef VDEBUG
     debug_output << "Using " << input_file.toLatin1().data() << "\n";
@@ -98,10 +97,31 @@ int main(int argc, char **argv) {
     GeometryViewControl w;
     w.show();
     w.setFilename(input_file);
+
+    QString tracks_file = QString("");
+    QString config_file = QString("");
+    if(argc >= 3) {
+        QString argv2 = argv[2];
+        if(argv2.endsWith("ptracks")) {
+            tracks_file = argv2;
+        } else {
+            config_file = argv2;
+        }
+    }
+    if(argc >= 4) {
+        QString argv3 = argv[3];
+        if(argv3.endsWith("ptracks")) {
+            tracks_file = argv3;
+        } else {
+            config_file = argv3;
+        }
+    }
+
     w.setTracksFilename(tracks_file);
     if (!w.loadInput(false)) {
         return 1;
     }
+    w.loadConfig(config_file);
 
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
 

--- a/HEN_HOUSE/egs++/view/main.cpp
+++ b/HEN_HOUSE/egs++/view/main.cpp
@@ -124,9 +124,11 @@ int main(int argc, char **argv) {
     w.loadConfig(config_file);
 
     // Request a monospace font from the OS
+#if QT_VERSION >= 0x040700
     QFont new_font = a.font();
     new_font.setStyleHint(QFont::Monospace);
     a.setFont( new_font );
+#endif
 
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
 

--- a/HEN_HOUSE/egs++/view/main.cpp
+++ b/HEN_HOUSE/egs++/view/main.cpp
@@ -123,6 +123,11 @@ int main(int argc, char **argv) {
     }
     w.loadConfig(config_file);
 
+    // Request a monospace font from the OS
+    QFont new_font = a.font();
+    new_font.setStyleHint(QFont::Monospace);
+    a.setFont( new_font );
+
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));
 
     return a.exec();

--- a/HEN_HOUSE/egs++/view/main.cpp
+++ b/HEN_HOUSE/egs++/view/main.cpp
@@ -100,19 +100,21 @@ int main(int argc, char **argv) {
 
     QString tracks_file = QString("");
     QString config_file = QString("");
-    if(argc >= 3) {
+    if (argc >= 3) {
         QString argv2 = argv[2];
-        if(argv2.endsWith("ptracks")) {
+        if (argv2.endsWith("ptracks")) {
             tracks_file = argv2;
-        } else {
+        }
+        else {
             config_file = argv2;
         }
     }
-    if(argc >= 4) {
+    if (argc >= 4) {
         QString argv3 = argv[3];
-        if(argv3.endsWith("ptracks")) {
+        if (argv3.endsWith("ptracks")) {
             tracks_file = argv3;
-        } else {
+        }
+        else {
             config_file = argv3;
         }
     }
@@ -127,7 +129,7 @@ int main(int argc, char **argv) {
 #if QT_VERSION >= 0x040700
     QFont new_font = a.font();
     new_font.setStyleHint(QFont::Monospace);
-    a.setFont( new_font );
+    a.setFont(new_font);
 #endif
 
     a.connect(&a, SIGNAL(lastWindowClosed()), &a, SLOT(quit()));

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -208,6 +208,8 @@ void applyParameters(EGS_GeometryVisualizer *vis, const struct RenderParameters 
         vis->setMaterialColor(i,p.material_colors[i]);
     }
     vis->setGlobalAmbientLight(p.global_ambient_light);
+    vis->setShowRegions(p.show_regions);
+    vis->setAllowRegionSelection(p.allowRegionSelection);
 }
 
 void RenderWorker::render(EGS_BaseGeometry *g, struct RenderParameters p) {

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -212,6 +212,8 @@ void applyParameters(EGS_GeometryVisualizer *vis, const struct RenderParameters 
     vis->setAllowRegionSelection(p.allowRegionSelection);
     vis->setDisplayColors(p.displayColors);
     vis->setEnergyScaling(p.energyScaling);
+    vis->setScoreColors(p.scoreColor);
+    vis->setDoseTransparency(p.doseTransparency);
 }
 
 void RenderWorker::render(EGS_BaseGeometry *g, struct RenderParameters p) {

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -259,7 +259,7 @@ struct RenderResults RenderWorker::renderSync(EGS_BaseGeometry *g, struct Render
         vis->setParticleVisibility(1,p.show_photons);
         vis->setParticleVisibility(2,p.show_electrons);
         vis->setParticleVisibility(3,p.show_positrons);
-        if (!vis->renderTracks(g,p.nx,p.ny,image,&abort_location)) {
+        if (!vis->renderTracks(p.nx,p.ny,image,&abort_location)) {
             // Undo track drawing and rezero image
             memset(image, 0, sizeof(EGS_Vector));
             return r;

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -210,6 +210,8 @@ void applyParameters(EGS_GeometryVisualizer *vis, const struct RenderParameters 
     vis->setGlobalAmbientLight(p.global_ambient_light);
     vis->setShowRegions(p.show_regions);
     vis->setAllowRegionSelection(p.allowRegionSelection);
+    vis->setDisplayColors(p.displayColors);
+    vis->setEnergyScaling(p.energyScaling);
 }
 
 void RenderWorker::render(EGS_BaseGeometry *g, struct RenderParameters p) {
@@ -257,7 +259,6 @@ struct RenderResults RenderWorker::renderSync(EGS_BaseGeometry *g, struct Render
         vis->setParticleVisibility(1,p.show_photons);
         vis->setParticleVisibility(2,p.show_electrons);
         vis->setParticleVisibility(3,p.show_positrons);
-        vis->setParticleVisibility(4,p.show_other);
         if (!vis->renderTracks(g,p.nx,p.ny,image,&abort_location)) {
             // Undo track drawing and rezero image
             memset(image, 0, sizeof(EGS_Vector));
@@ -320,7 +321,7 @@ struct RenderResults RenderWorker::renderSync(EGS_BaseGeometry *g, struct Render
     {
         QPainter q(&img);
         if (p.draw_axeslabels) {
-            q.setPen(QColor(255,255,255));
+            q.setPen(QColor((int)(255*p.displayColors[1].x), (int)(255*p.displayColors[1].y), (int)(255*p.displayColors[1].z)));
             q.drawText((int)(p.nxr*axeslabelsX.x-3),p.nyr*p.ny-(int)(p.nyr*axeslabelsX.y-3),"x");
             q.drawText((int)(p.nxr*axeslabelsY.x-3),p.nyr*p.ny-(int)(p.nyr*axeslabelsY.y-3),"y");
             q.drawText((int)(p.nxr*axeslabelsZ.x-3),p.nyr*p.ny-(int)(p.nyr*axeslabelsZ.y-3),"z");

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -52,7 +52,8 @@ RenderWorker::~RenderWorker() {
 }
 
 void RenderWorker::loadTracks(QString fileName) {
-    vis->loadTracksData(fileName.toUtf8().constData());
+    vector<size_t> ntracks = vis->loadTracksData(fileName.toUtf8().constData());
+    emit tracksLoaded(ntracks);
 }
 
 void RenderWorker::drawAxes(const RenderParameters &p) {
@@ -258,6 +259,7 @@ struct RenderResults RenderWorker::renderSync(EGS_BaseGeometry *g, struct Render
 
     // render tracks
     if (p.draw_tracks) {
+        vis->setTrackIndices(p.trackIndices);
         vis->setParticleVisibility(1,p.show_photons);
         vis->setParticleVisibility(2,p.show_electrons);
         vis->setParticleVisibility(3,p.show_positrons);

--- a/HEN_HOUSE/egs++/view/renderworker.h
+++ b/HEN_HOUSE/egs++/view/renderworker.h
@@ -74,6 +74,7 @@ struct RenderParameters {
     bool show_photons;
     bool show_electrons;
     bool show_positrons;
+    vector<size_t> trackIndices;
     // viewport
     EGS_Vector camera;
     EGS_Vector camera_v1;
@@ -134,6 +135,7 @@ signals:
 
     void aborted();
     void rendered(struct RenderResults, struct RenderParameters params);
+    void tracksLoaded(vector<size_t> ntracks);
 
 private:
     void drawAxes(const struct RenderParameters &);

--- a/HEN_HOUSE/egs++/view/renderworker.h
+++ b/HEN_HOUSE/egs++/view/renderworker.h
@@ -58,6 +58,14 @@ struct RenderParameters {
     vector<bool> show_regions;
     // Whether or not to allow show_regions to be used
     bool allowRegionSelection;
+    // Transparency of dose
+    EGS_Float doseTransparency;
+
+    // Unordered map is much more efficient when there is not
+    // dose in every region
+    unordered_map<size_t, EGS_Float> score;
+    unordered_map<size_t, EGS_Vector> scoreColor;
+
     // lights
     vector<EGS_Light> lights;
     EGS_Vector global_ambient_light;

--- a/HEN_HOUSE/egs++/view/renderworker.h
+++ b/HEN_HOUSE/egs++/view/renderworker.h
@@ -52,8 +52,12 @@ struct RenderParameters {
     int nyr;
     // Clipping planes
     vector<EGS_ClippingPlane> clipping_planes;
-    // material colors
+    // Material colors
     vector<EGS_MaterialColor> material_colors;
+    // Regions to show/hide
+    vector<bool> show_regions;
+    // Whether or not to allow show_regions to be used
+    bool allowRegionSelection;
     // lights
     vector<EGS_Light> lights;
     EGS_Vector global_ambient_light;

--- a/HEN_HOUSE/egs++/view/renderworker.h
+++ b/HEN_HOUSE/egs++/view/renderworker.h
@@ -66,7 +66,6 @@ struct RenderParameters {
     bool show_photons;
     bool show_electrons;
     bool show_positrons;
-    bool show_other;
     // viewport
     EGS_Vector camera;
     EGS_Vector camera_v1;
@@ -82,6 +81,16 @@ struct RenderParameters {
     EGS_Float size;
     // Purpose of request
     RenderRequestType requestType;
+
+    // Various display colors
+    // 0 - background
+    // 1 - text
+    // 2 - axis
+    // 3 - photons
+    // 4 - electrons
+    // 5 - positrons
+    vector<EGS_Vector> displayColors;
+    bool energyScaling;
 };
 
 struct RenderResults {

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -93,6 +93,7 @@ unix {
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"
 
+QMAKE_CXXFLAGS+=-std=c++11
 UI_DIR = .ui/$$my_machine
 MOC_DIR = .moc/$$my_machine
 OBJECTS_DIR = .obj/$$my_machine

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -122,7 +122,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     showPhotonTracks = this->showPhotonsCheckbox->isChecked();
     showElectronTracks = this->showElectronsCheckbox->isChecked();
     showPositronTracks = this->showPositronsCheckbox->isChecked();
-    if(showPhotonTracks || showElectronTracks || showPositronTracks) {
+    if (showPhotonTracks || showElectronTracks || showPositronTracks) {
         showTracks = true;
     }
 
@@ -184,13 +184,13 @@ GeometryViewControl::~GeometryViewControl() {
         delete [] m_colors;
     }
     g = origSimGeom;
-    if(g) {
+    if (g) {
         delete g;
         g = 0;
     }
     EGS_BaseGeometry::clearGeometries();
     int nobj = EGS_AusgabObject::nObjects();
-    for(int j=0; j<3; ++j) {
+    for (int j=0; j<3; ++j) {
         for (int i=0; i<nobj; ++i) {
             delete EGS_AusgabObject::getObject(i);
         }
@@ -218,9 +218,9 @@ void GeometryViewControl::selectInput() {
 }
 
 bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
-    #ifdef VIEW_DEBUG
-        egsWarning("In loadInput(), reloading is %d\n",reloading);
-    #endif
+#ifdef VIEW_DEBUG
+    egsWarning("In loadInput(), reloading is %d\n",reloading);
+#endif
 
     // check that the file (still) exists
     QFile file(filename);
@@ -240,11 +240,11 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     qApp->processEvents();
 
     // Delete any previous geometry
-    if(!simGeom) {
+    if (!simGeom) {
 #ifdef VIEW_DEBUG
         egsInformation("GeometryViewControl::loadInput: Clearing previous geometries...\n");
 #endif
-        if(g) {
+        if (g) {
             delete g;
             g = 0;
         }
@@ -255,7 +255,7 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
         egsInformation("GeometryViewControl::loadInput: Clearing previous ausgab objects...\n");
 #endif
         int nobj = EGS_AusgabObject::nObjects();
-        for(int j=0; j<3; ++j) {
+        for (int j=0; j<3; ++j) {
             for (int i=0; i<nobj; ++i) {
                 delete EGS_AusgabObject::getObject(i);
             }
@@ -274,15 +274,16 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     egsInformation("GeometryViewControl::loadInput: Creating the geometry...\n");
 #endif
     EGS_BaseGeometry *newGeom;
-    if(!simGeom) {
+    if (!simGeom) {
         newGeom = EGS_BaseGeometry::createGeometry(&input);
         if (!newGeom) {
             QMessageBox::critical(this,"Geometry error",
-                    "The geometry is not correctly defined. Edit the input file and reload.",QMessageBox::Ok,0,0);
+                                  "The geometry is not correctly defined. Edit the input file and reload.",QMessageBox::Ok,0,0);
 
             return false;
         }
-    } else {
+    }
+    else {
         newGeom = simGeom;
     }
 
@@ -340,10 +341,11 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
 
     // Only allow region selection for up to 1k regions
     int nreg = newGeom->regions();
-    if(nreg < 1001) {
+    if (nreg < 1001) {
         allowRegionSelection = true;
         show_regions.resize(nreg,true);
-    } else {
+    }
+    else {
         allowRegionSelection = false;
         show_regions.resize(0);
         egsInformation("Region selection tab has been disabled due to >1000 regions (for performance reasons)\n");
@@ -358,11 +360,11 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     gview->restartWorker();
     setGeometry(newGeom,user_colors,xmin,xmax,ymin,ymax,zmin,zmax,reloading);
 
-    if(!simGeom) {
-       origSimGeom = g;
+    if (!simGeom) {
+        origSimGeom = g;
     }
 
-    if(allowRegionSelection) {
+    if (allowRegionSelection) {
         updateRegionTable();
     }
 
@@ -370,13 +372,13 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     comboBox_simGeom->clear();
     EGS_BaseGeometry **geoms = g->getGeometries();
     int ngeom = g->getNGeometries();
-    for(int i=0; i<ngeom; ++i) {
+    for (int i=0; i<ngeom; ++i) {
         comboBox_simGeom->addItem((geoms[i]->getName() + " (" + geoms[i]->getType() + ")").c_str(), geoms[i]->getName().c_str());
     }
     comboBox_simGeom->setCurrentIndex(comboBox_simGeom->findData(g->getName().c_str()));
 
     // Load ausgab objects from the input file
-    if(!simGeom) {
+    if (!simGeom) {
 #ifdef VIEW_DEBUG
         egsInformation("GeometryViewControl::loadInput: Processing ausgab objects...\n");
 #endif
@@ -400,11 +402,13 @@ EGS_Vector GeometryViewControl::getHeatMapColor(EGS_Float value) {
     unsigned int idx2;
     EGS_Float fractBetween = 0;
 
-    if(value <= 0) {
+    if (value <= 0) {
         idx1 = idx2 = 0;
-    } else if(value >= 1) {
+    }
+    else if (value >= 1) {
         idx1 = idx2 = NUM_COLORS-1;
-    } else {
+    }
+    else {
         value = value * (NUM_COLORS-1);
         idx1  = floor(value);
         idx2  = idx1+1;
@@ -421,7 +425,7 @@ EGS_Vector GeometryViewControl::getHeatMapColor(EGS_Float value) {
 
 void GeometryViewControl::reloadInput() {
     g = origSimGeom;
-    if(!loadInput(true)) {
+    if (!loadInput(true)) {
         egsWarning("GeometryViewControl::reloadInput: Error: The geometry is not correctly defined\n");
     }
 }
@@ -439,7 +443,7 @@ void GeometryViewControl::saveConfig() {
     // Prompt the user for a filename and open the file for writing
     QString configFilename = QFileDialog::getSaveFileName(this, "Save config file as...", defaultFilename, "*.egsview");
     QFile configFile(configFilename);
-    if(!configFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+    if (!configFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
         return;
     }
     QTextStream out(&configFile);
@@ -458,33 +462,33 @@ void GeometryViewControl::saveConfig() {
 
     out << ":start camera view:" << endl;
     out << "    rotation point = " << lookX->text() << " "
-            << lookY->text() << " "
-            << lookZ->text() << endl;
+        << lookY->text() << " "
+        << lookZ->text() << endl;
     out << "    camera = " << camera.x << " "
-            << camera.y << " "
-            << camera.z << endl;
+        << camera.y << " "
+        << camera.z << endl;
     out << "    camera v1 = " << camera_v1.x << " "
-            << camera_v1.y << " "
-            << camera_v1.z << endl;
+        << camera_v1.y << " "
+        << camera_v1.z << endl;
     out << "    camera v2 = " << camera_v2.x << " "
-            << camera_v2.y << " "
-            << camera_v2.z << endl;
+        << camera_v2.y << " "
+        << camera_v2.z << endl;
     out << "    zoom = " << zoomlevel << endl;
     out << ":stop camera view:" << endl;
 
     out << ":start home view:" << endl;
     out << "    home position = " << look_at_home.x << " "
-            << look_at_home.y << " "
-            << look_at_home.z << endl;
+        << look_at_home.y << " "
+        << look_at_home.z << endl;
     out << "    home = " << camera_home.x << " "
-            << camera_home.y << " "
-            << camera_home.z << endl;
+        << camera_home.y << " "
+        << camera_home.z << endl;
     out << "    home v1 = " << camera_home_v1.x << " "
-            << camera_home_v1.y << " "
-            << camera_home_v1.z << endl;
+        << camera_home_v1.y << " "
+        << camera_home_v1.z << endl;
     out << "    home v2 = " << camera_home_v2.x << " "
-            << camera_home_v2.y << " "
-            << camera_home_v2.z << endl;
+        << camera_home_v2.y << " "
+        << camera_home_v2.z << endl;
     out << "    zoom = " << zoomlevel_home << endl;
     out << ":stop home view:" << endl;
 
@@ -505,18 +509,19 @@ void GeometryViewControl::saveConfig() {
     out << "    alpha = " << slider_dose->value() << endl;
     out << ":stop dose:" << endl;
 
-    if(rp.material_colors.size() > 0) {
+    if (rp.material_colors.size() > 0) {
         out << ":start material colors:" << endl;
         for (size_t i=0; i<rp.material_colors.size(); ++i) {
             out << "    :start material:" << endl;
-            if(i==size_t(nmed)) {
+            if (i==size_t(nmed)) {
                 out << "        material = vacuum" << endl;
-            } else {
+            }
+            else {
                 out << "        material = " << g->getMediumName(i) << endl;
             }
             out << "        rgb = " << qRed(m_colors[i]) << " "
-                            << qGreen(m_colors[i]) << " "
-                            << qBlue(m_colors[i]) << endl;
+                << qGreen(m_colors[i]) << " "
+                << qBlue(m_colors[i]) << endl;
             out << "        alpha = " << qAlpha(m_colors[i]) << endl;
             out << "    :stop material:" << endl;
         }
@@ -526,25 +531,25 @@ void GeometryViewControl::saveConfig() {
     out << ":start clipping planes:" << endl;
     for (int i=0; i<cplanes->numPlanes(); i++) {
         QTableWidgetItem *itemAx = cplanes->getItem(i,0),
-                     *itemAy = cplanes->getItem(i,1),
-                     *itemAz = cplanes->getItem(i,2),
-                     *itemD = cplanes->getItem(i,3),
-                     *itemApplied = cplanes->getItem(i,4);
+                          *itemAy = cplanes->getItem(i,1),
+                           *itemAz = cplanes->getItem(i,2),
+                            *itemD = cplanes->getItem(i,3),
+                             *itemApplied = cplanes->getItem(i,4);
 
         out << "    :start plane:" << endl;
-        if(itemAx) {
+        if (itemAx) {
             out << "        ax = " << itemAx->text() << endl;
         }
-        if(itemAy) {
+        if (itemAy) {
             out << "        ay = " << itemAy->text() << endl;
         }
-        if(itemAz) {
+        if (itemAz) {
             out << "        az = " << itemAz->text() << endl;
         }
-        if(itemD) {
+        if (itemD) {
             out << "        d = " << itemD->text() << endl;
         }
-        if(itemApplied) {
+        if (itemApplied) {
             out << "        applied = " << itemApplied->checkState() << endl;
         }
         out << "    :stop plane:" << endl;
@@ -553,11 +558,11 @@ void GeometryViewControl::saveConfig() {
 
     out << ":start hidden regions:" << endl;
     out << "    region list =";
-    for(size_t i = 0; i < show_regions.size(); ++i) {
+    for (size_t i = 0; i < show_regions.size(); ++i) {
         // List all the unchecked regions
-        if(!show_regions[i]) {
+        if (!show_regions[i]) {
             QTableWidgetItem *itemRegion = regionTable->item(i,0);
-            if(itemRegion) {
+            if (itemRegion) {
                 out << " " << itemRegion->text();
             }
         }
@@ -567,23 +572,23 @@ void GeometryViewControl::saveConfig() {
 
     out << ":start colors:" << endl;
     out << "    background = " << backgroundColor.red() << " " <<
-            backgroundColor.green() << " " <<
-            backgroundColor.blue() << endl;
+        backgroundColor.green() << " " <<
+        backgroundColor.blue() << endl;
     out << "    text = " << textColor.red() << " " <<
-            textColor.green() << " " <<
-            textColor.blue() << endl;
+        textColor.green() << " " <<
+        textColor.blue() << endl;
     out << "    axis = " << axisColor.red() << " " <<
-            axisColor.green() << " " <<
-            axisColor.blue() << endl;
+        axisColor.green() << " " <<
+        axisColor.blue() << endl;
     out << "    photons = " << photonColor.red() << " " <<
-            photonColor.green() << " " <<
-            photonColor.blue() << endl;
+        photonColor.green() << " " <<
+        photonColor.blue() << endl;
     out << "    electrons = " << electronColor.red() << " " <<
-            electronColor.green() << " " <<
-            electronColor.blue() << endl;
+        electronColor.green() << " " <<
+        electronColor.blue() << endl;
     out << "    positrons = " << positronColor.red() << " " <<
-            positronColor.green() << " " <<
-            positronColor.blue() << endl;
+        positronColor.green() << " " <<
+        positronColor.blue() << endl;
     out << "    energy scaling = " << energyScaling << endl;
     out << ":stop colors:" << endl;
 }
@@ -608,7 +613,7 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     if (configFilename.size() > 0) {
         if (input->setContentFromFile(configFilename.toLatin1().data())) {
             QMessageBox::critical(this,"Config file read error",
-                "Failed to open the config file for reading.",QMessageBox::Ok,0,0);
+                                  "Failed to open the config file for reading.",QMessageBox::Ok,0,0);
             delete input;
             return;
         }
@@ -617,32 +622,32 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     int err; // A variable to track errors
 
     EGS_Input *iGeneral = input->takeInputItem("general");
-    if(iGeneral) {
+    if (iGeneral) {
         int fontSize;
         err = iGeneral->getInput("font size",fontSize);
-        if(!err) {
+        if (!err) {
             setFontSize(fontSize);
         }
 
         vector<int> position;
         err = iGeneral->getInput("controls position",position);
-        if(!err && position.size() == 2) {
+        if (!err && position.size() == 2) {
             this->move(position[0], position[1]);
         }
 
         vector<int> windowSize;
         err = iGeneral->getInput("controls size",windowSize);
-        if(!err && windowSize.size() == 2) {
+        if (!err && windowSize.size() == 2) {
             this->resize(windowSize[0], windowSize[1]);
         }
 
         err = iGeneral->getInput("view position",position);
-        if(!err && position.size() == 2) {
+        if (!err && position.size() == 2) {
             gview->move(position[0], position[1]);
         }
 
         err = iGeneral->getInput("view size",windowSize);
-        if(!err && windowSize.size() == 2) {
+        if (!err && windowSize.size() == 2) {
             gview->resize(windowSize[0], windowSize[1]);
         }
 
@@ -651,7 +656,7 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the image size
     EGS_Input *iImageSize = input->takeInputItem("image size");
-    if(iImageSize) {
+    if (iImageSize) {
         err = iImageSize->getInput("nx",rp.nx);
         err = iImageSize->getInput("ny",rp.ny);
 
@@ -662,36 +667,39 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the particle track options
     EGS_Input *iTracks = input->takeInputItem("tracks");
-    if(iTracks) {
+    if (iTracks) {
         int show;
         err = iTracks->getInput("show tracks",show);
-        if(!err) {
+        if (!err) {
             showTracks = show;
         }
 
         err = iTracks->getInput("photons",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showPhotonsCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showPhotonsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
 
         err = iTracks->getInput("electrons",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showElectronsCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showElectronsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
 
         err = iTracks->getInput("positrons",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showPositronsCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showPositronsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
@@ -701,31 +709,34 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the overlay options
     EGS_Input *iOverlay = input->takeInputItem("overlay");
-    if(iOverlay) {
+    if (iOverlay) {
         int show;
         err = iOverlay->getInput("show axis",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showAxesCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showAxesCheckbox->setCheckState(Qt::Unchecked);
             }
         }
 
         err = iOverlay->getInput("show axis labels",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showAxesLabelsCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showAxesLabelsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
 
         err = iOverlay->getInput("show regions",show);
-        if(!err) {
-            if(show) {
+        if (!err) {
+            if (show) {
                 showRegionsCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 showRegionsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
@@ -734,11 +745,11 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load camera view
     EGS_Input *iView = input->takeInputItem("camera view");
-    if(iView) {
+    if (iView) {
         // Get the rotation point
         vector<EGS_Float> look;
         err = iView->getInput("rotation point",look);
-        if(!err) {
+        if (!err) {
             look_at.x = look[0];
             look_at.y = look[1];
             look_at.z = look[2];
@@ -751,11 +762,11 @@ void GeometryViewControl::loadConfig(QString configFilename) {
         // Get the camera orientation
         vector<EGS_Float> cam, camv1, camv2;
         err = iView->getInput("camera",cam);
-        if(!err) {
+        if (!err) {
             err = iView->getInput("camera v1",camv1);
-            if(!err) {
+            if (!err) {
                 err = iView->getInput("camera v2",camv2);
-                if(!err) {
+                if (!err) {
                     camera = EGS_Vector(cam[0],cam[1],cam[2]);
                     camera_v1 = EGS_Vector(camv1[0],camv1[1],camv1[2]);
                     camera_v2 = EGS_Vector(camv2[0],camv2[1],camv2[2]);
@@ -774,11 +785,11 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load home view
     EGS_Input *iHome = input->takeInputItem("home view");
-    if(iHome) {
+    if (iHome) {
         // Get the home position
         vector<EGS_Float> look;
         err = iHome->getInput("home position",look);
-        if(!err) {
+        if (!err) {
             look_at_home.x = look[0];
             look_at_home.y = look[1];
             look_at_home.z = look[2];
@@ -787,11 +798,11 @@ void GeometryViewControl::loadConfig(QString configFilename) {
         // Get the home orientation
         vector<EGS_Float> cam, camv1, camv2;
         err = iHome->getInput("home",cam);
-        if(!err) {
+        if (!err) {
             err = iHome->getInput("home v1",camv1);
-            if(!err) {
+            if (!err) {
                 err = iHome->getInput("home v2",camv2);
-                if(!err) {
+                if (!err) {
                     camera_home = EGS_Vector(cam[0],cam[1],cam[2]);
                     camera_home_v1 = EGS_Vector(camv1[0],camv1[1],camv1[2]);
                     camera_home_v2 = EGS_Vector(camv2[0],camv2[1],camv2[2]);
@@ -805,15 +816,15 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the media colors
     EGS_Input *iMatColors = input->takeInputItem("material colors");
-    if(iMatColors) {
-        while(1) {
+    if (iMatColors) {
+        while (1) {
             EGS_Input *iMatList = iMatColors->getInputItem("material");
-            if(!iMatList) {
+            if (!iMatList) {
                 break;
             }
 
             EGS_Input *iMat = iMatColors->takeInputItem("material");
-            if(!iMat) {
+            if (!iMat) {
                 break;
             }
 
@@ -822,7 +833,7 @@ void GeometryViewControl::loadConfig(QString configFilename) {
             int alpha;
 
             err = iMat->getInput("material",material);
-            if(err) {
+            if (err) {
                 delete iMat;
                 delete iMatList;
                 continue;
@@ -830,24 +841,25 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
             // Find the index of the material by the same name
             int imed;
-            if(material == "vacuum") {
+            if (material == "vacuum") {
                 imed = nmed;
-            } else {
-                for(imed = 0; imed<nmed; ++imed) {
-                    if(g->getMediumName(imed) == material) {
+            }
+            else {
+                for (imed = 0; imed<nmed; ++imed) {
+                    if (g->getMediumName(imed) == material) {
                         break;
                     }
                 }
             }
 
             err = iMat->getInput("rgb",rgb);
-            if(err || rgb.size() < 3) {
+            if (err || rgb.size() < 3) {
                 delete iMat;
                 delete iMatList;
                 continue;
             }
             err = iMat->getInput("alpha",alpha);
-            if(err) {
+            if (err) {
                 delete iMat;
                 delete iMatList;
                 continue;
@@ -856,7 +868,7 @@ void GeometryViewControl::loadConfig(QString configFilename) {
             m_colors[imed] = qRgba(rgb[0], rgb[1], rgb[2], alpha);
 
             // Update the transparency bar
-            if(imed == 0) {
+            if (imed == 0) {
                 transparency->setValue(alpha);
             }
             delete iMat;
@@ -874,10 +886,10 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the clipping planes
     EGS_Input *iClip = input->takeInputItem("clipping planes");
-    if(iClip) {
+    if (iClip) {
         for (int i=0; i<cplanes->numPlanes(); i++) {
             EGS_Input *iPlane = iClip->takeInputItem("plane");
-            if(!iPlane) {
+            if (!iPlane) {
                 break;
             }
 
@@ -885,44 +897,50 @@ void GeometryViewControl::loadConfig(QString configFilename) {
             int check;
 
             err = iPlane->getInput("ax",ax);
-            if(!err) {
+            if (!err) {
                 cplanes->setCell(i,0,ax);
-            } else {
+            }
+            else {
                 cplanes->clearCell(i,0);
             }
 
             err = iPlane->getInput("ay",ay);
-            if(!err) {
+            if (!err) {
                 cplanes->setCell(i,1,ay);
-            } else {
+            }
+            else {
                 cplanes->clearCell(i,1);
             }
 
             err = iPlane->getInput("az",az);
-            if(!err) {
+            if (!err) {
                 cplanes->setCell(i,2,az);
-            } else {
+            }
+            else {
                 cplanes->clearCell(i,2);
             }
 
             err = iPlane->getInput("d",d);
-            if(!err) {
+            if (!err) {
                 cplanes->setCell(i,3,d);
-            } else {
+            }
+            else {
                 cplanes->clearCell(i,3);
             }
 
             err = iPlane->getInput("applied",check);
-            if(!err) {
+            if (!err) {
                 Qt::CheckState isChecked;
-                if(check == Qt::Checked) {
+                if (check == Qt::Checked) {
                     isChecked = Qt::Checked;
-                } else {
+                }
+                else {
                     isChecked = Qt::Unchecked;
                 }
 
                 cplanes->setCell(i,4,isChecked);
-            } else {
+            }
+            else {
                 cplanes->setCell(i,4,Qt::Checked);
             }
 
@@ -932,21 +950,21 @@ void GeometryViewControl::loadConfig(QString configFilename) {
         delete iClip;
     }
 
-    if(allowRegionSelection) {
+    if (allowRegionSelection) {
         updateRegionTable();
     }
 
     // Load the hidden regions
     EGS_Input *iReg = input->takeInputItem("hidden regions");
-    if(iReg) {
+    if (iReg) {
         vector<int> regionList;
         err = iReg->getInput("region list",regionList);
         // For every region in the table, check to see if it
         // is listed in the hidden regions list.
         // If so, hide it; if not, show it
-        for(size_t i = 0; i < show_regions.size(); ++i) {
+        for (size_t i = 0; i < show_regions.size(); ++i) {
             QTableWidgetItem *itemRegion = regionTable->item(i,0);
-            if(!itemRegion) {
+            if (!itemRegion) {
                 continue;
             }
 
@@ -954,13 +972,14 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
             // Hide the listed regions, otherwise show them
             QTableWidgetItem *itemShow = regionTable->item(i,3);
-            if(!itemShow) {
+            if (!itemShow) {
                 continue;
             }
-            if(std::find(regionList.begin(), regionList.end(), ireg) != regionList.end()) {
+            if (std::find(regionList.begin(), regionList.end(), ireg) != regionList.end()) {
                 itemShow->setCheckState(Qt::Unchecked);
                 show_regions[i] = false;
-            } else {
+            }
+            else {
                 itemShow->setCheckState(Qt::Checked);
                 show_regions[i] = true;
             }
@@ -969,46 +988,47 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     }
 
     EGS_Input *iColors = input->takeInputItem("colors");
-    if(iColors) {
+    if (iColors) {
         vector<int> rgb;
 
         err = iColors->getInput("background",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             backgroundColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         err = iColors->getInput("text",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             textColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         err = iColors->getInput("axis",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             axisColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         err = iColors->getInput("photons",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             photonColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         err = iColors->getInput("electrons",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             electronColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         err = iColors->getInput("positrons",rgb);
-        if(!err && rgb.size() >= 3) {
+        if (!err && rgb.size() >= 3) {
             positronColor = QColor(rgb[0], rgb[1], rgb[2]);
         }
 
         int useScaling;
         err = iColors->getInput("energy scaling",useScaling);
-        if(!err) {
+        if (!err) {
             energyScaling = useScaling;
-            if(energyScaling) {
+            if (energyScaling) {
                 energyScalingCheckbox->setCheckState(Qt::Checked);
-            } else {
+            }
+            else {
                 energyScalingCheckbox->setCheckState(Qt::Unchecked);
             }
         }
@@ -1019,7 +1039,7 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     }
 
     EGS_Input *iDose = input->takeInputItem("dose");
-    if(iDose) {
+    if (iDose) {
         int alpha;
         err = iDose->getInput("alpha",alpha);
         slider_dose->setValue(alpha);
@@ -1055,7 +1075,7 @@ void GeometryViewControl::loadDose() {
 
 void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
 
-    if(scoreArrays.size() > 0) {
+    if (scoreArrays.size() > 0) {
         scoreArrays.assign(scoreArrays.size(),vector<EGS_Float>());
     }
     size_t doseIndex = 0;
@@ -1063,34 +1083,34 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
     // Clear anything already in the layout for checkboxes
     // This is just for reloading an input file
     QList<QCheckBox *> list = groupBox_dose->findChildren<QCheckBox *>();
-    foreach(QCheckBox *cb, list) {
+    foreach (QCheckBox *cb, list) {
         delete cb;
     }
 
     // Load the dose a user selected from the file menu
-    if(userDoseFile.length()) {
+    if (userDoseFile.length()) {
         label_dose->hide();
 
         // 3ddose files
-        if(userDoseFile.endsWith(".3ddose")) {
+        if (userDoseFile.endsWith(".3ddose")) {
 
             QFile doseFile(userDoseFile);
 
             // Add a checkbox
             QCheckBox *doseCheckbox = new QCheckBox(QFileInfo(doseFile).fileName(),this);
             // If the user just selected this file, check the checkbox
-            if(loadUserDose) {
+            if (loadUserDose) {
                 doseCheckbox->setCheckState(Qt::Checked);
             }
             verticalLayout_dose->addWidget(doseCheckbox);
 
-            if(doseIndex+1 > scoreArrays.size()) {
+            if (doseIndex+1 > scoreArrays.size()) {
                 scoreArrays.push_back(vector<EGS_Float>());
             }
 
             connect(doseCheckbox, SIGNAL(toggled(bool)), this, SLOT(doseCheckbox_toggled()));
 
-            if(doseFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+            if (doseFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
 
 #ifdef VIEW_DEBUG
                 egsInformation("Reading dose file: %s\n", userDoseFile.toLatin1().data());
@@ -1101,7 +1121,7 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                 // Sanity check the number of voxels
                 int nx, ny, nz;
                 in >> nx >> ny >> nz;
-                if(g->regions() >= nx*ny*nz) {
+                if (g->regions() >= nx*ny*nz) {
 
                     scoreArrays[doseIndex].assign(g->regions(),0);
 
@@ -1135,9 +1155,10 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                                 int g_reg = g->isWhere(tp);
 
                                 // Read in the dose values
-                                if(g_reg >= 0) {
+                                if (g_reg >= 0) {
                                     in >> scoreArrays[doseIndex][g_reg];
-                                } else {
+                                }
+                                else {
 #ifdef VIEW_DEBUG
                                     egsWarning("Warning: Dose region out of bounds, skipping this file...\n");
 #endif
@@ -1147,20 +1168,22 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                                     break;
                                 }
                             }
-                            if(err) {
+                            if (err) {
                                 break;
                             }
                         }
-                        if(err) {
+                        if (err) {
                             break;
                         }
                     }
-                } else {
+                }
+                else {
                     doseCheckbox->setEnabled(false);
                 }
 
                 doseFile.close();
-            } else {
+            }
+            else {
                 doseCheckbox->setEnabled(false);
             }
             doseIndex++;
@@ -1169,23 +1192,23 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
 
     // Look through ausgab objects in the input file for EGS_DoseScoring
     for (int q=0; q<EGS_AusgabObject::nObjects(); ++q) {
-        if(EGS_AusgabObject::getObject(q)->getObjectType() == "EGS_DoseScoring") {
+        if (EGS_AusgabObject::getObject(q)->getObjectType() == "EGS_DoseScoring") {
             EGS_DoseScoring *o = static_cast<EGS_DoseScoring *>(EGS_AusgabObject::getObject(q));
             EGS_BaseGeometry *dgeom;
             int file_type;
-            if(o->getOutputFile(dgeom, file_type)) {
+            if (o->getOutputFile(dgeom, file_type)) {
 
                 int nx=dgeom->getNRegDir(0);
                 int ny=dgeom->getNRegDir(1);
                 int nz=dgeom->getNRegDir(2);
 
                 // Hide the label saying there are no ausgab objects
-                if(doseIndex == 0) {
+                if (doseIndex == 0) {
                     label_dose->hide();
                 }
 
                 // If the file type is 3ddose
-                if(file_type == 0) {
+                if (file_type == 0) {
 
                     QFileInfo inputFileInfo = QFileInfo(filename);
                     QString doseFilename = inputFileInfo.canonicalPath() + "/" + o->getObjectName().c_str() + ".3ddose";
@@ -1194,13 +1217,13 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                     QCheckBox *doseCheckbox = new QCheckBox(QString(dgeom->getName().c_str()) + ": " + QString(o->getObjectName().c_str()) + ".3ddose", this);
                     verticalLayout_dose->addWidget(doseCheckbox);
 
-                    if(doseIndex+1 > scoreArrays.size()) {
+                    if (doseIndex+1 > scoreArrays.size()) {
                         scoreArrays.push_back(vector<EGS_Float>());
                     }
 
                     connect(doseCheckbox, SIGNAL(toggled(bool)), this, SLOT(doseCheckbox_toggled()));
 
-                    if(doseFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                    if (doseFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
 
 #ifdef VIEW_DEBUG
                         egsInformation("Reading dose file: %s\n", doseFilename.toLatin1().data());
@@ -1211,7 +1234,7 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                         // Sanity check the number of voxels
                         int nx_tmp, ny_tmp, nz_tmp;
                         in >> nx_tmp >> ny_tmp >> nz_tmp;
-                        if(nx == nx_tmp && ny == ny_tmp && nz == nz_tmp && g->regions() >= nx_tmp*ny_tmp*nz_tmp) {
+                        if (nx == nx_tmp && ny == ny_tmp && nz == nz_tmp && g->regions() >= nx_tmp*ny_tmp*nz_tmp) {
 
                             scoreArrays[doseIndex].assign(g->regions(),0);
 
@@ -1237,9 +1260,10 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                                         int g_reg = g->isWhere(tp);
 
                                         // Read in the dose values
-                                        if(g_reg >= 0) {
+                                        if (g_reg >= 0) {
                                             in >> scoreArrays[doseIndex][g_reg];
-                                        } else {
+                                        }
+                                        else {
 #ifdef VIEW_DEBUG
                                             egsWarning("Warning: Dose region out of bounds, skipping this file...\n");
 #endif
@@ -1249,20 +1273,22 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
                                             break;
                                         }
                                     }
-                                    if(err) {
+                                    if (err) {
                                         break;
                                     }
                                 }
-                                if(err) {
+                                if (err) {
                                     break;
                                 }
                             }
-                        } else {
+                        }
+                        else {
                             doseCheckbox->setEnabled(false);
                         }
 
                         doseFile.close();
-                    } else {
+                    }
+                    else {
                         doseCheckbox->setEnabled(false);
                     }
                     doseIndex++;
@@ -1272,10 +1298,11 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
     }
 
     // If there were no dose ausgab objects, set the area blank
-    if(doseIndex == 0) {
+    if (doseIndex == 0) {
         label_dose->show();
         slider_dose->hide();
-    } else if(loadUserDose) {
+    }
+    else if (loadUserDose) {
         doseCheckbox_toggled();
     }
 }
@@ -1283,7 +1310,7 @@ void GeometryViewControl::updateAusgabObjects(bool loadUserDose) {
 void GeometryViewControl::doseCheckbox_toggled() {
     vector<bool> useArray;
     QList<QCheckBox *> list = groupBox_dose->findChildren<QCheckBox *>();
-    foreach(QCheckBox *cb, list) {
+    foreach (QCheckBox *cb, list) {
         useArray.push_back(cb->isChecked());
     }
 
@@ -1291,8 +1318,8 @@ void GeometryViewControl::doseCheckbox_toggled() {
     RenderParameters &rp = gview->pars;
 
     bool somethingChecked = false;
-    for(size_t i=0; i<useArray.size(); ++i) {
-        if(useArray[i]) {
+    for (size_t i=0; i<useArray.size(); ++i) {
+        if (useArray[i]) {
             somethingChecked = true;
             break;
         }
@@ -1301,20 +1328,21 @@ void GeometryViewControl::doseCheckbox_toggled() {
     // If nothing is checked, clear the scoring arrays and return
     rp.score.clear();
     rp.scoreColor.clear();
-    if(!somethingChecked) {
+    if (!somethingChecked) {
         updateView();
         return;
     }
 
     // Every time a dose checkbox is toggled, we recalculate the total dose
-    if(scoreArrays.size() >= useArray.size()) {
-        for(size_t i=0; i<useArray.size(); ++i) {
-            if(useArray[i] && scoreArrays[i].size() > 0) {
+    if (scoreArrays.size() >= useArray.size()) {
+        for (size_t i=0; i<useArray.size(); ++i) {
+            if (useArray[i] && scoreArrays[i].size() > 0) {
                 for (int j=0; j<g->regions(); ++j) {
-                    if(scoreArrays[i][j] > 0) {
-                        if(rp.score.count(j)) {
+                    if (scoreArrays[i][j] > 0) {
+                        if (rp.score.count(j)) {
                             rp.score[j] += scoreArrays[i][j];
-                        } else {
+                        }
+                        else {
                             rp.score[j] = scoreArrays[i][j];
                         }
                     }
@@ -1326,19 +1354,20 @@ void GeometryViewControl::doseCheckbox_toggled() {
     // Determine the total dose minimum and maximum
     EGS_Float dmin=1e10, dmax=0.;
     for (int j=0; j<g->regions(); ++j) {
-        if(rp.score.count(j)) {
-            if(rp.score[j] < dmin) {
+        if (rp.score.count(j)) {
+            if (rp.score[j] < dmin) {
                 dmin = rp.score[j];
-            } else if(rp.score[j] > dmax) {
+            }
+            else if (rp.score[j] > dmax) {
                 dmax = rp.score[j];
             }
         }
     }
 
     // Calculate the colors
-    if(dmax > 0.) {
+    if (dmax > 0.) {
         for (int i=0; i<g->regions(); ++i) {
-            if(rp.score.count(i)) {
+            if (rp.score.count(i)) {
                 EGS_Float scoreNorm = (rp.score[i] - dmin) / (dmax - dmin);
                 rp.scoreColor[i] = getHeatMapColor(scoreNorm);
             }
@@ -1353,8 +1382,8 @@ void GeometryViewControl::updateSimulationGeometry(int ind) {
 
     EGS_BaseGeometry **geoms = g->getGeometries();
     int ngeom = g->getNGeometries();
-    for(int i=0; i<ngeom; ++i) {
-        if(geomName == geoms[i]->getName().c_str()) {
+    for (int i=0; i<ngeom; ++i) {
+        if (geomName == geoms[i]->getName().c_str()) {
             g = geoms[i];
             break;
         }
@@ -1505,9 +1534,10 @@ void GeometryViewControl::cameraTranslate(int dx, int dy) {
     // Set a scaling factor for the camera translation so that
     // it goes slower at higher zoom levels
     EGS_Float scale;
-    if(zoomlevel > -10) {
+    if (zoomlevel > -10) {
         scale = pow(1./(zoomlevel+110),1.5);
-    } else {
+    }
+    else {
         scale = 0.001;
     }
 
@@ -1545,9 +1575,10 @@ void GeometryViewControl::cameraRotate(int dx, int dy) {
     // it goes slower at higher zoom levels
     // Note: the minimum zoomlevel is -400 and does become positive
     EGS_Float scale;
-    if(zoomlevel > -97) {
+    if (zoomlevel > -97) {
         scale = pow(1./(zoomlevel+110),1.2);
-    } else {
+    }
+    else {
         scale = 0.05;
     }
 
@@ -1746,7 +1777,7 @@ void GeometryViewControl::setLookAt() {
     }
     if (ok_x || ok_y || ok_z) {
 
-        if(g->isWhere(look_at) < 0) {
+        if (g->isWhere(look_at) < 0) {
             look_at = look_at_orig;
             setLookAtLineEdit();
             return;
@@ -1803,7 +1834,7 @@ void GeometryViewControl::setLookPosition() {
         look_at.z += dz;
 
         // The new rotation point must be inside the geometry
-        if(g->isWhere(look_at) < 0) {
+        if (g->isWhere(look_at) < 0) {
             look_at = look_at_orig;
             setCameraLineEdit();
             return;
@@ -1848,7 +1879,7 @@ void GeometryViewControl::loadTracksDialog() {
 }
 
 void GeometryViewControl::updateTracks(vector<size_t> ntracks) {
-    if(ntracks.size() != 3) {
+    if (ntracks.size() != 3) {
         return;
     }
 
@@ -2011,9 +2042,10 @@ int GeometryViewControl::setGeometry(
     int js = 0;
     for (int j=0; j<=nmed; j++) {
         string med_name;
-        if(j == nmed) {
+        if (j == nmed) {
             med_name = "vacuum";
-        } else {
+        }
+        else {
             med_name = g->getMediumName(j);
         }
         unsigned int i;
@@ -2024,10 +2056,11 @@ int GeometryViewControl::setGeometry(
             m_colors[j] = qRgba(ucolors[i].red,ucolors[i].green,ucolors[i].blue,ucolors[i].alpha);
         }
         else {
-            if(j == nmed) {
+            if (j == nmed) {
                 // Vacuum defaults to black, transparent
                 m_colors[j] = qRgba(0,0,0,0);
-            } else {
+            }
+            else {
                 m_colors[j] = qRgba(standard_red[js], standard_green[js], standard_blue[js], 255);
             }
             if ((++js) >= nstandard) {
@@ -2288,13 +2321,13 @@ int GeometryViewControl::setGeometry(
         size = zsize;
     }
 
-    if(pmax.x < 0) {
+    if (pmax.x < 0) {
         pmax.x = 0;
     }
-    if(pmax.y < 0) {
+    if (pmax.y < 0) {
         pmax.y = 0;
     }
-    if(pmax.z < 0) {
+    if (pmax.z < 0) {
         pmax.z = 0;
     }
 
@@ -2423,7 +2456,7 @@ void GeometryViewControl::changeColor() {
         pixmap.fill(m_colors[med]);
         materialCB->setItemIcon(med, pixmap);
         transparency->setValue(qAlpha(newc));
-        if(allowRegionSelection) {
+        if (allowRegionSelection) {
             updateRegionTable(med);
         }
         updateView();
@@ -2579,7 +2612,7 @@ void GeometryViewControl::setClippingPlanes() {
 }
 
 void GeometryViewControl::showPhotonsCheckbox_toggled(bool toggle) {
-    if(toggle) {
+    if (toggle) {
         showTracks = toggle;
     }
     showPhotonTracks = toggle;
@@ -2587,7 +2620,7 @@ void GeometryViewControl::showPhotonsCheckbox_toggled(bool toggle) {
 }
 
 void GeometryViewControl::showElectronsCheckbox_toggled(bool toggle) {
-    if(toggle) {
+    if (toggle) {
         showTracks = toggle;
     }
     showElectronTracks = toggle;
@@ -2595,7 +2628,7 @@ void GeometryViewControl::showElectronsCheckbox_toggled(bool toggle) {
 }
 
 void GeometryViewControl::showPositronsCheckbox_toggled(bool toggle) {
-    if(toggle) {
+    if (toggle) {
         showTracks = toggle;
     }
     showPositronTracks = toggle;
@@ -2648,8 +2681,8 @@ void GeometryViewControl::updateRegionTable() {
 
     // Count the number of real regions
     int nReal = 0;
-    for(int ireg = 0; ireg < nreg; ++ireg) {
-        if(g->isRealRegion(ireg)) {
+    for (int ireg = 0; ireg < nreg; ++ireg) {
+        if (g->isRealRegion(ireg)) {
             nReal++;
         }
     }
@@ -2662,13 +2695,13 @@ void GeometryViewControl::updateRegionTable() {
 
     // Populate the table
     int i = 0;
-    for(int ireg = 0; ireg < nreg; ++ireg) {
-        if(g->isRealRegion(ireg)) {
+    for (int ireg = 0; ireg < nreg; ++ireg) {
+        if (g->isRealRegion(ireg)) {
             int imed = g->medium(ireg);
 
             // Set the region number
             QTableWidgetItem *regItem = regionTable->item(i,0);
-            if(!regItem) {
+            if (!regItem) {
                 regItem = new QTableWidgetItem();
                 regionTable->setItem(i,0,regItem);
             }
@@ -2676,33 +2709,35 @@ void GeometryViewControl::updateRegionTable() {
 
             // Set the material color
             QTableWidgetItem *colorItem = regionTable->item(i,1);
-            if(!colorItem) {
+            if (!colorItem) {
                 colorItem = new QTableWidgetItem();
                 regionTable->setItem(i,1,colorItem);
             }
-            if(imed < 0) {
+            if (imed < 0) {
                 colorItem->setBackground(QBrush(QColor(m_colors[nmed])));
-            } else {
+            }
+            else {
                 colorItem->setBackground(QBrush(QColor(m_colors[imed])));
             }
             colorItem->setFlags(colorItem->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsSelectable);
 
             // Set the material name
             QTableWidgetItem *matItem = regionTable->item(i,2);
-            if(!matItem) {
+            if (!matItem) {
                 matItem = new QTableWidgetItem();
                 regionTable->setItem(i,2,matItem);
             }
-            if(imed < 0) {
+            if (imed < 0) {
                 matItem->setText(QString("vacuum"));
-            } else {
+            }
+            else {
                 matItem->setText(QString(g->getMediumName(imed)));
             }
             matItem->setFlags(matItem->flags() & ~Qt::ItemIsEditable & ~Qt::ItemIsSelectable);
 
             // Set the show/hide checkbox
             QTableWidgetItem *showItem = regionTable->item(i,3);
-            if(!showItem) {
+            if (!showItem) {
                 showItem = new QTableWidgetItem();
                 regionTable->setItem(i,3,showItem);
             }
@@ -2724,21 +2759,21 @@ void GeometryViewControl::updateRegionTable(int imedToChange) {
     // Update the material color
     int i = 0;
     int nreg = g->regions();
-    for(int ireg = 0; ireg < nreg; ++ireg) {
-        if(g->isRealRegion(ireg)) {
+    for (int ireg = 0; ireg < nreg; ++ireg) {
+        if (g->isRealRegion(ireg)) {
             int imed = g->medium(ireg);
 
-            if(imed < 0) {
+            if (imed < 0) {
                 imed = nmed;
             }
-            if(imed != imedToChange) {
+            if (imed != imedToChange) {
                 ++i;
                 continue;
             }
 
             // Set the material color
             QTableWidgetItem *colorItem = regionTable->item(i,1);
-            if(!colorItem) {
+            if (!colorItem) {
                 colorItem = new QTableWidgetItem();
                 regionTable->setItem(i,1,colorItem);
             }
@@ -2750,7 +2785,7 @@ void GeometryViewControl::updateRegionTable(int imedToChange) {
 }
 
 void GeometryViewControl::toggleRegion(int i, int j) {
-    if(!g) {
+    if (!g) {
         return;
     }
 
@@ -2758,32 +2793,33 @@ void GeometryViewControl::toggleRegion(int i, int j) {
     Qt::CheckState checked = Qt::Checked;
 
     QTableWidgetItem *item = regionTable->item(i,0);
-    if(item) {
+    if (item) {
         ireg = item->text().toInt();
     }
 
     item = regionTable->item(i,3);
-    if(item) {
+    if (item) {
         checked = item->checkState();
     }
 
-    if(checked == Qt::Checked) {
+    if (checked == Qt::Checked) {
         show_regions[ireg] = true;
-    } else {
+    }
+    else {
         show_regions[ireg] = false;
     }
 
     // If the region number was changed, update the color swatch and material
-    if(j == 0) {
+    if (j == 0) {
         int imed = g->medium(ireg);
 
-        if(imed < 0) {
+        if (imed < 0) {
             imed = nmed;
         }
 
         // Set the material color
         QTableWidgetItem *colorItem = regionTable->item(i,1);
-        if(!colorItem) {
+        if (!colorItem) {
             colorItem = new QTableWidgetItem();
             regionTable->setItem(i,1,colorItem);
         }
@@ -2791,7 +2827,7 @@ void GeometryViewControl::toggleRegion(int i, int j) {
 
         // Set the material name
         QTableWidgetItem *matItem = regionTable->item(i,2);
-        if(!matItem) {
+        if (!matItem) {
             matItem = new QTableWidgetItem();
             regionTable->setItem(i,2,matItem);
         }
@@ -2806,11 +2842,11 @@ void GeometryViewControl::showAllRegions() {
         return;
     }
 
-    for(size_t i = 0; i < show_regions.size(); ++i) {
+    for (size_t i = 0; i < show_regions.size(); ++i) {
 
         // Set the show/hide checkbox
         QTableWidgetItem *showItem = regionTable->item(i,3);
-        if(!showItem) {
+        if (!showItem) {
             showItem = new QTableWidgetItem();
             regionTable->setItem(i,3,showItem);
         }
@@ -2823,11 +2859,11 @@ void GeometryViewControl::hideAllRegions() {
         return;
     }
 
-    for(size_t i = 0; i < show_regions.size(); ++i) {
+    for (size_t i = 0; i < show_regions.size(); ++i) {
 
         // Set the show/hide checkbox
         QTableWidgetItem *showItem = regionTable->item(i,3);
-        if(!showItem) {
+        if (!showItem) {
             showItem = new QTableWidgetItem();
             regionTable->setItem(i,3,showItem);
         }
@@ -2849,7 +2885,7 @@ void GeometryViewControl::enlargeFont() {
 
 void GeometryViewControl::shrinkFont() {
     QFont new_font = this->font();
-    if(new_font.pointSize() > 1) {
+    if (new_font.pointSize() > 1) {
         new_font.setPointSize(new_font.pointSize() - 1);
         QApplication::setFont(new_font);
     }

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -69,24 +69,25 @@ public:
     virtual void updateCameraLineEdit();
     virtual int setGeometry(EGS_BaseGeometry *geom, const std::vector<EGS_UserColor> &ucolors, EGS_Float xmin, EGS_Float xmax, EGS_Float ymin, EGS_Float ymax, EGS_Float zmin, EGS_Float zmax, bool justReloading);
     virtual void updateView(bool transform = false);
-    virtual bool loadInput(bool first_time);
+    virtual bool loadInput(bool first_time, EGS_BaseGeometry *simGeom = 0);
     virtual void loadConfig(QString configFilename);
     virtual EGS_Vector getHeatMapColor(EGS_Float value);
     virtual void updateRegionTable();
     virtual void updateRegionTable(int imed);
-    virtual void updateAusgabObjects();
+    virtual void updateAusgabObjects(bool loadUserDose=false);
     virtual void initColorSwatches();
 
 public slots:
 
     virtual void reloadInput();
     virtual void selectInput();
+    virtual void loadDose();
     virtual void loadConfig();
     virtual void saveConfig();
+    virtual void updateSimulationGeometry(int ind);
     virtual void checkboxAxes(bool toggle);
     virtual void checkboxAxesLabels(bool toggle);
     virtual void checkboxShowRegions(bool toggle);
-    virtual void checkboxShowTracks(bool toggle);
     virtual void cameraHome();
     virtual void cameraOnAxis(char axis);
     virtual void camera_x();
@@ -137,6 +138,11 @@ public slots:
     virtual void setFontSize(int size);
     virtual void doseCheckbox_toggled();
     virtual void changeDoseTransparency(int t);
+    virtual void changeTrackMin();
+    virtual void changeTrackMaxP(int t);
+    virtual void changeTrackMaxE(int t);
+    virtual void changeTrackMaxPo(int t);
+    virtual void updateTracks(vector<size_t> ntracks);
 
 private:
 
@@ -146,6 +152,7 @@ private:
 
     QString filename;
     QString filename_tracks;
+    QString userDoseFile;
     int nmed;
     QRgb *m_colors;
     QColor  backgroundColor,
@@ -191,6 +198,7 @@ private:
     bool    allowRegionSelection,
             energyScaling;
     vector<vector<EGS_Float>> scoreArrays;
+    EGS_BaseGeometry *origSimGeom;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -69,11 +69,14 @@ public:
     virtual int setGeometry(EGS_BaseGeometry *geom, const std::vector<EGS_UserColor> &ucolors, EGS_Float xmin, EGS_Float xmax, EGS_Float ymin, EGS_Float ymax, EGS_Float zmin, EGS_Float zmax, bool justReloading);
     virtual void updateView(bool transform = false);
     virtual bool loadInput(bool first_time);
+    virtual void loadConfig(QString configFilename);
 
 public slots:
 
     virtual void reloadInput();
     virtual void selectInput();
+    virtual void loadConfig();
+    virtual void saveConfig();
     virtual void checkboxAxes(bool toggle);
     virtual void checkboxAxesLabels(bool toggle);
     virtual void checkboxShowRegions(bool toggle);
@@ -106,7 +109,6 @@ public slots:
     virtual void changeColor();
     virtual void saveImage();
     virtual void reenableSave();
-    virtual void showHideOptions();
     virtual void setClippingPlanes();
     virtual void showPhotonsCheckbox_toggled(bool toggle);
     virtual void showElectronsCheckbox_toggled(bool toggle);

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -71,6 +71,7 @@ public:
     virtual void loadConfig(QString configFilename);
     virtual void updateRegionTable();
     virtual void updateRegionTable(int imed);
+    virtual void initColorSwatches();
 
 public slots:
 
@@ -108,13 +109,19 @@ public slots:
     virtual void quitApplication();
     virtual void updateColorLabel(int med);
     virtual void changeColor();
+    virtual void setBackgroundColor();
+    virtual void setTextColor();
+    virtual void setAxisColor();
+    virtual void setPhotonColor();
+    virtual void setElectronColor();
+    virtual void setPositronColor();
+    virtual void setEnergyScaling(bool toggle);
     virtual void saveImage();
     virtual void reenableSave();
     virtual void setClippingPlanes();
     virtual void showPhotonsCheckbox_toggled(bool toggle);
     virtual void showElectronsCheckbox_toggled(bool toggle);
     virtual void showPositronsCheckbox_toggled(bool toggle);
-    virtual void showOthersCheckbox_toggled(bool toggle);
     virtual void startTransformation();
     virtual void endTransformation();
     virtual void toggleRegion(int i, int j);
@@ -131,6 +138,12 @@ private:
     QString filename_tracks;
     int nmed;
     QRgb *m_colors;
+    QColor  backgroundColor,
+            textColor,
+            axisColor,
+            photonColor,
+            electronColor,
+            positronColor;
     int zoomlevel_home;
     int zoomlevel;
     EGS_Float a_light;
@@ -163,9 +176,9 @@ private:
     bool showPhotonTracks;
     bool showElectronTracks;
     bool showPositronTracks;
-    bool showOtherTracks;
     vector<bool> show_regions;
-    bool allowRegionSelection;
+    bool    allowRegionSelection,
+            energyScaling;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -65,6 +65,8 @@ public:
     virtual void setLightLineEdit();
     virtual void setLookAtLineEdit();
     virtual void updateLookAtLineEdit();
+    virtual void setCameraLineEdit();
+    virtual void updateCameraLineEdit();
     virtual int setGeometry(EGS_BaseGeometry *geom, const std::vector<EGS_UserColor> &ucolors, EGS_Float xmin, EGS_Float xmax, EGS_Float ymin, EGS_Float ymax, EGS_Float zmin, EGS_Float zmax, bool justReloading);
     virtual void updateView(bool transform = false);
     virtual bool loadInput(bool first_time);
@@ -103,6 +105,7 @@ public slots:
     virtual void moveLightChanged(int toggle);
     virtual void setLightPosition();
     virtual void setLookAt();
+    virtual void setLookPosition();
     virtual void loadTracksDialog();
     virtual void viewAllMaterials();
     virtual void reportViewSettings(int x, int y);

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -71,8 +71,10 @@ public:
     virtual void updateView(bool transform = false);
     virtual bool loadInput(bool first_time);
     virtual void loadConfig(QString configFilename);
+    virtual EGS_Vector getHeatMapColor(EGS_Float value);
     virtual void updateRegionTable();
     virtual void updateRegionTable(int imed);
+    virtual void updateAusgabObjects();
     virtual void initColorSwatches();
 
 public slots:
@@ -132,6 +134,9 @@ public slots:
     virtual void hideAllRegions();
     virtual void enlargeFont();
     virtual void shrinkFont();
+    virtual void setFontSize(int size);
+    virtual void doseCheckbox_toggled();
+    virtual void changeDoseTransparency(int t);
 
 private:
 
@@ -160,6 +165,7 @@ private:
     EGS_Float theta;
     EGS_Float distance;
     EGS_Float size;
+    EGS_Float doseTransparency;
     EGS_Vector axesmax;
     EGS_Vector center;
     EGS_Vector camera_home_v2;
@@ -184,6 +190,7 @@ private:
     vector<bool> show_regions;
     bool    allowRegionSelection,
             energyScaling;
+    vector<vector<EGS_Float>> scoreArrays;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -65,11 +65,12 @@ public:
     virtual void setLightLineEdit();
     virtual void setLookAtLineEdit();
     virtual void updateLookAtLineEdit();
-    virtual void setMaterialColor(int j);
     virtual int setGeometry(EGS_BaseGeometry *geom, const std::vector<EGS_UserColor> &ucolors, EGS_Float xmin, EGS_Float xmax, EGS_Float ymin, EGS_Float ymax, EGS_Float zmin, EGS_Float zmax, bool justReloading);
     virtual void updateView(bool transform = false);
     virtual bool loadInput(bool first_time);
     virtual void loadConfig(QString configFilename);
+    virtual void updateRegionTable();
+    virtual void updateRegionTable(int imed);
 
 public slots:
 
@@ -116,6 +117,9 @@ public slots:
     virtual void showOthersCheckbox_toggled(bool toggle);
     virtual void startTransformation();
     virtual void endTransformation();
+    virtual void toggleRegion(int i, int j);
+    virtual void showAllRegions();
+    virtual void hideAllRegions();
 
 private:
 
@@ -160,6 +164,8 @@ private:
     bool showElectronTracks;
     bool showPositronTracks;
     bool showOtherTracks;
+    vector<bool> show_regions;
+    bool allowRegionSelection;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -106,6 +106,7 @@ public slots:
     virtual void loadTracksDialog();
     virtual void viewAllMaterials();
     virtual void reportViewSettings(int x, int y);
+    virtual void setRotationPoint(EGS_Vector hitCoord);
     virtual void quitApplication();
     virtual void updateColorLabel(int med);
     virtual void changeColor();

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -73,6 +73,7 @@ public:
 public slots:
 
     virtual void reloadInput();
+    virtual void selectInput();
     virtual void checkboxAxes(bool toggle);
     virtual void checkboxAxesLabels(bool toggle);
     virtual void checkboxShowRegions(bool toggle);

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -39,7 +39,7 @@
 #include "egs_user_color.h"
 #include "egs_vector.h"
 
-#include <qdialog.h>
+#include <QMainWindow>
 
 class EGS_BaseGeometry;
 class EGS_GeometryVisualizer;
@@ -50,7 +50,7 @@ class SaveImage;
 class ClippingPlanesWidget;
 
 
-class GeometryViewControl : public QDialog, public Ui::GeometryViewControl {
+class GeometryViewControl : public QMainWindow, public Ui::GeometryViewControl {
     Q_OBJECT
 
 public:
@@ -118,7 +118,6 @@ public slots:
     virtual void setPositronColor();
     virtual void setEnergyScaling(bool toggle);
     virtual void saveImage();
-    virtual void reenableSave();
     virtual void setClippingPlanes();
     virtual void showPhotonsCheckbox_toggled(bool toggle);
     virtual void showElectronsCheckbox_toggled(bool toggle);
@@ -128,6 +127,8 @@ public slots:
     virtual void toggleRegion(int i, int j);
     virtual void showAllRegions();
     virtual void hideAllRegions();
+    virtual void enlargeFont();
+    virtual void shrinkFont();
 
 private:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -912,7 +912,7 @@
                 <item>
                  <widget class="QGroupBox" name="groupBox">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -1157,8 +1157,77 @@
                 </item>
                 <item>
                  <widget class="QGroupBox" name="groupBox9">
+                  <property name="toolTip">
+                   <string>This also translates the rotation point</string>
+                  </property>
+                  <property name="toolTipDuration">
+                   <number>4000</number>
+                  </property>
                   <property name="title">
                    <string>Camera position [cm]</string>
+                  </property>
+                  <layout class="QHBoxLayout">
+                   <item>
+                    <widget class="QLineEdit" name="cameraX"/>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="cameraY"/>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="cameraZ"/>
+                   </item>
+                   <item>
+                    <spacer name="spacer4">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Expanding</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>16</width>
+                       <height>21</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="applyPosition">
+                     <property name="text">
+                      <string>Apply</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox9">
+                  <property name="toolTip">
+                   <string>Must be inside the geometry</string>
+                  </property>
+                  <property name="toolTipDuration">
+                   <number>4000</number>
+                  </property>
+                  <property name="title">
+                   <string>Rotation point [cm]</string>
                   </property>
                   <layout class="QHBoxLayout">
                    <item>
@@ -1197,66 +1266,22 @@
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer">
+                 <spacer name="verticalSpacer_14">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
-                  </property>
-                  <property name="sizeType">
-                   <enum>QSizePolicy::Fixed</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>20</width>
-                    <height>10</height>
+                    <height>40</height>
                    </size>
                   </property>
                  </spacer>
                 </item>
-                <item>
-                 <widget class="QGroupBox" name="groupBox_4">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>0</width>
-                    <height>220</height>
-                   </size>
-                  </property>
-                  <property name="title">
-                   <string>Controls</string>
-                  </property>
-                  <layout class="QHBoxLayout" name="horizontalLayout_12">
-                   <item>
-                    <widget class="QTextBrowser" name="controlsText">
-                     <property name="html">
-                      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Rotate: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;hold left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Zoom:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; scroll or hold middle MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Pan: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ctrl + left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Roll:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Shift + left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set rotation point:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; double left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Home&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Alt + Home&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at X: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;x&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Y:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; y&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Z:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </widget>
-                </item>
                </layout>
               </item>
               <item>
-               <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
+               <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0,0">
                 <property name="leftMargin">
                  <number>0</number>
                 </property>
@@ -1287,7 +1312,7 @@ p, li { white-space: pre-wrap; }
                   <property name="minimumSize">
                    <size>
                     <width>329</width>
-                    <height>291</height>
+                    <height>230</height>
                    </size>
                   </property>
                   <property name="title">
@@ -1324,23 +1349,50 @@ p, li { white-space: pre-wrap; }
                         <bool>false</bool>
                        </property>
                        <property name="sizePolicy">
-                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                          <horstretch>0</horstretch>
                          <verstretch>0</verstretch>
                         </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>0</width>
+                         <height>70</height>
+                        </size>
                        </property>
                        <property name="title">
                         <string>Light position</string>
                        </property>
                        <layout class="QHBoxLayout">
                         <item>
-                         <widget class="QLineEdit" name="lightX"/>
+                         <widget class="QLineEdit" name="lightX">
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                         </widget>
                         </item>
                         <item>
-                         <widget class="QLineEdit" name="lightY"/>
+                         <widget class="QLineEdit" name="lightY">
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                         </widget>
                         </item>
                         <item>
-                         <widget class="QLineEdit" name="lightZ"/>
+                         <widget class="QLineEdit" name="lightZ">
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                         </widget>
                         </item>
                         <item>
                          <spacer name="spacer6">
@@ -1360,6 +1412,12 @@ p, li { white-space: pre-wrap; }
                         </item>
                         <item>
                          <widget class="QPushButton" name="applyLight">
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>24</height>
+                           </size>
+                          </property>
                           <property name="text">
                            <string>Apply</string>
                           </property>
@@ -1371,7 +1429,7 @@ p, li { white-space: pre-wrap; }
                      <item>
                       <widget class="QGroupBox" name="groupBox17">
                        <property name="sizePolicy">
-                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                          <horstretch>0</horstretch>
                          <verstretch>0</verstretch>
                         </sizepolicy>
@@ -1379,7 +1437,7 @@ p, li { white-space: pre-wrap; }
                        <property name="minimumSize">
                         <size>
                          <width>301</width>
-                         <height>0</height>
+                         <height>60</height>
                         </size>
                        </property>
                        <property name="title">
@@ -1388,6 +1446,12 @@ p, li { white-space: pre-wrap; }
                        <layout class="QHBoxLayout">
                         <item>
                          <widget class="QSlider" name="ambientLight">
+                          <property name="minimumSize">
+                           <size>
+                            <width>0</width>
+                            <height>22</height>
+                           </size>
+                          </property>
                           <property name="maximum">
                            <number>100</number>
                           </property>
@@ -1411,17 +1475,59 @@ p, li { white-space: pre-wrap; }
                  </widget>
                 </item>
                 <item>
-                 <spacer name="verticalSpacer_2">
+                 <spacer name="verticalSpacer_13">
                   <property name="orientation">
                    <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Minimum</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
                     <width>20</width>
-                    <height>40</height>
+                    <height>10</height>
                    </size>
                   </property>
                  </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_4">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>230</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Controls</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_12">
+                   <item>
+                    <widget class="QTextBrowser" name="controlsText">
+                     <property name="html">
+                      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Rotate: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;hold left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Zoom:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; scroll or hold middle MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Pan: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ctrl + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Roll:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Shift + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set rotation point:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; double left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Alt + Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look along X (Y or Z): &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;x (y or z)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
                 </item>
                </layout>
               </item>
@@ -1548,6 +1654,22 @@ p, li { white-space: pre-wrap; }
    <signal>clicked()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>setLookAt()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>applyPosition</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setLookPosition()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -158,10 +158,16 @@
                   <item>
                    <widget class="QGroupBox" name="groupBox10">
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>120</height>
+                     </size>
                     </property>
                     <property name="maximumSize">
                      <size>
@@ -226,7 +232,7 @@
                   <item>
                    <widget class="QGroupBox" name="groupBox15">
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
@@ -234,7 +240,7 @@
                     <property name="minimumSize">
                      <size>
                       <width>0</width>
-                      <height>0</height>
+                      <height>120</height>
                      </size>
                     </property>
                     <property name="maximumSize">
@@ -254,58 +260,146 @@
                     </property>
                     <layout class="QHBoxLayout">
                      <item>
-                      <layout class="QVBoxLayout">
+                      <layout class="QVBoxLayout" name="vlayout_overlay">
                        <item>
-                        <layout class="QVBoxLayout">
-                         <item>
-                          <widget class="QCheckBox" name="showAxesCheckbox">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Show axes</string>
-                           </property>
-                           <property name="checked">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QCheckBox" name="showAxesLabelsCheckbox">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Show axes labels</string>
-                           </property>
-                           <property name="checked">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QCheckBox" name="showRegionsCheckbox">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Show regions</string>
-                           </property>
-                           <property name="checked">
-                            <bool>true</bool>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
+                        <widget class="QCheckBox" name="showAxesCheckbox">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Show axes</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QCheckBox" name="showAxesLabelsCheckbox">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Show axis labels</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QCheckBox" name="showRegionsCheckbox">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Show regions and surface info</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_dose">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>140</height>
+                     </size>
+                    </property>
+                    <property name="toolTip">
+                     <string>Use egs_dose_scoring to output a dose file</string>
+                    </property>
+                    <property name="title">
+                     <string>Dose</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_9">
+                     <property name="leftMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>6</number>
+                     </property>
+                     <item>
+                      <widget class="QSlider" name="slider_dose">
+                       <property name="maximum">
+                        <number>100</number>
+                       </property>
+                       <property name="value">
+                        <number>50</number>
+                       </property>
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <layout class="QVBoxLayout" name="outerLayout_dose">
+                       <item>
+                        <widget class="QScrollArea" name="scrollArea_2">
+                         <property name="frameShape">
+                          <enum>QFrame::Box</enum>
+                         </property>
+                         <property name="widgetResizable">
+                          <bool>true</bool>
+                         </property>
+                         <widget class="QWidget" name="scrollAreaWidgetContents">
+                          <property name="geometry">
+                           <rect>
+                            <x>0</x>
+                            <y>0</y>
+                            <width>294</width>
+                            <height>103</height>
+                           </rect>
+                          </property>
+                          <layout class="QVBoxLayout" name="verticalLayout_16">
+                           <item>
+                            <layout class="QVBoxLayout" name="verticalLayout_dose">
+                             <property name="spacing">
+                              <number>5</number>
+                             </property>
+                             <item>
+                              <widget class="QLabel" name="label_dose">
+                               <property name="text">
+                                <string>No ausgab objects found</string>
+                               </property>
+                               <property name="alignment">
+                                <set>Qt::AlignCenter</set>
+                               </property>
+                              </widget>
+                             </item>
+                            </layout>
+                           </item>
+                          </layout>
+                         </widget>
+                        </widget>
                        </item>
                       </layout>
                      </item>
@@ -323,7 +417,7 @@
                     <property name="sizeHint" stdset="0">
                      <size>
                       <width>20</width>
-                      <height>160</height>
+                      <height>10</height>
                      </size>
                     </property>
                    </spacer>
@@ -1156,12 +1250,9 @@
                  </spacer>
                 </item>
                 <item>
-                 <widget class="QGroupBox" name="groupBox9">
+                 <widget class="QGroupBox" name="groupBox_cam">
                   <property name="toolTip">
                    <string>This also translates the rotation point</string>
-                  </property>
-                  <property name="toolTipDuration">
-                   <number>4000</number>
                   </property>
                   <property name="title">
                    <string>Camera position [cm]</string>
@@ -1177,7 +1268,7 @@
                     <widget class="QLineEdit" name="cameraZ"/>
                    </item>
                    <item>
-                    <spacer name="spacer4">
+                    <spacer name="spacer_cam">
                      <property name="orientation">
                       <enum>Qt::Horizontal</enum>
                      </property>
@@ -1222,9 +1313,6 @@
                  <widget class="QGroupBox" name="groupBox9">
                   <property name="toolTip">
                    <string>Must be inside the geometry</string>
-                  </property>
-                  <property name="toolTipDuration">
-                   <number>4000</number>
                   </property>
                   <property name="title">
                    <string>Rotation point [cm]</string>
@@ -2118,6 +2206,22 @@ p, li { white-space: pre-wrap; }
    <signal>valueChanged(int)</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>changeTransparency(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>slider_dose</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeDoseTransparency(int)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -31,14 +31,20 @@
 ###############################################################################
 </comment>
  <class>GeometryViewControl</class>
- <widget class="QDialog" name="GeometryViewControl">
+ <widget class="QMainWindow" name="GeometryViewControl">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>691</width>
-    <height>614</height>
+    <width>675</width>
+    <height>592</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
   </property>
   <property name="maximumSize">
    <size>
@@ -49,1142 +55,1179 @@
   <property name="windowTitle">
    <string>View Controls</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>false</bool>
+  <property name="sizeGripEnabled" stdset="0">
+   <bool>true</bool>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_4">
-   <item>
-    <layout class="QVBoxLayout" name="verticalLayout_7">
-     <item>
-      <widget class="QTabWidget" name="tabWidget">
-       <property name="currentIndex">
-        <number>0</number>
-       </property>
-       <widget class="QWidget" name="displayTab">
-        <attribute name="title">
-         <string>Display</string>
-        </attribute>
-        <widget class="QWidget" name="layoutWidget">
+  <widget class="QWidget" name="centralWidget">
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <layout class="QHBoxLayout" name="horizontalLayout_9">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
+     <number>0</number>
+    </property>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <item>
+       <widget class="QScrollArea" name="scrollArea">
+        <property name="widgetResizable">
+         <bool>true</bool>
+        </property>
+        <widget class="QWidget" name="scrollAreaWidgetContents_2">
          <property name="geometry">
           <rect>
            <x>0</x>
-           <y>10</y>
-           <width>661</width>
-           <height>511</height>
+           <y>0</y>
+           <width>671</width>
+           <height>563</height>
           </rect>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
-          <property name="sizeConstraint">
-           <enum>QLayout::SetDefaultConstraint</enum>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_8">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
           </property>
           <item>
-           <layout class="QVBoxLayout" name="clipLayout"/>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_4">
-            <item>
-             <spacer name="verticalSpacer_3">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>10</width>
-                <height>11</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox10">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Particle tracks</string>
-              </property>
-              <layout class="QGridLayout">
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="showTracksCheckbox">
-                 <property name="text">
-                  <string>Show tracks</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="showPhotonsCheckbox">
-                 <property name="text">
-                  <string>Photons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="1">
-                <widget class="QCheckBox" name="showElectronsCheckbox">
-                 <property name="text">
-                  <string>Electrons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QCheckBox" name="showPositronsCheckbox">
-                 <property name="text">
-                  <string>Positrons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QPushButton" name="loadTracks">
-                 <property name="text">
-                  <string>Load tracks</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox15">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="baseSize">
-               <size>
-                <width>331</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Overlay</string>
-              </property>
-              <layout class="QHBoxLayout">
-               <item>
-                <layout class="QVBoxLayout">
-                 <item>
-                  <layout class="QVBoxLayout">
-                   <item>
-                    <widget class="QCheckBox" name="showAxesCheckbox">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Show axes</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QCheckBox" name="showAxesLabelsCheckbox">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Show axes labels</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QCheckBox" name="showRegionsCheckbox">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Show regions</string>
-                     </property>
-                     <property name="checked">
-                      <bool>true</bool>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="spacer4_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>160</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="QWidget" name="colorTab">
-        <attribute name="title">
-         <string>Colors</string>
-        </attribute>
-        <widget class="QWidget" name="horizontalLayoutWidget_3">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>651</width>
-           <height>511</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_7">
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_8">
-            <item>
-             <widget class="QGroupBox" name="groupBox20">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Materials</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout">
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout">
-                   <item>
-                    <widget class="QComboBox" name="materialCB">
-                     <property name="minimumSize">
-                      <size>
-                       <width>120</width>
-                       <height>0</height>
-                      </size>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="pickColor">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Color...</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="groupBox19">
-                   <property name="title">
-                    <string>Transparency</string>
-                   </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="QSlider" name="transparency">
-                      <property name="maximum">
-                       <number>255</number>
-                      </property>
-                      <property name="value">
-                       <number>255</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>25</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_2">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>170</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>General</string>
-              </property>
-              <widget class="QWidget" name="verticalLayoutWidget_3">
-               <property name="geometry">
-                <rect>
-                 <x>19</x>
-                 <y>30</y>
-                 <width>291</width>
-                 <height>134</height>
-                </rect>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_11">
-                <item>
-                 <widget class="QPushButton" name="cBackgroundButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Background</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="cTextButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Text</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="cAxisButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Axis</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_9">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_15">
-            <property name="leftMargin">
+           <widget class="QTabWidget" name="tabWidget">
+            <property name="currentIndex">
              <number>0</number>
             </property>
-            <item>
-             <widget class="QGroupBox" name="groupBox_3">
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>200</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Particle tracks</string>
-              </property>
-              <widget class="QWidget" name="verticalLayoutWidget_2">
-               <property name="geometry">
-                <rect>
-                 <x>19</x>
-                 <y>29</y>
-                 <width>291</width>
-                 <height>166</height>
-                </rect>
-               </property>
-               <layout class="QVBoxLayout" name="verticalLayout_10">
+            <widget class="QWidget" name="displayTab">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <attribute name="title">
+              <string>Display</string>
+             </attribute>
+             <layout class="QVBoxLayout" name="verticalLayout_7" stretch="1">
+              <item>
+               <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
+                <property name="sizeConstraint">
+                 <enum>QLayout::SetDefaultConstraint</enum>
+                </property>
                 <item>
-                 <widget class="QPushButton" name="cPhotonsButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Photons</string>
-                  </property>
-                 </widget>
+                 <layout class="QVBoxLayout" name="clipLayout"/>
                 </item>
                 <item>
-                 <widget class="QPushButton" name="cElectronsButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Electrons</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="cPositronsButton">
-                  <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                   </sizepolicy>
-                  </property>
-                  <property name="minimumSize">
-                   <size>
-                    <width>200</width>
-                    <height>30</height>
-                   </size>
-                  </property>
-                  <property name="text">
-                   <string>Positrons</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QCheckBox" name="energyScalingCheckbox">
-                  <property name="text">
-                   <string>Energy-dependent transparency</string>
-                  </property>
-                  <property name="checked">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </widget>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_10">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="QWidget" name="regionTab">
-        <attribute name="title">
-         <string>Regions</string>
-        </attribute>
-        <widget class="QWidget" name="horizontalLayoutWidget_2">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>651</width>
-           <height>511</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_6">
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_6">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <spacer name="verticalSpacer_7">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QPushButton" name="regionCheckAllButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Check all</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="regionUncheckAllButton">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>30</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Uncheck all</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <spacer name="horizontalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>40</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_8">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_14">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <widget class="QTableWidget" name="regionTable">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>332</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="sortingEnabled">
-               <bool>true</bool>
-              </property>
-              <property name="rowCount">
-               <number>1</number>
-              </property>
-              <property name="columnCount">
-               <number>4</number>
-              </property>
-              <attribute name="horizontalHeaderStretchLastSection">
-               <bool>true</bool>
-              </attribute>
-              <attribute name="verticalHeaderVisible">
-               <bool>false</bool>
-              </attribute>
-              <attribute name="verticalHeaderHighlightSections">
-               <bool>true</bool>
-              </attribute>
-              <row/>
-              <column>
-               <property name="text">
-                <string>Region</string>
-               </property>
-              </column>
-              <column>
-               <property name="text">
-                <string/>
-               </property>
-              </column>
-              <column>
-               <property name="text">
-                <string>Material</string>
-               </property>
-              </column>
-              <column>
-               <property name="text">
-                <string/>
-               </property>
-              </column>
-              <item row="0" column="1">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="background">
-                <brush brushstyle="SolidPattern">
-                 <color alpha="255">
-                  <red>80</red>
-                  <green>24</green>
-                  <blue>100</blue>
-                 </color>
-                </brush>
-               </property>
-               <property name="foreground">
-                <brush brushstyle="NoBrush">
-                 <color alpha="255">
-                  <red>90</red>
-                  <green>90</green>
-                  <blue>200</blue>
-                 </color>
-                </brush>
-               </property>
-              </item>
-              <item row="0" column="3">
-               <property name="text">
-                <string/>
-               </property>
-               <property name="background">
-                <brush brushstyle="SolidPattern">
-                 <color alpha="255">
-                  <red>186</red>
-                  <green>189</green>
-                  <blue>182</blue>
-                 </color>
-                </brush>
-               </property>
-               <property name="checkState">
-                <enum>Checked</enum>
-               </property>
-              </item>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer_3">
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>40</width>
-              <height>20</height>
-             </size>
-            </property>
-           </spacer>
-          </item>
-         </layout>
-        </widget>
-       </widget>
-       <widget class="QWidget" name="cameraTab">
-        <attribute name="title">
-         <string>Camera</string>
-        </attribute>
-        <widget class="QWidget" name="horizontalLayoutWidget">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>651</width>
-           <height>511</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_12">
-            <item>
-             <spacer name="verticalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>11</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>120</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Camera presets</string>
-              </property>
-              <widget class="QWidget" name="layoutWidget">
-               <property name="geometry">
-                <rect>
-                 <x>10</x>
-                 <y>30</y>
-                 <width>292</width>
-                 <height>81</height>
-                </rect>
-               </property>
-               <layout class="QHBoxLayout" name="presetsLayout">
-                <item>
-                 <layout class="QVBoxLayout" name="axisLayout">
-                  <property name="spacing">
-                   <number>20</number>
-                  </property>
+                 <layout class="QVBoxLayout" name="verticalLayout_4">
                   <item>
-                   <layout class="QHBoxLayout" name="axisPosLayout">
-                    <item>
-                     <widget class="QPushButton" name="xButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>x</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="yButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>y</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="zButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>z</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                   <spacer name="verticalSpacer_3">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>10</width>
+                      <height>11</height>
+                     </size>
+                    </property>
+                   </spacer>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout" name="axisNegLayout">
-                    <item>
-                     <widget class="QPushButton" name="mxButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- x</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="myButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- y</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="mzButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- z</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
+                   <widget class="QGroupBox" name="groupBox10">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="title">
+                     <string>Particle tracks</string>
+                    </property>
+                    <layout class="QGridLayout">
+                     <item row="0" column="0">
+                      <widget class="QCheckBox" name="showTracksCheckbox">
+                       <property name="text">
+                        <string>Show tracks</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QCheckBox" name="showPhotonsCheckbox">
+                       <property name="text">
+                        <string>Photons</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QCheckBox" name="showElectronsCheckbox">
+                       <property name="text">
+                        <string>Electrons</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QCheckBox" name="showPositronsCheckbox">
+                       <property name="text">
+                        <string>Positrons</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="2">
+                      <widget class="QPushButton" name="loadTracks">
+                       <property name="text">
+                        <string>Load tracks</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox15">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="baseSize">
+                     <size>
+                      <width>331</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="title">
+                     <string>Overlay</string>
+                    </property>
+                    <layout class="QHBoxLayout">
+                     <item>
+                      <layout class="QVBoxLayout">
+                       <item>
+                        <layout class="QVBoxLayout">
+                         <item>
+                          <widget class="QCheckBox" name="showAxesCheckbox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Show axes</string>
+                           </property>
+                           <property name="checked">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QCheckBox" name="showAxesLabelsCheckbox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Show axes labels</string>
+                           </property>
+                           <property name="checked">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QCheckBox" name="showRegionsCheckbox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Show regions</string>
+                           </property>
+                           <property name="checked">
+                            <bool>true</bool>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
+                   <spacer name="spacer4_2">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>160</height>
+                     </size>
+                    </property>
+                   </spacer>
                   </item>
                  </layout>
                 </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="colorTab">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <attribute name="title">
+              <string>Colors</string>
+             </attribute>
+             <layout class="QHBoxLayout" name="horizontalLayout_7" stretch="1,1">
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_8">
                 <item>
-                 <spacer name="horizontalSpacer_4">
+                 <spacer name="verticalSpacer_11">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>11</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox20">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Materials</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_2">
+                   <item>
+                    <layout class="QVBoxLayout" name="verticalLayout">
+                     <item>
+                      <layout class="QHBoxLayout" name="horizontalLayout">
+                       <item>
+                        <widget class="QComboBox" name="materialCB">
+                         <property name="minimumSize">
+                          <size>
+                           <width>120</width>
+                           <height>0</height>
+                          </size>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="pickColor">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="text">
+                          <string>Color...</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <widget class="QGroupBox" name="groupBox19">
+                       <property name="title">
+                        <string>Transparency</string>
+                       </property>
+                       <layout class="QHBoxLayout" name="horizontalLayout_2">
+                        <item>
+                         <widget class="QSlider" name="transparency">
+                          <property name="maximum">
+                           <number>255</number>
+                          </property>
+                          <property name="value">
+                           <number>255</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>25</number>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_2">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>170</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>General</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_10">
+                   <item>
+                    <layout class="QVBoxLayout" name="verticalLayout_11">
+                     <item>
+                      <widget class="QPushButton" name="cBackgroundButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Background</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="cTextButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Text</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="cAxisButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Axis</string>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_9">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_15">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="verticalSpacer_12">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>11</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_3">
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>200</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Particle tracks</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_11">
+                   <item>
+                    <layout class="QVBoxLayout" name="verticalLayout_10">
+                     <item>
+                      <widget class="QPushButton" name="cPhotonsButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Photons</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="cElectronsButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Electrons</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QPushButton" name="cPositronsButton">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>200</width>
+                         <height>30</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Positrons</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QCheckBox" name="energyScalingCheckbox">
+                       <property name="text">
+                        <string>Energy-dependent transparency</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_10">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_5">
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
                   <property name="sizeHint" stdset="0">
                    <size>
+                    <width>40</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="regionTab">
+             <attribute name="title">
+              <string>Regions</string>
+             </attribute>
+             <layout class="QHBoxLayout" name="horizontalLayout_6">
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_6" stretch="1,1,0,0,0">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="verticalSpacer_7">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
                     <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="regionCheckAllButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Check all</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="regionUncheckAllButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Uncheck all</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_2">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>40</width>
                     <height>20</height>
                    </size>
                   </property>
                  </spacer>
                 </item>
                 <item>
-                 <layout class="QVBoxLayout" name="setHomeLayout">
-                  <property name="spacing">
-                   <number>20</number>
+                 <spacer name="verticalSpacer_8">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
                   </property>
-                  <item>
-                   <widget class="QPushButton" name="homeButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>90</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>Home</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="setHomeButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>90</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>Set Home</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
                 </item>
                </layout>
-              </widget>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox9">
-              <property name="title">
-               <string>Camera position [cm]</string>
-              </property>
-              <layout class="QHBoxLayout">
-               <item>
-                <widget class="QLineEdit" name="lookX"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lookY"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lookZ"/>
-               </item>
-               <item>
-                <spacer name="spacer4">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>16</width>
-                   <height>21</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="applyLook">
-                 <property name="text">
-                  <string>Apply</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox_4">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>220</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Controls</string>
-              </property>
-              <widget class="QTextBrowser" name="textBrowser">
-               <property name="geometry">
-                <rect>
-                 <x>10</x>
-                 <y>30</y>
-                 <width>256</width>
-                 <height>181</height>
-                </rect>
-               </property>
-               <property name="html">
-                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_14">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <widget class="QTableWidget" name="regionTable">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>332</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="sortingEnabled">
+                   <bool>true</bool>
+                  </property>
+                  <property name="rowCount">
+                   <number>1</number>
+                  </property>
+                  <property name="columnCount">
+                   <number>4</number>
+                  </property>
+                  <attribute name="horizontalHeaderStretchLastSection">
+                   <bool>true</bool>
+                  </attribute>
+                  <attribute name="verticalHeaderVisible">
+                   <bool>false</bool>
+                  </attribute>
+                  <attribute name="verticalHeaderHighlightSections">
+                   <bool>true</bool>
+                  </attribute>
+                  <row/>
+                  <column>
+                   <property name="text">
+                    <string>Region</string>
+                   </property>
+                  </column>
+                  <column>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </column>
+                  <column>
+                   <property name="text">
+                    <string>Material</string>
+                   </property>
+                  </column>
+                  <column>
+                   <property name="text">
+                    <string/>
+                   </property>
+                  </column>
+                  <item row="0" column="1">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="background">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>80</red>
+                      <green>24</green>
+                      <blue>100</blue>
+                     </color>
+                    </brush>
+                   </property>
+                   <property name="foreground">
+                    <brush brushstyle="NoBrush">
+                     <color alpha="255">
+                      <red>90</red>
+                      <green>90</green>
+                      <blue>200</blue>
+                     </color>
+                    </brush>
+                   </property>
+                  </item>
+                  <item row="0" column="3">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="background">
+                    <brush brushstyle="SolidPattern">
+                     <color alpha="255">
+                      <red>186</red>
+                      <green>189</green>
+                      <blue>182</blue>
+                     </color>
+                    </brush>
+                   </property>
+                   <property name="checkState">
+                    <enum>Checked</enum>
+                   </property>
+                  </item>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <spacer name="horizontalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="cameraTab">
+             <attribute name="title">
+              <string>Camera</string>
+             </attribute>
+             <layout class="QHBoxLayout" name="horizontalLayout_5">
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_12">
+                <item>
+                 <spacer name="verticalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>11</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>120</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Camera presets</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_13">
+                   <item>
+                    <layout class="QHBoxLayout" name="presetsLayout" stretch="1,1,1">
+                     <item>
+                      <layout class="QVBoxLayout" name="axisLayout">
+                       <property name="spacing">
+                        <number>20</number>
+                       </property>
+                       <item>
+                        <layout class="QHBoxLayout" name="axisPosLayout" stretch="1,1,1">
+                         <item>
+                          <widget class="QPushButton" name="xButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>x</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="yButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>y</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="zButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>z</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                       <item>
+                        <layout class="QHBoxLayout" name="axisNegLayout" stretch="1,1,1">
+                         <item>
+                          <widget class="QPushButton" name="mxButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>- x</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="myButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>- y</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                         <item>
+                          <widget class="QPushButton" name="mzButton">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>50</width>
+                             <height>20</height>
+                            </size>
+                           </property>
+                           <property name="text">
+                            <string>- z</string>
+                           </property>
+                           <property name="shortcut">
+                            <string/>
+                           </property>
+                          </widget>
+                         </item>
+                        </layout>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <spacer name="horizontalSpacer_4">
+                       <property name="orientation">
+                        <enum>Qt::Horizontal</enum>
+                       </property>
+                       <property name="sizeHint" stdset="0">
+                        <size>
+                         <width>20</width>
+                         <height>20</height>
+                        </size>
+                       </property>
+                      </spacer>
+                     </item>
+                     <item>
+                      <layout class="QVBoxLayout" name="setHomeLayout">
+                       <property name="spacing">
+                        <number>20</number>
+                       </property>
+                       <item>
+                        <widget class="QPushButton" name="homeButton">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>90</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                         <property name="text">
+                          <string>Home</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item>
+                        <widget class="QPushButton" name="setHomeButton">
+                         <property name="sizePolicy">
+                          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                           <horstretch>0</horstretch>
+                           <verstretch>0</verstretch>
+                          </sizepolicy>
+                         </property>
+                         <property name="minimumSize">
+                          <size>
+                           <width>90</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                         <property name="text">
+                          <string>Set Home</string>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_6">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox9">
+                  <property name="title">
+                   <string>Camera position [cm]</string>
+                  </property>
+                  <layout class="QHBoxLayout">
+                   <item>
+                    <widget class="QLineEdit" name="lookX"/>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="lookY"/>
+                   </item>
+                   <item>
+                    <widget class="QLineEdit" name="lookZ"/>
+                   </item>
+                   <item>
+                    <spacer name="spacer4">
+                     <property name="orientation">
+                      <enum>Qt::Horizontal</enum>
+                     </property>
+                     <property name="sizeType">
+                      <enum>QSizePolicy::Expanding</enum>
+                     </property>
+                     <property name="sizeHint" stdset="0">
+                      <size>
+                       <width>16</width>
+                       <height>21</height>
+                      </size>
+                     </property>
+                    </spacer>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="applyLook">
+                     <property name="text">
+                      <string>Apply</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>10</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox_4">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>0</width>
+                    <height>220</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Controls</string>
+                  </property>
+                  <layout class="QHBoxLayout" name="horizontalLayout_12">
+                   <item>
+                    <widget class="QTextBrowser" name="controlsText">
+                     <property name="html">
+                      <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
@@ -1198,253 +1241,293 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at X: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;x&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Y:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; y&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Z:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-               </property>
-              </widget>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <spacer name="verticalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>11</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox18">
-              <property name="minimumSize">
-               <size>
-                <width>329</width>
-                <height>291</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>329</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Lighting</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_5">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                 <item>
-                  <widget class="QCheckBox" name="moveLight">
-                   <property name="minimumSize">
-                    <size>
-                     <width>311</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>311</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>Move Light with viewer</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="lightPosGroup">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>315</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Light position</string>
-                   </property>
-                   <layout class="QHBoxLayout">
-                    <item>
-                     <widget class="QLineEdit" name="lightX"/>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="lightY"/>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="lightZ"/>
-                    </item>
-                    <item>
-                     <spacer name="spacer6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Expanding</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>16</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="applyLight">
-                      <property name="text">
-                       <string>Apply</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="groupBox17">
-                   <property name="minimumSize">
-                    <size>
-                     <width>301</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>301</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Ambient light</string>
-                   </property>
-                   <layout class="QHBoxLayout">
-                    <item>
-                     <widget class="QSlider" name="ambientLight">
-                      <property name="maximum">
-                       <number>100</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>10</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="verticalSpacer_5">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Fixed</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>11</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QGroupBox" name="groupBox18">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>329</width>
+                    <height>291</height>
+                   </size>
+                  </property>
+                  <property name="title">
+                   <string>Lighting</string>
+                  </property>
+                  <layout class="QVBoxLayout" name="verticalLayout_5">
+                   <item>
+                    <layout class="QVBoxLayout" name="verticalLayout_3">
+                     <item>
+                      <widget class="QCheckBox" name="moveLight">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>311</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                       <property name="text">
+                        <string>Move Light with viewer</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QGroupBox" name="lightPosGroup">
+                       <property name="enabled">
+                        <bool>false</bool>
+                       </property>
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="title">
+                        <string>Light position</string>
+                       </property>
+                       <layout class="QHBoxLayout">
+                        <item>
+                         <widget class="QLineEdit" name="lightX"/>
+                        </item>
+                        <item>
+                         <widget class="QLineEdit" name="lightY"/>
+                        </item>
+                        <item>
+                         <widget class="QLineEdit" name="lightZ"/>
+                        </item>
+                        <item>
+                         <spacer name="spacer6">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeType">
+                           <enum>QSizePolicy::Expanding</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>16</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item>
+                         <widget class="QPushButton" name="applyLight">
+                          <property name="text">
+                           <string>Apply</string>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QGroupBox" name="groupBox17">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                       <property name="minimumSize">
+                        <size>
+                         <width>301</width>
+                         <height>0</height>
+                        </size>
+                       </property>
+                       <property name="title">
+                        <string>Ambient light</string>
+                       </property>
+                       <layout class="QHBoxLayout">
+                        <item>
+                         <widget class="QSlider" name="ambientLight">
+                          <property name="maximum">
+                           <number>100</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>10</number>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                    </layout>
+                   </item>
+                  </layout>
+                 </widget>
+                </item>
+                <item>
+                 <spacer name="verticalSpacer_2">
+                  <property name="orientation">
+                   <enum>Qt::Vertical</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>40</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+           </widget>
           </item>
          </layout>
         </widget>
        </widget>
-      </widget>
-     </item>
-     <item>
-      <layout class="QHBoxLayout">
-       <item>
-        <widget class="QPushButton" name="loadButton">
-         <property name="text">
-          <string>Load input</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="reloadButton">
-         <property name="text">
-          <string>Reload</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="pushButton5">
-         <property name="text">
-          <string>Save image</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout">
-         <item>
-          <widget class="QPushButton" name="loadConfigButton">
-           <property name="text">
-            <string>Load config</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="saveConfigButton">
-           <property name="text">
-            <string>Save config</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="pushButton6">
-           <property name="text">
-            <string>Close</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-  </layout>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+  <widget class="QMenuBar" name="menuBar">
+   <property name="geometry">
+    <rect>
+     <x>0</x>
+     <y>0</y>
+     <width>675</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <widget class="QMenu" name="menuFile">
+    <property name="title">
+     <string>&amp;File</string>
+    </property>
+    <addaction name="actionOpen"/>
+    <addaction name="actionOpen_settings"/>
+    <addaction name="separator"/>
+    <addaction name="actionSave_image"/>
+    <addaction name="actionSave_settings"/>
+    <addaction name="separator"/>
+    <addaction name="actionReload"/>
+    <addaction name="separator"/>
+    <addaction name="actionQuit"/>
+   </widget>
+   <widget class="QMenu" name="menu_Options">
+    <property name="title">
+     <string>&amp;Options</string>
+    </property>
+    <addaction name="action_Enlarge_font"/>
+    <addaction name="action_Shrink_font"/>
+   </widget>
+   <addaction name="menuFile"/>
+   <addaction name="menu_Options"/>
+  </widget>
+  <action name="actionOpen">
+   <property name="text">
+    <string>&amp;Open...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+O</string>
+   </property>
+  </action>
+  <action name="actionOpen_settings">
+   <property name="text">
+    <string>Open se&amp;ttings...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+T</string>
+   </property>
+  </action>
+  <action name="actionSave_image">
+   <property name="text">
+    <string>Save &amp;image...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+I</string>
+   </property>
+  </action>
+  <action name="actionSave_settings">
+   <property name="text">
+    <string>&amp;Save settings...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
+   </property>
+  </action>
+  <action name="actionReload">
+   <property name="text">
+    <string>&amp;Reload</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+R</string>
+   </property>
+  </action>
+  <action name="actionQuit">
+   <property name="text">
+    <string>&amp;Quit</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
+  </action>
+  <action name="action_Enlarge_font">
+   <property name="text">
+    <string>&amp;Enlarge font</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+=</string>
+   </property>
+  </action>
+  <action name="action_Shrink_font">
+   <property name="text">
+    <string>&amp;Shrink font</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+-</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <includes>
@@ -1535,14 +1618,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>pushButton6</sender>
-   <signal>clicked()</signal>
+   <sender>actionQuit</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>quitApplication()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1551,14 +1634,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>pushButton5</sender>
-   <signal>clicked()</signal>
+   <sender>actionSave_image</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>saveImage()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1759,14 +1842,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>reloadButton</sender>
-   <signal>clicked()</signal>
+   <sender>actionReload</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>reloadInput()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1775,14 +1858,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>loadButton</sender>
-   <signal>clicked()</signal>
+   <sender>actionOpen</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>selectInput()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1791,14 +1874,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>loadConfigButton</sender>
-   <signal>clicked()</signal>
+   <sender>actionOpen_settings</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>loadConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -1807,14 +1890,14 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>saveConfigButton</sender>
-   <signal>clicked()</signal>
+   <sender>actionSave_settings</sender>
+   <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>saveConfig()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>
@@ -2135,6 +2218,38 @@ p, li { white-space: pre-wrap; }
     <hint type="sourcelabel">
      <x>20</x>
      <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_Enlarge_font</sender>
+   <signal>triggered()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>enlargeFont()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>action_Shrink_font</sender>
+   <signal>triggered()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>shrinkFont()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
     </hint>
     <hint type="destinationlabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -135,7 +135,36 @@
                  <enum>QLayout::SetDefaultConstraint</enum>
                 </property>
                 <item>
-                 <layout class="QVBoxLayout" name="clipLayout"/>
+                 <layout class="QVBoxLayout" name="clipLayout">
+                  <item>
+                   <spacer name="verticalSpacer_2">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeType">
+                     <enum>QSizePolicy::Fixed</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>11</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                  <item>
+                   <widget class="QGroupBox" name="groupBox_5">
+                    <property name="title">
+                     <string>Simulation geometry</string>
+                    </property>
+                    <layout class="QHBoxLayout" name="horizontalLayout_14">
+                     <item>
+                      <widget class="QComboBox" name="comboBox_simGeom"/>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                 <item>
                  <layout class="QVBoxLayout" name="verticalLayout_4">
@@ -179,37 +208,17 @@
                      <string>Particle tracks</string>
                     </property>
                     <layout class="QGridLayout">
-                     <item row="0" column="0">
-                      <widget class="QCheckBox" name="showTracksCheckbox">
-                       <property name="text">
-                        <string>Show tracks</string>
+                     <item row="0" column="2">
+                      <widget class="QSpinBox" name="spin_tmaxp">
+                       <property name="minimum">
+                        <number>1</number>
                        </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QCheckBox" name="showPhotonsCheckbox">
-                       <property name="text">
-                        <string>Photons</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
+                       <property name="value">
+                        <number>1</number>
                        </property>
                       </widget>
                      </item>
-                     <item row="1" column="1">
-                      <widget class="QCheckBox" name="showElectronsCheckbox">
-                       <property name="text">
-                        <string>Electrons</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
+                     <item row="2" column="0">
                       <widget class="QCheckBox" name="showPositronsCheckbox">
                        <property name="text">
                         <string>Positrons</string>
@@ -219,10 +228,73 @@
                        </property>
                       </widget>
                      </item>
-                     <item row="0" column="2">
-                      <widget class="QPushButton" name="loadTracks">
+                     <item row="0" column="0">
+                      <widget class="QCheckBox" name="showPhotonsCheckbox">
                        <property name="text">
-                        <string>Load tracks</string>
+                        <string>Photons</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="0">
+                      <widget class="QCheckBox" name="showElectronsCheckbox">
+                       <property name="text">
+                        <string>Electrons</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="1">
+                      <widget class="QSpinBox" name="spin_tminp">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QSpinBox" name="spin_tmine">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QSpinBox" name="spin_tmaxe">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="1">
+                      <widget class="QSpinBox" name="spin_tminpo">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="2" column="2">
+                      <widget class="QSpinBox" name="spin_tmaxpo">
+                       <property name="minimum">
+                        <number>1</number>
+                       </property>
+                       <property name="value">
+                        <number>1</number>
                        </property>
                       </widget>
                      </item>
@@ -243,12 +315,6 @@
                       <height>120</height>
                      </size>
                     </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
                     <property name="baseSize">
                      <size>
                       <width>331</width>
@@ -264,7 +330,7 @@
                        <item>
                         <widget class="QCheckBox" name="showAxesCheckbox">
                          <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
@@ -280,7 +346,7 @@
                        <item>
                         <widget class="QCheckBox" name="showAxesLabelsCheckbox">
                          <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
@@ -296,7 +362,7 @@
                        <item>
                         <widget class="QCheckBox" name="showRegionsCheckbox">
                          <property name="sizePolicy">
-                          <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                          <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
                            <horstretch>0</horstretch>
                            <verstretch>0</verstretch>
                           </sizepolicy>
@@ -321,12 +387,6 @@
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>140</height>
-                     </size>
                     </property>
                     <property name="toolTip">
                      <string>Use egs_dose_scoring to output a dose file</string>
@@ -371,14 +431,6 @@
                           <bool>true</bool>
                          </property>
                          <widget class="QWidget" name="scrollAreaWidgetContents">
-                          <property name="geometry">
-                           <rect>
-                            <x>0</x>
-                            <y>0</y>
-                            <width>294</width>
-                            <height>103</height>
-                           </rect>
-                          </property>
                           <layout class="QVBoxLayout" name="verticalLayout_16">
                            <item>
                             <layout class="QVBoxLayout" name="verticalLayout_dose">
@@ -405,22 +457,6 @@
                      </item>
                     </layout>
                    </widget>
-                  </item>
-                  <item>
-                   <spacer name="spacer4_2">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeType">
-                     <enum>QSizePolicy::Fixed</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>10</height>
-                     </size>
-                    </property>
-                   </spacer>
                   </item>
                  </layout>
                 </item>
@@ -1645,6 +1681,8 @@ p, li { white-space: pre-wrap; }
      <string>&amp;File</string>
     </property>
     <addaction name="actionOpen"/>
+    <addaction name="actionOpen_tracks"/>
+    <addaction name="actionOpen_dose"/>
     <addaction name="actionOpen_settings"/>
     <addaction name="separator"/>
     <addaction name="actionSave_image"/>
@@ -1728,6 +1766,22 @@ p, li { white-space: pre-wrap; }
     <string>Ctrl+-</string>
    </property>
   </action>
+  <action name="actionOpen_dose">
+   <property name="text">
+    <string>Open &amp;dose...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+D</string>
+   </property>
+  </action>
+  <action name="actionOpen_tracks">
+   <property name="text">
+    <string>Open trac&amp;ks...</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+K</string>
+   </property>
+  </action>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <includes>
@@ -1806,22 +1860,6 @@ p, li { white-space: pre-wrap; }
    <signal>clicked()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>showAllRegions()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>loadTracks</sender>
-   <signal>clicked()</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>loadTracksDialog()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>
@@ -2042,22 +2080,6 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
-   <sender>showTracksCheckbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>checkboxShowTracks(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>actionReload</sender>
    <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
@@ -2078,6 +2100,38 @@ p, li { white-space: pre-wrap; }
    <signal>triggered()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>selectInput()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionOpen_tracks</sender>
+   <signal>triggered()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>loadTracksDialog()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>actionOpen_dose</sender>
+   <signal>triggered()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>loadDose()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>-1</x>
@@ -2222,6 +2276,118 @@ p, li { white-space: pre-wrap; }
    <signal>valueChanged(int)</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>changeDoseTransparency(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tminp</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMin()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tmine</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMin()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tminpo</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMin()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tmaxp</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMaxP(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tmaxe</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMaxE(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>spin_tmaxpo</sender>
+   <signal>valueChanged(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>changeTrackMaxPo(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>comboBox_simGeom</sender>
+   <signal>activated(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>updateSimulationGeometry(int)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -287,6 +287,17 @@
          </property>
         </spacer>
        </item>
+       <item>
+        <layout class="QHBoxLayout">
+         <item>
+          <widget class="QPushButton" name="loadButton">
+           <property name="text">
+            <string>Load input</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </item>
      <item>
@@ -951,6 +962,22 @@
    </hints>
   </connection>
   <connection>
+   <sender>loadButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>selectInput()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>showPhotonsCheckbox</sender>
    <signal>toggled(bool)</signal>
    <receiver>GeometryViewControl</receiver>
@@ -1015,7 +1042,7 @@
    </hints>
   </connection>
   <connection>
-   <sender>transparancy</sender>
+   <sender>transparency</sender>
    <signal>sliderReleased()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>endTransformation()</slot>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -99,86 +99,6 @@
              </spacer>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox20">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Materials</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_2">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout">
-                 <item>
-                  <layout class="QHBoxLayout" name="horizontalLayout">
-                   <item>
-                    <widget class="QComboBox" name="materialCB">
-                     <property name="minimumSize">
-                      <size>
-                       <width>120</width>
-                       <height>0</height>
-                      </size>
-                     </property>
-                    </widget>
-                   </item>
-                   <item>
-                    <widget class="QPushButton" name="pickColor">
-                     <property name="sizePolicy">
-                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                       <horstretch>0</horstretch>
-                       <verstretch>0</verstretch>
-                      </sizepolicy>
-                     </property>
-                     <property name="text">
-                      <string>Color...</string>
-                     </property>
-                    </widget>
-                   </item>
-                  </layout>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="groupBox19">
-                   <property name="title">
-                    <string>Transparency</string>
-                   </property>
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="QSlider" name="transparency">
-                      <property name="maximum">
-                       <number>255</number>
-                      </property>
-                      <property name="value">
-                       <number>255</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>25</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
              <widget class="QGroupBox" name="groupBox10">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -196,40 +116,20 @@
                <string>Particle tracks</string>
               </property>
               <layout class="QGridLayout">
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="showPhotonsCheckbox">
-                 <property name="text">
-                  <string>Photons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="showPositronsCheckbox">
-                 <property name="text">
-                  <string>Positrons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
                <item row="0" column="0">
                 <widget class="QCheckBox" name="showTracksCheckbox">
                  <property name="text">
                   <string>Show tracks</string>
                  </property>
                  <property name="checked">
-                  <bool>false</bool>
+                  <bool>true</bool>
                  </property>
                 </widget>
                </item>
-               <item row="2" column="1">
-                <widget class="QCheckBox" name="showOthersCheckbox">
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="showPhotonsCheckbox">
                  <property name="text">
-                  <string>Other</string>
+                  <string>Photons</string>
                  </property>
                  <property name="checked">
                   <bool>true</bool>
@@ -246,7 +146,17 @@
                  </property>
                 </widget>
                </item>
-               <item row="0" column="1">
+               <item row="1" column="2">
+                <widget class="QCheckBox" name="showPositronsCheckbox">
+                 <property name="text">
+                  <string>Positrons</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
                 <widget class="QPushButton" name="loadTracks">
                  <property name="text">
                   <string>Load tracks</string>
@@ -356,7 +266,7 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>40</height>
+                <height>160</height>
                </size>
               </property>
              </spacer>
@@ -873,6 +783,327 @@
                <size>
                 <width>20</width>
                 <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="colorTab">
+        <attribute name="title">
+         <string>Colors</string>
+        </attribute>
+        <widget class="QWidget" name="horizontalLayoutWidget_3">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>651</width>
+           <height>511</height>
+          </rect>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_7">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_8">
+            <item>
+             <widget class="QGroupBox" name="groupBox20">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>16777215</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Materials</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout">
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout">
+                   <item>
+                    <widget class="QComboBox" name="materialCB">
+                     <property name="minimumSize">
+                      <size>
+                       <width>120</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="pickColor">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>Color...</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="groupBox19">
+                   <property name="title">
+                    <string>Transparency</string>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QSlider" name="transparency">
+                      <property name="maximum">
+                       <number>255</number>
+                      </property>
+                      <property name="value">
+                       <number>255</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="tickPosition">
+                       <enum>QSlider::TicksBelow</enum>
+                      </property>
+                      <property name="tickInterval">
+                       <number>25</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_2">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>170</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>General</string>
+              </property>
+              <widget class="QWidget" name="verticalLayoutWidget_3">
+               <property name="geometry">
+                <rect>
+                 <x>19</x>
+                 <y>30</y>
+                 <width>291</width>
+                 <height>134</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_11">
+                <item>
+                 <widget class="QPushButton" name="cBackgroundButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Background</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="cTextButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Text</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="cAxisButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Axis</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_9">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_15">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="groupBox_3">
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>200</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Particle tracks</string>
+              </property>
+              <widget class="QWidget" name="verticalLayoutWidget_2">
+               <property name="geometry">
+                <rect>
+                 <x>19</x>
+                 <y>29</y>
+                 <width>291</width>
+                 <height>166</height>
+                </rect>
+               </property>
+               <layout class="QVBoxLayout" name="verticalLayout_10">
+                <item>
+                 <widget class="QPushButton" name="cPhotonsButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Photons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="cElectronsButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Electrons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="cPositronsButton">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="minimumSize">
+                   <size>
+                    <width>200</width>
+                    <height>30</height>
+                   </size>
+                  </property>
+                  <property name="text">
+                   <string>Positrons</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QCheckBox" name="energyScalingCheckbox">
+                  <property name="text">
+                   <string>Energy-dependent transparency</string>
+                  </property>
+                  <property name="checked">
+                   <bool>true</bool>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_10">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
                </size>
               </property>
              </spacer>
@@ -1595,22 +1826,6 @@
    </hints>
   </connection>
   <connection>
-   <sender>showOthersCheckbox</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>showOthersCheckbox_toggled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>transparency</sender>
    <signal>sliderReleased()</signal>
    <receiver>GeometryViewControl</receiver>
@@ -1759,6 +1974,118 @@
    <signal>activated(int)</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>updateColorLabel(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cBackgroundButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setBackgroundColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cTextButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setTextColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cAxisButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setAxisColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cPhotonsButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setPhotonColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cElectronsButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setElectronColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>cPositronsButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setPositronColor()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>energyScalingCheckbox</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>setEnergyScaling(bool)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -50,7 +50,7 @@
    <string>View Controls</string>
   </property>
   <property name="sizeGripEnabled">
-   <bool>true</bool>
+   <bool>false</bool>
   </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
@@ -60,7 +60,7 @@
        <property name="currentIndex">
         <number>0</number>
        </property>
-       <widget class="QWidget" name="tab">
+       <widget class="QWidget" name="displayTab">
         <attribute name="title">
          <string>Display</string>
         </attribute>
@@ -73,7 +73,10 @@
            <height>511</height>
           </rect>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
+         <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="1,1">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetDefaultConstraint</enum>
+          </property>
           <item>
            <layout class="QVBoxLayout" name="clipLayout"/>
           </item>
@@ -90,16 +93,22 @@
               <property name="sizeHint" stdset="0">
                <size>
                 <width>10</width>
-                <height>12</height>
+                <height>11</height>
                </size>
               </property>
              </spacer>
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox20">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="maximumSize">
                <size>
-                <width>331</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -171,9 +180,15 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox10">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
               <property name="maximumSize">
                <size>
-                <width>331</width>
+                <width>16777215</width>
                 <height>16777215</height>
                </size>
               </property>
@@ -243,10 +258,28 @@
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox15">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>0</height>
+               </size>
+              </property>
               <property name="maximumSize">
                <size>
-                <width>331</width>
+                <width>16777215</width>
                 <height>16777215</height>
+               </size>
+              </property>
+              <property name="baseSize">
+               <size>
+                <width>331</width>
+                <height>0</height>
                </size>
               </property>
               <property name="title">
@@ -259,6 +292,12 @@
                   <layout class="QVBoxLayout">
                    <item>
                     <widget class="QCheckBox" name="showAxesCheckbox">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="text">
                       <string>Show axes</string>
                      </property>
@@ -269,6 +308,12 @@
                    </item>
                    <item>
                     <widget class="QCheckBox" name="showAxesLabelsCheckbox">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="text">
                       <string>Show axes labels</string>
                      </property>
@@ -279,6 +324,12 @@
                    </item>
                    <item>
                     <widget class="QCheckBox" name="showRegionsCheckbox">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
                      <property name="text">
                       <string>Show regions</string>
                      </property>
@@ -300,12 +351,12 @@
                <enum>Qt::Vertical</enum>
               </property>
               <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
+               <enum>QSizePolicy::Fixed</enum>
               </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
-                <height>20</height>
+                <height>40</height>
                </size>
               </property>
              </spacer>
@@ -315,7 +366,7 @@
          </layout>
         </widget>
        </widget>
-       <widget class="QWidget" name="tab_2">
+       <widget class="QWidget" name="cameraTab">
         <attribute name="title">
          <string>Camera</string>
         </attribute>
@@ -332,6 +383,22 @@
           <item>
            <layout class="QVBoxLayout" name="verticalLayout_12">
             <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Minimum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>11</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <widget class="QGroupBox" name="groupBox">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -342,33 +409,42 @@
               <property name="minimumSize">
                <size>
                 <width>0</width>
-                <height>110</height>
+                <height>120</height>
                </size>
               </property>
               <property name="title">
-               <string>Look direction</string>
+               <string>Camera presets</string>
               </property>
-              <widget class="QWidget" name="">
+              <widget class="QWidget" name="layoutWidget">
                <property name="geometry">
                 <rect>
                  <x>10</x>
                  <y>30</y>
-                 <width>291</width>
-                 <height>71</height>
+                 <width>292</width>
+                 <height>81</height>
                 </rect>
                </property>
-               <layout class="QHBoxLayout">
+               <layout class="QHBoxLayout" name="presetsLayout">
                 <item>
-                 <layout class="QVBoxLayout">
+                 <layout class="QVBoxLayout" name="axisLayout">
+                  <property name="spacing">
+                   <number>20</number>
+                  </property>
                   <item>
-                   <layout class="QHBoxLayout">
+                   <layout class="QHBoxLayout" name="axisPosLayout">
                     <item>
                      <widget class="QPushButton" name="xButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>x</string>
@@ -381,10 +457,16 @@
                     <item>
                      <widget class="QPushButton" name="yButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>y</string>
@@ -397,10 +479,16 @@
                     <item>
                      <widget class="QPushButton" name="zButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>z</string>
@@ -413,14 +501,20 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout">
+                   <layout class="QHBoxLayout" name="axisNegLayout">
                     <item>
                      <widget class="QPushButton" name="mxButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>- x</string>
@@ -433,10 +527,16 @@
                     <item>
                      <widget class="QPushButton" name="myButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>- y</string>
@@ -449,10 +549,16 @@
                     <item>
                      <widget class="QPushButton" name="mzButton">
                       <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
                         <horstretch>0</horstretch>
                         <verstretch>0</verstretch>
                        </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
                       </property>
                       <property name="text">
                        <string>- z</string>
@@ -467,9 +573,37 @@
                  </layout>
                 </item>
                 <item>
-                 <layout class="QVBoxLayout">
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="setHomeLayout">
+                  <property name="spacing">
+                   <number>20</number>
+                  </property>
                   <item>
                    <widget class="QPushButton" name="homeButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>90</width>
+                      <height>20</height>
+                     </size>
+                    </property>
                     <property name="text">
                      <string>Home</string>
                     </property>
@@ -477,6 +611,18 @@
                   </item>
                   <item>
                    <widget class="QPushButton" name="setHomeButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>90</width>
+                      <height>20</height>
+                     </size>
+                    </property>
                     <property name="text">
                      <string>Set Home</string>
                     </property>
@@ -487,6 +633,22 @@
                </layout>
               </widget>
              </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox9">
@@ -534,6 +696,9 @@
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
                 <width>20</width>
@@ -545,10 +710,26 @@
            </layout>
           </item>
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0">
+           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
             <property name="leftMargin">
              <number>0</number>
             </property>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Minimum</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>11</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item>
              <widget class="QGroupBox" name="groupBox18">
               <property name="minimumSize">
@@ -701,6 +882,225 @@
          </layout>
         </widget>
        </widget>
+       <widget class="QWidget" name="regionTab">
+        <attribute name="title">
+         <string>Regions</string>
+        </attribute>
+        <widget class="QWidget" name="horizontalLayoutWidget_2">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>651</width>
+           <height>511</height>
+          </rect>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_6">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <spacer name="verticalSpacer_7">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QPushButton" name="regionCheckAllButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Check all</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="regionUncheckAllButton">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>30</height>
+               </size>
+              </property>
+              <property name="text">
+               <string>Uncheck all</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <spacer name="horizontalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>40</width>
+                <height>20</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_8">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_14">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QTableWidget" name="regionTable">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>332</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="sortingEnabled">
+               <bool>true</bool>
+              </property>
+              <property name="rowCount">
+               <number>1</number>
+              </property>
+              <property name="columnCount">
+               <number>4</number>
+              </property>
+              <attribute name="horizontalHeaderStretchLastSection">
+               <bool>true</bool>
+              </attribute>
+              <attribute name="verticalHeaderVisible">
+               <bool>false</bool>
+              </attribute>
+              <attribute name="verticalHeaderHighlightSections">
+               <bool>true</bool>
+              </attribute>
+              <row/>
+              <column>
+               <property name="text">
+                <string>Region</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string/>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string>Material</string>
+               </property>
+              </column>
+              <column>
+               <property name="text">
+                <string/>
+               </property>
+              </column>
+              <item row="0" column="1">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="background">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>80</red>
+                  <green>24</green>
+                  <blue>100</blue>
+                 </color>
+                </brush>
+               </property>
+               <property name="foreground">
+                <brush brushstyle="NoBrush">
+                 <color alpha="255">
+                  <red>90</red>
+                  <green>90</green>
+                  <blue>200</blue>
+                 </color>
+                </brush>
+               </property>
+              </item>
+              <item row="0" column="3">
+               <property name="text">
+                <string/>
+               </property>
+               <property name="background">
+                <brush brushstyle="SolidPattern">
+                 <color alpha="255">
+                  <red>186</red>
+                  <green>189</green>
+                  <blue>182</blue>
+                 </color>
+                </brush>
+               </property>
+               <property name="checkState">
+                <enum>Checked</enum>
+               </property>
+              </item>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
       </widget>
      </item>
      <item>
@@ -783,6 +1183,54 @@
    <signal>clicked()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>setLookAt()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>regionTable</sender>
+   <signal>cellChanged(int,int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>toggleRegion(int,int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>regionUncheckAllButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>hideAllRegions()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>regionCheckAllButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>showAllRegions()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <comment>
 ###############################################################################
@@ -35,162 +36,276 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>694</width>
-    <height>466</height>
+    <width>691</width>
+    <height>614</height>
    </rect>
   </property>
   <property name="maximumSize">
    <size>
     <width>16777215</width>
-    <height>466</height>
+    <height>16777215</height>
    </size>
   </property>
   <property name="windowTitle">
    <string>View Controls</string>
   </property>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
   <layout class="QHBoxLayout" name="horizontalLayout_4">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+    <layout class="QVBoxLayout" name="verticalLayout_7">
      <item>
-      <layout class="QVBoxLayout" name="verticalLayout_6">
-       <item>
-        <widget class="QGroupBox" name="groupBox18">
-         <property name="minimumSize">
-          <size>
-           <width>329</width>
-           <height>291</height>
-          </size>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="tab">
+        <attribute name="title">
+         <string>Display</string>
+        </attribute>
+        <widget class="QWidget" name="layoutWidget">
+         <property name="geometry">
+          <rect>
+           <x>0</x>
+           <y>10</y>
+           <width>661</width>
+           <height>511</height>
+          </rect>
          </property>
-         <property name="maximumSize">
-          <size>
-           <width>329</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Light</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_5">
+         <layout class="QHBoxLayout" name="horizontalLayout_3">
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout_3">
+           <layout class="QVBoxLayout" name="clipLayout"/>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_4">
             <item>
-             <widget class="QCheckBox" name="moveLight">
-              <property name="minimumSize">
-               <size>
-                <width>311</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>311</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="text">
-               <string>Move Light with viewer</string>
-              </property>
-              <property name="checked">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="lightPosGroup">
-              <property name="enabled">
-               <bool>false</bool>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>315</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Light position</string>
-              </property>
-              <layout class="QHBoxLayout">
-               <item>
-                <widget class="QLineEdit" name="lightX"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lightY"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lightZ"/>
-               </item>
-               <item>
-                <spacer name="spacer6">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>16</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="applyLight">
-                 <property name="text">
-                  <string>Apply</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox17">
-              <property name="minimumSize">
-               <size>
-                <width>301</width>
-                <height>0</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>301</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Ambient light</string>
-              </property>
-              <layout class="QHBoxLayout">
-               <item>
-                <widget class="QSlider" name="ambientLight">
-                 <property name="maximum">
-                  <number>100</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="tickPosition">
-                  <enum>QSlider::TicksBelow</enum>
-                 </property>
-                 <property name="tickInterval">
-                  <number>10</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_2">
+             <spacer name="verticalSpacer_3">
               <property name="orientation">
                <enum>Qt::Vertical</enum>
               </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
               <property name="sizeHint" stdset="0">
                <size>
-                <width>17</width>
-                <height>18</height>
+                <width>10</width>
+                <height>12</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox20">
+              <property name="maximumSize">
+               <size>
+                <width>331</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Materials</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_2">
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout">
+                 <item>
+                  <layout class="QHBoxLayout" name="horizontalLayout">
+                   <item>
+                    <widget class="QComboBox" name="materialCB">
+                     <property name="minimumSize">
+                      <size>
+                       <width>120</width>
+                       <height>0</height>
+                      </size>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QPushButton" name="pickColor">
+                     <property name="sizePolicy">
+                      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                       <horstretch>0</horstretch>
+                       <verstretch>0</verstretch>
+                      </sizepolicy>
+                     </property>
+                     <property name="text">
+                      <string>Color...</string>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="groupBox19">
+                   <property name="title">
+                    <string>Transparency</string>
+                   </property>
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QSlider" name="transparency">
+                      <property name="maximum">
+                       <number>255</number>
+                      </property>
+                      <property name="value">
+                       <number>255</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="tickPosition">
+                       <enum>QSlider::TicksBelow</enum>
+                      </property>
+                      <property name="tickInterval">
+                       <number>25</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox10">
+              <property name="maximumSize">
+               <size>
+                <width>331</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Particle tracks</string>
+              </property>
+              <layout class="QGridLayout">
+               <item row="1" column="0">
+                <widget class="QCheckBox" name="showPhotonsCheckbox">
+                 <property name="text">
+                  <string>Photons</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="0">
+                <widget class="QCheckBox" name="showPositronsCheckbox">
+                 <property name="text">
+                  <string>Positrons</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QCheckBox" name="showTracksCheckbox">
+                 <property name="text">
+                  <string>Show tracks</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="2" column="1">
+                <widget class="QCheckBox" name="showOthersCheckbox">
+                 <property name="text">
+                  <string>Other</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="1" column="1">
+                <widget class="QCheckBox" name="showElectronsCheckbox">
+                 <property name="text">
+                  <string>Electrons</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QPushButton" name="loadTracks">
+                 <property name="text">
+                  <string>Load tracks</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox15">
+              <property name="maximumSize">
+               <size>
+                <width>331</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Overlay</string>
+              </property>
+              <layout class="QHBoxLayout">
+               <item>
+                <layout class="QVBoxLayout">
+                 <item>
+                  <layout class="QVBoxLayout">
+                   <item>
+                    <widget class="QCheckBox" name="showAxesCheckbox">
+                     <property name="text">
+                      <string>Show axes</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="showAxesLabelsCheckbox">
+                     <property name="text">
+                      <string>Show axes labels</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                   <item>
+                    <widget class="QCheckBox" name="showRegionsCheckbox">
+                     <property name="text">
+                      <string>Show regions</string>
+                     </property>
+                     <property name="checked">
+                      <bool>true</bool>
+                     </property>
+                    </widget>
+                   </item>
+                  </layout>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="spacer4_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Expanding</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>20</height>
                </size>
               </property>
              </spacer>
@@ -199,257 +314,184 @@
           </item>
          </layout>
         </widget>
-       </item>
-       <item>
-        <widget class="QGroupBox" name="groupBox20">
-         <property name="maximumSize">
-          <size>
-           <width>331</width>
-           <height>16777215</height>
-          </size>
+       </widget>
+       <widget class="QWidget" name="tab_2">
+        <attribute name="title">
+         <string>Camera</string>
+        </attribute>
+        <widget class="QWidget" name="horizontalLayoutWidget">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>651</width>
+           <height>501</height>
+          </rect>
          </property>
-         <property name="title">
-          <string>Material colors</string>
-         </property>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
           <item>
-           <layout class="QVBoxLayout" name="verticalLayout">
+           <layout class="QVBoxLayout" name="verticalLayout_12">
             <item>
-             <layout class="QHBoxLayout" name="horizontalLayout">
-              <item>
-               <widget class="QComboBox" name="materialCB">
-                <property name="minimumSize">
-                 <size>
-                  <width>120</width>
-                  <height>0</height>
-                 </size>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QPushButton" name="pickColor">
-                <property name="sizePolicy">
-                 <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                  <horstretch>0</horstretch>
-                  <verstretch>0</verstretch>
-                 </sizepolicy>
-                </property>
-                <property name="text">
-                 <string>Color...</string>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox19">
-              <property name="title">
-               <string>Transparency</string>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
               </property>
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QSlider" name="transparency">
-                 <property name="maximum">
-                  <number>255</number>
-                 </property>
-                 <property name="value">
-                  <number>255</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="tickPosition">
-                  <enum>QSlider::TicksBelow</enum>
-                 </property>
-                 <property name="tickInterval">
-                  <number>25</number>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>110</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Look direction</string>
+              </property>
+              <widget class="QWidget" name="">
+               <property name="geometry">
+                <rect>
+                 <x>10</x>
+                 <y>30</y>
+                 <width>291</width>
+                 <height>71</height>
+                </rect>
+               </property>
+               <layout class="QHBoxLayout">
+                <item>
+                 <layout class="QVBoxLayout">
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QPushButton" name="xButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>x</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="yButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>y</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="zButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>z</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QPushButton" name="mxButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>- x</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="myButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>- y</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="mzButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="text">
+                       <string>- z</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout">
+                  <item>
+                   <widget class="QPushButton" name="homeButton">
+                    <property name="text">
+                     <string>Home</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="setHomeButton">
+                    <property name="text">
+                     <string>Set Home</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
              </widget>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item>
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>28</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <layout class="QHBoxLayout">
-         <item>
-          <widget class="QPushButton" name="loadButton">
-           <property name="text">
-            <string>Load input</string>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_4">
-       <item>
-        <widget class="QGroupBox" name="groupBox15">
-         <property name="maximumSize">
-          <size>
-           <width>321</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>View</string>
-         </property>
-         <layout class="QHBoxLayout">
-          <item>
-           <layout class="QVBoxLayout">
-            <item>
-             <layout class="QHBoxLayout">
-              <item>
-               <layout class="QVBoxLayout">
-                <item>
-                 <layout class="QHBoxLayout">
-                  <item>
-                   <widget class="QPushButton" name="xButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>x</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="yButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>y</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="zButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>z</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <layout class="QHBoxLayout">
-                  <item>
-                   <widget class="QPushButton" name="mxButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>- x</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="myButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>- y</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="mzButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>- z</string>
-                    </property>
-                    <property name="shortcut">
-                     <string/>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </item>
-              <item>
-               <layout class="QVBoxLayout">
-                <item>
-                 <widget class="QPushButton" name="homeButton">
-                  <property name="text">
-                   <string>Home</string>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QPushButton" name="setHomeButton">
-                  <property name="text">
-                   <string>Set Home</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
-              </item>
-             </layout>
             </item>
             <item>
              <widget class="QGroupBox" name="groupBox9">
               <property name="title">
-               <string>Look at</string>
+               <string>Camera position [cm]</string>
               </property>
               <layout class="QHBoxLayout">
                <item>
@@ -488,147 +530,210 @@
              </widget>
             </item>
             <item>
-             <widget class="QGroupBox" name="groupBox10">
-              <property name="title">
-               <string>Particle Tracks</string>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-              <layout class="QGridLayout">
-               <item row="1" column="0">
-                <widget class="QCheckBox" name="showPhotonsCheckbox">
-                 <property name="text">
-                  <string>Photons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="2" column="0">
-                <widget class="QCheckBox" name="showPositronsCheckbox">
-                 <property name="text">
-                  <string>Positrons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="0">
-                <widget class="QCheckBox" name="showTracksCheckbox">
-                 <property name="text">
-                  <string>Show tracks</string>
-                 </property>
-                 <property name="checked">
-                  <bool>false</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <spacer name="spacer5">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>20</width>
-                   <height>21</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item row="2" column="2">
-                <widget class="QCheckBox" name="showOthersCheckbox">
-                 <property name="text">
-                  <string>Other</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="1" column="2">
-                <widget class="QCheckBox" name="showElectronsCheckbox">
-                 <property name="text">
-                  <string>Electrons</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QPushButton" name="loadTracks">
-                 <property name="text">
-                  <string>Load tracks</string>
-                 </property>
-                </widget>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <widget class="QGroupBox" name="groupBox18">
+              <property name="minimumSize">
+               <size>
+                <width>329</width>
+                <height>291</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>329</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Lighting</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_3">
+                 <item>
+                  <widget class="QCheckBox" name="moveLight">
+                   <property name="minimumSize">
+                    <size>
+                     <width>311</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>311</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Move Light with viewer</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="lightPosGroup">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>315</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="title">
+                    <string>Light position</string>
+                   </property>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLineEdit" name="lightX"/>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="lightY"/>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="lightZ"/>
+                    </item>
+                    <item>
+                     <spacer name="spacer6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Expanding</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>16</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="applyLight">
+                      <property name="text">
+                       <string>Apply</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="groupBox17">
+                   <property name="minimumSize">
+                    <size>
+                     <width>301</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>301</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="title">
+                    <string>Ambient light</string>
+                   </property>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QSlider" name="ambientLight">
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="tickPosition">
+                       <enum>QSlider::TicksBelow</enum>
+                      </property>
+                      <property name="tickInterval">
+                       <number>10</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>
             </item>
             <item>
-             <layout class="QVBoxLayout">
-              <item>
-               <widget class="QCheckBox" name="showAxesCheckbox">
-                <property name="text">
-                 <string>Show axes</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="showAxesLabelsCheckbox">
-                <property name="text">
-                 <string>Show axes labels</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QCheckBox" name="showRegionsCheckbox">
-                <property name="text">
-                 <string>Show regions</string>
-                </property>
-                <property name="checked">
-                 <bool>true</bool>
-                </property>
-               </widget>
-              </item>
-             </layout>
-            </item>
-            <item>
-             <widget class="QPushButton" name="moreButton">
-              <property name="text">
-               <string>Clipping planes...</string>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
               </property>
-              <property name="checkable">
-               <bool>true</bool>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
               </property>
-             </widget>
+             </spacer>
             </item>
            </layout>
           </item>
          </layout>
         </widget>
+       </widget>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout">
+       <item>
+        <widget class="QPushButton" name="loadButton">
+         <property name="text">
+          <string>Load input</string>
+         </property>
+        </widget>
        </item>
        <item>
-        <spacer name="spacer4_2">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
+        <widget class="QPushButton" name="reloadButton">
+         <property name="text">
+          <string>Reload</string>
          </property>
-         <property name="sizeType">
-          <enum>QSizePolicy::Expanding</enum>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="pushButton5">
+         <property name="text">
+          <string>Save image</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>20</width>
+           <width>40</width>
            <height>20</height>
           </size>
          </property>
@@ -637,16 +742,16 @@
        <item>
         <layout class="QHBoxLayout">
          <item>
-          <widget class="QPushButton" name="reloadButton">
+          <widget class="QPushButton" name="loadConfigButton">
            <property name="text">
-            <string>Reload</string>
+            <string>Load config</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="pushButton5">
+          <widget class="QPushButton" name="saveConfigButton">
            <property name="text">
-            <string>Save image</string>
+            <string>Save config</string>
            </property>
           </widget>
          </item>
@@ -726,22 +831,6 @@
    <signal>clicked()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>saveImage()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>moreButton</sender>
-   <signal>clicked()</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>showHideOptions()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>
@@ -966,6 +1055,38 @@
    <signal>clicked()</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>selectInput()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>loadConfigButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>loadConfig()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>saveConfigButton</sender>
+   <signal>clicked()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>saveConfig()</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -276,522 +276,6 @@
          </layout>
         </widget>
        </widget>
-       <widget class="QWidget" name="cameraTab">
-        <attribute name="title">
-         <string>Camera</string>
-        </attribute>
-        <widget class="QWidget" name="horizontalLayoutWidget">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>10</y>
-           <width>651</width>
-           <height>501</height>
-          </rect>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_5">
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_12">
-            <item>
-             <spacer name="verticalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Minimum</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>11</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="minimumSize">
-               <size>
-                <width>0</width>
-                <height>120</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Camera presets</string>
-              </property>
-              <widget class="QWidget" name="layoutWidget">
-               <property name="geometry">
-                <rect>
-                 <x>10</x>
-                 <y>30</y>
-                 <width>292</width>
-                 <height>81</height>
-                </rect>
-               </property>
-               <layout class="QHBoxLayout" name="presetsLayout">
-                <item>
-                 <layout class="QVBoxLayout" name="axisLayout">
-                  <property name="spacing">
-                   <number>20</number>
-                  </property>
-                  <item>
-                   <layout class="QHBoxLayout" name="axisPosLayout">
-                    <item>
-                     <widget class="QPushButton" name="xButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>x</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="yButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>y</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="zButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>z</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="axisNegLayout">
-                    <item>
-                     <widget class="QPushButton" name="mxButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- x</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="myButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- y</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="mzButton">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="minimumSize">
-                       <size>
-                        <width>50</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                      <property name="text">
-                       <string>- z</string>
-                      </property>
-                      <property name="shortcut">
-                       <string/>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
-                </item>
-                <item>
-                 <spacer name="horizontalSpacer_4">
-                  <property name="orientation">
-                   <enum>Qt::Horizontal</enum>
-                  </property>
-                  <property name="sizeHint" stdset="0">
-                   <size>
-                    <width>20</width>
-                    <height>20</height>
-                   </size>
-                  </property>
-                 </spacer>
-                </item>
-                <item>
-                 <layout class="QVBoxLayout" name="setHomeLayout">
-                  <property name="spacing">
-                   <number>20</number>
-                  </property>
-                  <item>
-                   <widget class="QPushButton" name="homeButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>90</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>Home</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QPushButton" name="setHomeButton">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>90</width>
-                      <height>20</height>
-                     </size>
-                    </property>
-                    <property name="text">
-                     <string>Set Home</string>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </widget>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_6">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Fixed</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>10</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox9">
-              <property name="title">
-               <string>Camera position [cm]</string>
-              </property>
-              <layout class="QHBoxLayout">
-               <item>
-                <widget class="QLineEdit" name="lookX"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lookY"/>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="lookZ"/>
-               </item>
-               <item>
-                <spacer name="spacer4">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeType">
-                  <enum>QSizePolicy::Expanding</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>16</width>
-                   <height>21</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QPushButton" name="applyLook">
-                 <property name="text">
-                  <string>Apply</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Expanding</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-          <item>
-           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
-            <property name="leftMargin">
-             <number>0</number>
-            </property>
-            <item>
-             <spacer name="verticalSpacer_5">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeType">
-               <enum>QSizePolicy::Minimum</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>11</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QGroupBox" name="groupBox18">
-              <property name="minimumSize">
-               <size>
-                <width>329</width>
-                <height>291</height>
-               </size>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>329</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="title">
-               <string>Lighting</string>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_5">
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                 <item>
-                  <widget class="QCheckBox" name="moveLight">
-                   <property name="minimumSize">
-                    <size>
-                     <width>311</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>311</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="text">
-                    <string>Move Light with viewer</string>
-                   </property>
-                   <property name="checked">
-                    <bool>true</bool>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="lightPosGroup">
-                   <property name="enabled">
-                    <bool>false</bool>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>315</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Light position</string>
-                   </property>
-                   <layout class="QHBoxLayout">
-                    <item>
-                     <widget class="QLineEdit" name="lightX"/>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="lightY"/>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="lightZ"/>
-                    </item>
-                    <item>
-                     <spacer name="spacer6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Expanding</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>16</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="applyLight">
-                      <property name="text">
-                       <string>Apply</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QGroupBox" name="groupBox17">
-                   <property name="minimumSize">
-                    <size>
-                     <width>301</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="maximumSize">
-                    <size>
-                     <width>301</width>
-                     <height>16777215</height>
-                    </size>
-                   </property>
-                   <property name="title">
-                    <string>Ambient light</string>
-                   </property>
-                   <layout class="QHBoxLayout">
-                    <item>
-                     <widget class="QSlider" name="ambientLight">
-                      <property name="maximum">
-                       <number>100</number>
-                      </property>
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="tickPosition">
-                       <enum>QSlider::TicksBelow</enum>
-                      </property>
-                      <property name="tickInterval">
-                       <number>10</number>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </widget>
-            </item>
-            <item>
-             <spacer name="verticalSpacer_2">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-           </layout>
-          </item>
-         </layout>
-        </widget>
-       </widget>
        <widget class="QWidget" name="colorTab">
         <attribute name="title">
          <string>Colors</string>
@@ -1328,6 +812,567 @@
              </size>
             </property>
            </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+       <widget class="QWidget" name="cameraTab">
+        <attribute name="title">
+         <string>Camera</string>
+        </attribute>
+        <widget class="QWidget" name="horizontalLayoutWidget">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>10</y>
+           <width>651</width>
+           <height>511</height>
+          </rect>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_5">
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_12">
+            <item>
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>11</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>120</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Camera presets</string>
+              </property>
+              <widget class="QWidget" name="layoutWidget">
+               <property name="geometry">
+                <rect>
+                 <x>10</x>
+                 <y>30</y>
+                 <width>292</width>
+                 <height>81</height>
+                </rect>
+               </property>
+               <layout class="QHBoxLayout" name="presetsLayout">
+                <item>
+                 <layout class="QVBoxLayout" name="axisLayout">
+                  <property name="spacing">
+                   <number>20</number>
+                  </property>
+                  <item>
+                   <layout class="QHBoxLayout" name="axisPosLayout">
+                    <item>
+                     <widget class="QPushButton" name="xButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>x</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="yButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>y</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="zButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>z</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="axisNegLayout">
+                    <item>
+                     <widget class="QPushButton" name="mxButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>- x</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="myButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>- y</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="mzButton">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                      <property name="minimumSize">
+                       <size>
+                        <width>50</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                      <property name="text">
+                       <string>- z</string>
+                      </property>
+                      <property name="shortcut">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </item>
+                <item>
+                 <spacer name="horizontalSpacer_4">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>20</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <layout class="QVBoxLayout" name="setHomeLayout">
+                  <property name="spacing">
+                   <number>20</number>
+                  </property>
+                  <item>
+                   <widget class="QPushButton" name="homeButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>90</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Home</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QPushButton" name="setHomeButton">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>90</width>
+                      <height>20</height>
+                     </size>
+                    </property>
+                    <property name="text">
+                     <string>Set Home</string>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </item>
+               </layout>
+              </widget>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_6">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox9">
+              <property name="title">
+               <string>Camera position [cm]</string>
+              </property>
+              <layout class="QHBoxLayout">
+               <item>
+                <widget class="QLineEdit" name="lookX"/>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lookY"/>
+               </item>
+               <item>
+                <widget class="QLineEdit" name="lookZ"/>
+               </item>
+               <item>
+                <spacer name="spacer4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
+                 </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Expanding</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>16</width>
+                   <height>21</height>
+                  </size>
+                 </property>
+                </spacer>
+               </item>
+               <item>
+                <widget class="QPushButton" name="applyLook">
+                 <property name="text">
+                  <string>Apply</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>10</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox_4">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="minimumSize">
+               <size>
+                <width>0</width>
+                <height>220</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Controls</string>
+              </property>
+              <widget class="QTextBrowser" name="textBrowser">
+               <property name="geometry">
+                <rect>
+                 <x>10</x>
+                 <y>30</y>
+                 <width>256</width>
+                 <height>181</height>
+                </rect>
+               </property>
+               <property name="html">
+                <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Rotate: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;hold left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Zoom:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; scroll or hold middle MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Pan: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ctrl + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Roll:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Shift + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set rotation point:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; double left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Alt + Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at X: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;x&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Y:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; y&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look at Z:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; z&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+              </widget>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="verticalLayout_13" stretch="0,0,0">
+            <property name="leftMargin">
+             <number>0</number>
+            </property>
+            <item>
+             <spacer name="verticalSpacer_5">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeType">
+               <enum>QSizePolicy::Fixed</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>11</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
+             <widget class="QGroupBox" name="groupBox18">
+              <property name="minimumSize">
+               <size>
+                <width>329</width>
+                <height>291</height>
+               </size>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>329</width>
+                <height>16777215</height>
+               </size>
+              </property>
+              <property name="title">
+               <string>Lighting</string>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_5">
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_3">
+                 <item>
+                  <widget class="QCheckBox" name="moveLight">
+                   <property name="minimumSize">
+                    <size>
+                     <width>311</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>311</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>Move Light with viewer</string>
+                   </property>
+                   <property name="checked">
+                    <bool>true</bool>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="lightPosGroup">
+                   <property name="enabled">
+                    <bool>false</bool>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>315</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="title">
+                    <string>Light position</string>
+                   </property>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QLineEdit" name="lightX"/>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="lightY"/>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="lightZ"/>
+                    </item>
+                    <item>
+                     <spacer name="spacer6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Expanding</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>16</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QPushButton" name="applyLight">
+                      <property name="text">
+                       <string>Apply</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QGroupBox" name="groupBox17">
+                   <property name="minimumSize">
+                    <size>
+                     <width>301</width>
+                     <height>0</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>301</width>
+                     <height>16777215</height>
+                    </size>
+                   </property>
+                   <property name="title">
+                    <string>Ambient light</string>
+                   </property>
+                   <layout class="QHBoxLayout">
+                    <item>
+                     <widget class="QSlider" name="ambientLight">
+                      <property name="maximum">
+                       <number>100</number>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="tickPosition">
+                       <enum>QSlider::TicksBelow</enum>
+                      </property>
+                      <property name="tickInterval">
+                       <number>10</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+              </layout>
+             </widget>
+            </item>
+            <item>
+             <spacer name="verticalSpacer_2">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -700,7 +700,7 @@
                 <item>
                  <widget class="QPushButton" name="regionCheckAllButton">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -719,7 +719,7 @@
                 <item>
                  <widget class="QPushButton" name="regionUncheckAllButton">
                   <property name="sizePolicy">
-                   <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
                     <horstretch>0</horstretch>
                     <verstretch>0</verstretch>
                    </sizepolicy>
@@ -740,9 +740,12 @@
                   <property name="orientation">
                    <enum>Qt::Horizontal</enum>
                   </property>
+                  <property name="sizeType">
+                   <enum>QSizePolicy::Preferred</enum>
+                  </property>
                   <property name="sizeHint" stdset="0">
                    <size>
-                    <width>40</width>
+                    <width>200</width>
                     <height>20</height>
                    </size>
                   </property>
@@ -870,9 +873,12 @@
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
+                <property name="sizeType">
+                 <enum>QSizePolicy::Preferred</enum>
+                </property>
                 <property name="sizeHint" stdset="0">
                  <size>
-                  <width>40</width>
+                  <width>200</width>
                   <height>20</height>
                  </size>
                 </property>


### PR DESCRIPTION
**New egs_view layout, settings file, dose viewing and more..**

- Added the ability to save & load a configuration file for `egs_view`. This includes saving the current look orientation, window size, track options, clipping planes, etc. You can load the config file from the GUI, or pass it as an argument (with or without ptracks file argument). E.g.

`egs_view myInput.egsinp myInput.egsview`

- Fixed various segmentation faults that occurred when reloading files. This includes a fix to clearGeometries() in egs_base_geometry so that composite geometries actually get cleaned up. Added an option to load a new input file.

- Changed the layout - now there are tabs to divide sections, and the more commonly used options are together. Also, clipping planes are more intuitive! The key-bindings can be found in the `Camera` tab, and there might be some there you didn't know about (plus a new `double click` functionality).

- Zooming has been modified - at higher zoom levels it switches to scaling with a power-law to slow it down (*let me know if you don't like it and I could make it optional*).

- Added region-by-region visibility, but only for geometries with <=1000 regions (for performance). Added color controls in the `Color` tab of backgrounds, tracks, etc. Also, you can now control the display of vacuum regions.

- The coordinate on the first surface hit by your mouse is now displayed in the viewer when region display is turned on. 

- Fixed a number of display bugs, like the axis flipping direction when the geometry was not near the origin. Added more hunting for an initial point inside the geometry so that it's less likely to crash when not near the origin or windowed properly.

- Added dose viewing (3ddose files). Replace `dosxyz_show` by loading the egsphant in an XYZ geometry and including an ausgab object for dose scoring that points to your 3ddose file. You can use any XYZ geometry. For speed, the dose is stored in an unordered_map, which requires `c++11`, so this was added as a compile flag since qt4 doesn't enable that compatibility by default. 3ddose example for egsphant files:
```
  :start geometry:
        name = my_phant
        library  = egs_ndgeometry
        type = EGS_XYZGeometry
        egsphant file = slice_files.egsphant
        ct ramp = 5MeV.ramp # this requirement will be removed in future PR
  :stop geometry:
  simulation geometry = my_phant
:stop geometry definition:
:start ausgab object definition:
  :start ausgab object:
        library = egs_dose_scoring
        name = example
        medium dose = no
        region dose = no
        :start output dose file:
            geometry name = my_phant
            file type = 3ddose
        :stop output dose file:
  :stop ausgab object:
```
- Added the ability to select the geometry that is being viewed. This includes geometries that are automatically generated, likes planes for an ND geometry, which may have no visual representation but allow for region analysis.

- Added track range selection. 
![egs_view1](https://user-images.githubusercontent.com/13069227/42651995-0cdf29a0-85df-11e8-9424-f459651c4c71.png)
![egs_view2](https://user-images.githubusercontent.com/13069227/42061525-858cd7b8-7af8-11e8-89a3-44a33c84d959.png)
![egs_view3](https://user-images.githubusercontent.com/13069227/42061528-8737ec9c-7af8-11e8-9bb4-d716947316b9.png)
![egs_view4](https://user-images.githubusercontent.com/13069227/42061530-88d79c28-7af8-11e8-8558-6b8f03e0ac23.png)
![egs_view5](https://user-images.githubusercontent.com/13069227/42471781-fb92d420-838c-11e8-8b27-242868389db1.png)


