### PR TITLE
Fix #430: Fix blank inputs for DOSXYZnrc sources

### DIFF
--- a/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
@@ -1993,7 +1993,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_beam_code,' ')=1) [
-      IF(len(the_beam_code)>=2)[
+      ilen = lnblnk1(the_beam_code) - 1;
+      IF(ilen>=2)[
         the_beam_code=the_beam_code(2:);
       ]
       ELSE [
@@ -2007,7 +2008,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_input_file,' ')=1) [
-      IF(len(the_input_file)>=2) [
+      ilen = lnblnk1(the_input_file) - 1;
+      IF(ilen>=2) [
         the_input_file=the_input_file(2:);
       ]
       ELSE [
@@ -2019,17 +2021,17 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
 
     the_pegs_file=FILNAM(:lnblnk1(FILNAM));
     "strip leading blanks"
-    IF(len($cstring(the_pegs_file))=0)the_pegs_file='pegsless';
     WHILE(INDEX(the_pegs_file,' ')=1) [
-      IF(len(the_pegs_file)>=2) [
+      ilen = lnblnk1(the_pegs_file) - 1;
+      IF(ilen>=2) [
         the_pegs_file=the_pegs_file(2:);
       ]
       ELSE [
+        "blank input"
+        the_pegs_file='pegsless';
         EXIT;
       ]
     ]
-
-    IF(the_pegs_file=' ')the_pegs_file='pegsless';
 
     OUTPUT $cstring(the_beam_code),$cstring(the_input_file),
              $cstring(the_pegs_file);
@@ -2052,10 +2054,13 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_shared_lib,' ')=1) [
-      IF(len(the_shared_lib)>=2)[
+      ilen = lnblnk1(the_shared_lib) - 1;
+      IF(ilen>=2)[
         the_shared_lib=the_shared_lib(2:);
       ]
       ELSE [
+        "blank input"
+        the_shared_lib='0';
         EXIT;
       ]
     ]
@@ -2066,7 +2071,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_phsp_file,' ')=1) [
-      IF(len(the_phsp_file)>=2) [
+      ilen = lnblnk1(the_phsp_file) - 1;
+      IF(ilen >=2) [
         the_phsp_file=the_phsp_file(2:);
       ]
       ELSE [
@@ -2155,7 +2161,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     the_input_file=FILNAM(:lnblnk1(FILNAM));
     "strip leading blanks"
     WHILE(INDEX(the_input_file,' ')=1) [
-         IF(len(the_input_file)>=2) [
+         ilen = lnblnk1(the_input_file) - 1;
+         IF(ilen>=2) [
            the_input_file=the_input_file(2:);
          ]
          ELSE [
@@ -2202,7 +2209,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_beam_code,' ')=1) [
-      IF(len(the_beam_code)>=2)[
+      ilen = lnblnk1(the_beam_code) - 1;
+      IF(ilen>=2)[
         the_beam_code=the_beam_code(2:);
       ]
       ELSE [
@@ -2216,7 +2224,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_input_file,' ')=1) [
-      IF(len(the_input_file)>=2) [
+      ilen = lnblnk1(the_input_file) - 1;
+      IF(ilen>=2) [
        the_input_file=the_input_file(2:);
       ]
       ELSE [
@@ -2228,28 +2237,33 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
 
 
     the_pegs_file=FILNAM(:INDEX(FILNAM,',')-1);
-    IF(len($cstring(the_pegs_file))=0)the_pegs_file='pegsless';
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_pegs_file,' ')=1) [
-      IF(len($cstring(the_pegs_file))>=2) [
+      ilen = lnblnk1(the_pegs_file) - 1;
+      IF(ilen>=2) [
         the_pegs_file=the_pegs_file(2:);
       ]
       ELSE [
+        "blank input"
+        the_pegs_file='pegsless';
         EXIT;
       ]
     ]
 
-    IF(the_pegs_file=' ')the_pegs_file='pegsless';
+    the_pegs_file = the_pegs_file(:lnblnk1(the_pegs_file));
 
     the_vcu_code=FILNAM(:INDEX(FILNAM,',')-1);
     FILNAM=FILNAM(INDEX(FILNAM,',')+1:);
     "strip leading blanks"
     WHILE(INDEX(the_vcu_code,' ')=1) [
-      IF(len(the_vcu_code)>=2)[
+      ilen = lnblnk1(the_vcu_code) - 1;
+      IF(ilen>=2)[
         the_vcu_code=the_vcu_code(2:);
       ]
       ELSE [
+        "blank input"
+        the_vcu_code='0';
         EXIT;
       ]
     ]
@@ -2268,7 +2282,8 @@ ELSEIF( (enflag = 2) | (enflag = 3) )["phase space input or full BEAM sim."
     the_vcu_input_file=FILNAM(:lnblnk1(FILNAM));
     "strip leading blanks"
     WHILE(INDEX(the_vcu_input_file,' ')=1) [
-      IF(len(the_vcu_input_file)>=2) [
+      ilen = lnblnk1(the_vcu_input_file) - 1;
+      IF(ilen>=2) [
         the_vcu_input_file=the_vcu_input_file(2:);
       ]
       ELSE [


### PR DESCRIPTION
Fixed a bug in inputs for sources 20, 21 in which the code
hung if the user indicated that a shared library geometry was not
to be included by inputting a blank (instead of a '0')
for the name of code defining the shared library geometry.

While fixing this, other input bugs related to incorrect
use of the Fortran len(char) were found and fixed.