### PR TITLE
Fix Qt GUI compile functions and tooltip

### DIFF
--- a/HEN_HOUSE/gui/egs_gui/egs_compile_page.cpp
+++ b/HEN_HOUSE/gui/egs_gui/egs_compile_page.cpp
@@ -163,7 +163,9 @@ void EGS_CompilePage::startCompilation() {
   if( !checkExeDir() )
     qFatal("Failed to create executable directory for %s",myMachine().toLatin1().data());
 
-  QStringList args;
+  QString egs_compiler = makeProgram();
+  QStringList args = egs_compiler.split(" ");
+
   //c_process->clearArguments();
   //c_process->addArgument(makeProgram());
 #ifdef IK_DEBUG
@@ -216,9 +218,9 @@ void EGS_CompilePage::startCompilation() {
   c_text->setText("");
 
   //c_process->start();
-  c_process->start(makeProgram(),args);
+  c_process->start(args.first(),args.mid(1));
   if(c_process->error()==QProcess::FailedToStart) {
-    c_text->insertPlainText(tr("Failed to execute: ")+ makeProgram() + args.join(" ") + tr("!!!"));
+    c_text->insertPlainText(tr("Failed to execute: ")+ args.join(" ") + tr("!!!"));
   }
   else{
    is_running = true; killed = false;

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZForm.cpp
@@ -84,6 +84,7 @@ void inputRZImpl::Initialize()
 
  the_year = (QDate::currentDate()).toString("yyyy");
 
+ this->setStyleSheet("QToolTip { color: black; background-color: #feffcd }");
 
 //  usercode     = cavrznrc;
   usercode     = dosrznrc;

--- a/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
+++ b/HEN_HOUSE/gui/egs_inprz/src/inputRZImpl.cpp
@@ -92,6 +92,10 @@ void inputRZImpl::compile_userCode()
     QString egs_compiler = readVarFromConf("make_prog");
     if ( egs_compiler.isEmpty() ) egs_compiler = "make";// default is GNU make
 
+    // If the make command contains an argument already (e.g. -j12) we need to
+    // separate the actual make command in the QStringList
+    QStringList args = egs_compiler.split(" ");
+
    QString code_generation = "opt"; // default
    if ( DebugradioButton->isChecked() )
         code_generation = "debug";
@@ -105,8 +109,6 @@ void inputRZImpl::compile_userCode()
 
    QDir::setCurrent( ironIt( EGS_HOME + QDir::separator() + usercodename) );
 
-   QStringList args;
-   args.push_back(egs_compiler);
    args += code_generation;
 //   if ( code_generation.toLower() != "clean"){
    QString dummy =  (QString)"EGS_CONFIG=" +


### PR DESCRIPTION
Fix a bug in the Qt GUI compilation functions. The make program from the
config may contain a space if it was provided arguments like -j12. Now
the Qt gui splits the string if there are spaces, so that it can
determine the make program correctly.

Also fix a bug on the odroid OS where the egs_inprz tooltip default
text color did not contrast with the tooltip background. This was fixed
by setting those colors explicitly.