### PR TITLE
Fix a tutor7pp ausgab bug

### DIFF
--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -522,7 +522,7 @@ public:
         PegsCut = 2,             //!< energy below AE or AP
         UserDiscard = 3,         //!< user requested discard
         ExtraEnergy = 4,         /*!< initiated when part of the energy is not
-                               transfered to particles (e.g. binding energy)*/
+                               transferred to particles (e.g. binding energy)*/
         AfterTransport = 5,      //!< after the step
         BeforeBrems = 6,         //!< before a bremsstrahlung interaction
         AfterBrems = 7,          //!< after a bremsstrahlung interaction
@@ -548,9 +548,13 @@ public:
         FluorescentEvent = 25,   //!< a fluorescent transition just occured
         CosterKronigEvent = 26,  //!< a Coster-Kronig transition just occured
         AugerEvent = 27,         //!< an Auger transition just occured
-        BeforePhotoNuc = 29,      //!< before a photonuclear event
-        AfterPhotoNuc = 30,       //!< after a photonuclear event
-        UnknownCall = 31         //!< last element in the enumeration
+        BeforePhotoNuc = 29,     //!< before a photonuclear event
+        AfterPhotoNuc = 30,      //!< after a photonuclear event
+        BeforeEII = 31,          //!< before electron impact ionization
+        AfterEII = 32,           //!< after electron impact ionization
+        AfterSubPhoton = 33,     //!< after sub-threshold photon energy deposition
+        AfterSubElectron = 34,   //!< after sub-threshold electron energy deposition
+        UnknownCall = 35         //!< last element in the enumeration
     };
 
     /*! \brief Turns on or off a call to the user scoring function ausgab.

--- a/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
+++ b/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
@@ -306,6 +306,10 @@ int Tutor7_Application::initScoring() {
     score = new EGS_ScoringArray(nreg+2);
      //i.e. we always score energy fractions
     eflu = new EGS_ScoringArray(200); gflu = new EGS_ScoringArray(200);
+
+    // Initialize with no russian roulette
+    the_egsvr->i_do_rr = 1;
+
     EGS_Input *options = input->takeInputItem("scoring options");
     if( options ) {
 


### PR DESCRIPTION
Fix a `tutor7pp` bug related to ausgab calls. When an ausgab object was used in the input file, results differed due to random memory accesses. This was due to an uninitialized value related to russian roulette. However, the results were correct when no ausgab objects were used.

This is therefore a critical bug fix for `tutor7pp`.

Also add some ausgab call values that were missing in `application.h`. This change is just for future use and consistency.

Thanks to Nigel Vezeau for reporting this bug.