### PR TITLE
Fix #423: change -ffast-math to -mtune=native

### DIFF
--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/pirs509a-beamnrc.tex
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/pirs509a-beamnrc.tex
@@ -665,7 +665,7 @@ The options for {\tt make} are:
 \index{make!options}
 \begin{verbatim}
 make              Compile the accelerator executable with default optimization
-make opt          turned on.  Default optimization is level 3 (-O3).
+make opt          turned on.  Default optimization is level 2 (-O2).
 
 make noopt        Compile the accelerator executable with optimization
                   turned off.
@@ -10362,4 +10362,3 @@ explicitly mention the contributions of many others.
 \typeout{ add page throws if needed                                  }
 \typeout{************************************************************}
 \end{document}
-

--- a/HEN_HOUSE/doc/src/pirs702-egsnrc-codes/pirs702-egsnrc-codes.tex
+++ b/HEN_HOUSE/doc/src/pirs702-egsnrc-codes/pirs702-egsnrc-codes.tex
@@ -2186,7 +2186,7 @@ The options for {\tt make} are:
 \index{make!options}
 \begin{verbatim}
 make              Compile with default optimization
-make opt          turned on.  Default optimization is level 3 (-O3).
+make opt          turned on.  Default optimization is level 2 (-O2).
 
 make noopt        Compile with no optimization
 
@@ -2219,7 +2219,7 @@ m[f] user_code [a] [opt|noopt|debug]
 The options for {\tt mf} are:
 \verb+mf         =>+ Mortran and Fortran compile and then link\\
 \verb+m          =>+ Mortran compile and create the Fortran file\\
-\verb+opt        =>+ use optimization (default level 3)\\
+\verb+opt        =>+ use optimization (default level 2)\\
 \verb+noopt      =>+ use no optimization\\
 \verb+debug      =>+ create executable ready for a debug run\\
 The parameter ``{\tt a}" is not used and is only present for compatibility
@@ -4769,4 +4769,3 @@ kernels.
 
 
 \end{document}
-

--- a/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
+++ b/HEN_HOUSE/doc/src/pirs794-dosxyznrc/pirs794-dosxyznrc.tex
@@ -609,7 +609,7 @@ The options for {\tt make} are:
 \indexm{make!options}
 \begin{verbatim}
 make              Compile with default optimization
-make opt          turned on.  Default optimization is level 3 (-O3).
+make opt          turned on.  Default optimization is level 2 (-O2).
 
 make noopt        Compile with no optimization
 
@@ -642,7 +642,7 @@ m[f] dosxyznrc [a] [opt|noopt|debug]
 The options for {\tt mf} are:
 \verb+mf         =>+ Mortran and Fortran compile and then link\\
 \verb+m          =>+ Mortran compile and create the Fortran file\\
-\verb+opt        =>+ use optimization (default level 3)\\
+\verb+opt        =>+ use optimization (default level 2)\\
 \verb+noopt      =>+ use no optimization\\
 \verb+debug      =>+ create executable ready for a debug run\\
 The parameter ``{\tt a}" is not used and is only present for compatibility

--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -788,7 +788,7 @@ void MCompiler::init(){
     dso = 0;
     the_name = "gfortran"; vopt = "--version";
     opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
-    optimiz = "-O3 -ffast-math";
+    optimiz = "-O2 -mtune=native";
     deb = "-g";
     eext = QString();
     oflag = "-o ";
@@ -809,7 +809,7 @@ void MCompiler::setLanguage(Language l){
     switch(l){
       case F:
         the_name = "gfortran";
-        optimiz = "-O3 -ffast-math";
+        optimiz = "-O2 -mtune=native";
         break;
       case C:
         the_name = "gcc";
@@ -817,7 +817,7 @@ void MCompiler::setLanguage(Language l){
         break;
       case CPP:
         the_name = "g++";
-        optimiz = "-O3 -ffast-math";
+        optimiz = "-O2 -mtune=native";
         dso = new EGS_DSO(name());// Creates dso, sets flibs to -lgfortran literally
         dso->flibs = getFlibs2LinkCPP("gfortran",path());
         break;
@@ -899,15 +899,15 @@ void MCompiler::setUpGnuMake(){
     _version = getVersion(); _version = _version.split("\n").takeFirst();
 }
 void MCompiler::setUpCCompiler(){
-    optimiz  = "-O3"; oflag = "-o "; vopt = "--version";
+    optimiz  = "-O2"; oflag = "-o "; vopt = "--version";
     opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
 
 #ifdef WIN32
   if (the_name.toLower()== "icc"){
-    optimiz  = "-O3 -no-prec-div -fp-model fast=2 -DWIN32";
+    optimiz  = "-O2 -no-prec-div -fp-model fast=2 -DWIN32";
   }
   else if ( the_name.contains("gcc") ){
-    optimiz  = "-O3 -DWIN32";
+    optimiz  = "-O2 -DWIN32";
   }
   else if ( the_name.toLower() == "cl.exe" ){//-Ox max. optimizations
     optimiz = "-Ox -DWIN32 -MD -nologo";//-MD link with MSVCRT.LIB
@@ -919,10 +919,10 @@ void MCompiler::setUpCCompiler(){
   }
 #else
   if (the_name.toLower()== "icc"){
-    optimiz  = "-O3 -no-prec-div -fp-model fast=2";
+    optimiz  = "-O2 -no-prec-div -fp-model fast=2";
   }
   else if ( the_name.contains("gcc") ){
-    optimiz  = "-O3 -ffast-math";
+    optimiz  = "-O2 -mtune=native";
   }
   else{
     optimiz  = "-O2";
@@ -940,17 +940,17 @@ void MCompiler::setUpCPPCompiler(const QString& link_to_name){
     vopt = QString();
   }
   else if ( the_name.contains("g++") ){
-    optimiz  = "-O3 -ffast-math -DWIN32";
+    optimiz  = "-O2 -mtune=native -DWIN32";
   }
   else if (the_name.toLower()== "icpc"){
-    optimiz  = "-O3 -no-prec-div -fp-model fast=2 -DWIN32";
+    optimiz  = "-O2 -no-prec-div -fp-model fast=2 -DWIN32";
   }
 #else
   if ( the_name.contains("g++") ){
-    optimiz  = "-O3 -ffast-math";
+    optimiz  = "-O2 -mtune=native";
   }
   else if (the_name.toLower()== "icpc"){
-    optimiz  = "-O3 -no-prec-div -fp-model fast=2";
+    optimiz  = "-O2 -no-prec-div -fp-model fast=2";
   }
   else{
     optimiz  = "-O2";
@@ -1025,7 +1025,7 @@ void MCompiler::setUpFortranCompiler(){
     // Setting some defaults
     oflag = "-o "; opt = QString();
     oext = "o"; lflag = "-l"; vopt = QString(); _version = "DUNO!";
-    eext = QString(); libs = QString(); deb = "-g"; optimiz = "-O3";
+    eext = QString(); libs = QString(); deb = "-g"; optimiz = "-O2";
     _exists = true;// determined below in method getVersion
 
 #if defined(WIN32) || defined(Q_OS_WIN32)
@@ -1034,7 +1034,7 @@ void MCompiler::setUpFortranCompiler(){
          the_name.contains("g77")      ){
         vopt = "--version";
         opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
-        optimiz = "-O3 -ffast-math";
+        optimiz = "-O2 -mtune=native";
     }
     else if (the_name == "ifl"){
         vopt = "-V";
@@ -1045,7 +1045,7 @@ void MCompiler::setUpFortranCompiler(){
     else if (the_name == "ifort"){
         vopt = "/logo";
         opt = "-fpp";
-        optimiz = "-O3";
+        optimiz = "-O2";
         deb = "-debug";
     }
     else if (the_name == "lf95" || the_name == "f77"){
@@ -1080,7 +1080,7 @@ void MCompiler::setUpFortranCompiler(){
     if ( the_name.contains("gfortran") || the_name == "g95" || the_name.contains("g77") ){ // GNU Fortran
         vopt = "-v --version";
         opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
-        optimiz = "-O3 -ffast-math";
+        optimiz = "-O2 -mtune=native";
         deb = "-g";
     }
     _version = getVersion(); _version = _version.split("\n").takeFirst();
@@ -1101,11 +1101,11 @@ void MCompiler::setUpFortranCompiler(){
     _version = getVersion(); _version = _version.split("\n").takeFirst();
 #elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
     if ( the_name.contains("gfortran") || the_name == "g95" || the_name.contains("g77")){ // GNU Fortran
-        vopt = "--version"; optimiz = "-O3 -ffast-math"; deb = "-g";
+        vopt = "--version"; optimiz = "-O2 -mtune=native"; deb = "-g";
         opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
     }
     else if (the_name == "ifort"){
-        vopt = "-logo"; optimiz = "-O3"; deb = "-g -CB";
+        vopt = "-logo"; optimiz = "-O2"; deb = "-g -CB";
         opt = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers;
     }
     else if ( the_name.contains("pgf") ){
@@ -1115,7 +1115,7 @@ void MCompiler::setUpFortranCompiler(){
     else{ // Use some typical values
         vopt = "-v -V -version";// Trick trying to get one of the options to produce version info
         opt  = is_x86_64() ? "-fPIC" : QString(); // Only for 64-bit GNU compilers
-        optimiz = "-O3"; deb = "-g";
+        optimiz = "-O2"; deb = "-g";
     }
     _version = getVersion(); _version = _version.split("\n").takeFirst();
 #endif

--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -340,13 +340,23 @@ for test_arg in -v; do
     echo $f_test_output >&5
     if test -s conftest.$test_objext; then
         if test "x$f_test_output" != x; then
+            junk=$(echo $f_test_output | grep "GNU Fortran")
+            if test "x$junk" != x; then
+                f_version=$(echo $junk | grep -o -m1 'GNU Fortran [^\s]* version [0-9.]*'| head -1)
+                f_oflags="-O2 -mtune=native"
+                f_dflags="-g"
+                if test ! x$is_x86_64 = x; then
+                    f_fflags="-fPIC"
+                fi
+                break
+            fi
             junk=$(echo $f_test_output | grep "GNU F77 version")
             if test "x$junk" != x; then
                 junk=$(echo $junk | sed 's/.*GNU F77 version//g' | awk '{print $1}')
                 f_version="GNU F77 version $junk"
                 #f_fflags="-fno-automatic -finit-local-zero"
                 # don't need this with new EGSnrc
-                f_oflags="-O2"
+                f_oflags="-O2 -mtune=native"
                 f_dflags="-g"
                 if test ! x$is_x86_64 = x; then
                     f_fflags="-fPIC"
@@ -357,7 +367,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 junk=$(echo $junk | sed 's/.*GNU F95 version//g' | awk '{print $1}')
                 f_version="GNU F95 version $junk"
-                f_oflags="-O2"
+                f_oflags="-O2 -mtune=native"
                 f_dflags="-g"
                 if test ! x$is_x86_64 = x; then
                     f_fflags="-fPIC"
@@ -377,7 +387,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 f_version="SGI Fortran compiler"
                 #f_fflags="-static"
-                f_oflags="-O3"
+                f_oflags="-O2"
                 f_dflags="-g -C"
                 break
             fi
@@ -385,7 +395,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 f_version="IBM XL Fortran compiler"
                 #f_fflags="-qsave"
-                f_oflags="-O3"
+                f_oflags="-O2"
                 f_dflags="-g -C"
                 break
             fi
@@ -416,7 +426,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 junk=$(echo $junk | sed 's/.*D__INTEL_COMPILER=//g' | awk '{print $1}')
                 f_version="Intel(R) Fortran Compiler Version $junk"
-                f_oflags="-O3"
+                f_oflags="-O2"
                 f_dflags="-g -CB"
                 need_fool_optimizer=yes
                 break
@@ -507,7 +517,6 @@ done
 
 while true; do
 printf $format "Input flags for debugging: " >&2
-printf "[-g] " >&2
 if test ! "x$f_dflags" = x; then
     printf "[$f_dflags] " >&2
 fi

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -165,9 +165,9 @@ if test $create_config=yes; then
 
 case $CXX in
 
-    *g++*) opt="-O3 -ffast-math";;# mingw32-g++ and g++4 also taken into account
-    icpc)  opt="-O3 -no-prec-div -fp-model fast=2";;
-    icc)   opt="-O3 -no-prec-div -fp-model fast=2";;
+    *g++*) opt="-O2 -mtune=native";;# mingw32-g++ and g++4 also taken into account
+    icpc)  opt="-O2 -no-prec-div -fp-model fast=2";;
+    icc)   opt="-O2 -no-prec-div -fp-model fast=2";;
     cl)    opt="-Ox -Ob2 -MD -GX -GR -nologo";;
     *)     opt="-O2";;
 


### PR DESCRIPTION
Update the default gcc optimization configuration to use -march=native
instead of -ffast-math. The latter causes various floating-point
exceptions on newer cpus and compilers. If the programs are run on a
different cpu, then one should use the corresponding -march option for
that architecture instead of "native", or else use the less aggressive
-mtune=native if the compiling and running cpus are in the same family.

The alternatives -march and -mtune were suggested by @Kawrakow in 
issue #174.

See also #85, #91, #174, #204 and #423.