### PR TITLE
Add Makefile clean target for IAEA phase space library

### DIFF
--- a/HEN_HOUSE/iaea_phsp/Makefile
+++ b/HEN_HOUSE/iaea_phsp/Makefile
@@ -54,3 +54,6 @@ $(DSO2)iaea_phsp.$(obje): iaea_record.h iaea_header.h $(my_common_deps)
 $(DSO2)iaea_record.$(obje): $(my_common_deps)
 
 $(DSO2)iaea_header.$(obje): iaea_record.h $(my_common_deps)
+
+clean:
+	$(REMOVE) $(DSO2)iaea_phsp.$(obje) $(DSO2)$(libpre)iaea_phsp$(libext) $(DSO2)$(libpre)iaea_phsp$(libext_bundle)


### PR DESCRIPTION
Patch as recommended by @mchamberland in issue/feature request #424.

Functionality:

    user@7c6a4a634f12:/egsnrc/HEN_HOUSE/iaea_phsp# make
    g++ -I../lib/linux -fPIC -DBUILD_IAEA_DLL -O3 -ffast-math -c -o ../egs++/dso/linux/iaea_phsp.o iaea_phsp.cpp
    g++ -I../lib/linux -fPIC -DBUILD_IAEA_DLL -O3 -ffast-math -shared  ../egs++/dso/linux/iaea_phsp.o ../egs++/dso/linux/iaea_header.o ../egs++/dso/linux/iaea_record.o ../egs++/dso/linux/utilities.o -o ../egs++/dso/linux/libiaea_phsp.so -ldl  
    user@7c6a4a634f12:/egsnrc/HEN_HOUSE/iaea_phsp# make clean
    rm -f ../egs++/dso/linux/iaea_phsp.o ../egs++/dso/linux/libiaea_phsp.so ../egs++/dso/linux/libiaea_phsp