### PR TITLE
Fix #447: Fix parallel runs with beam sim. source using phase space

### DIFF
--- a/HEN_HOUSE/cutils/load_beamlib.c
+++ b/HEN_HOUSE/cutils/load_beamlib.c
@@ -153,7 +153,7 @@ char *beamlib_maxenergy_name = beamlib_maxenergy_name1;
 
 DLL_HANDLE handle = 0;
 
-typedef void (*InitFunction)(const int *, const int *,
+typedef void (*InitFunction)(const int *, const int *, const int *,
                          const char *, const char *, const char *,
                          const char *, const char *, int,int,int,int,int);
 typedef void (*FinishFunction)();
@@ -363,7 +363,8 @@ void C_CONVENTION FINISH_BEAMSOURCE__() { finish_beamsource(); }
 #endif
 
 int MYF77OBJ_(init_beamsource,INIT_BEAMSOURCE)(
-        const int *i_par, const int *i_logunit, const char *config_name,
+        const int *i_par, const int *n_par, const int *i_logunit,
+        const char *config_name,
         const char *hhouse, const char *ehome, const char *beam_code,
         const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -487,14 +488,14 @@ int MYF77OBJ_(init_beamsource,INIT_BEAMSOURCE)(
         printf("Failed to resolve the finish function\n");
         return 4;
     }
-    libinit(i_par,i_logunit,hhouse,ehome,beam_code,pfile,ifile,nhh,neh,nbc,npf,nif);
+    libinit(i_par,n_par,i_logunit,hhouse,ehome,beam_code,pfile,ifile,nhh,neh,nbc,npf,nif);
 
     free(libname);
 
     return 0;
 }
 #ifdef MAKE_WIN_DISTRIBUTION
-int C_CONVENTION init_beamsource_(const int *i_par, const int *i_logunit,
+int C_CONVENTION init_beamsource_(const int *i_par, const int *n_par, const int *i_logunit,
         const char *config_name, const char *hhouse, const char *ehome,
         const char *beam_code, const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -504,10 +505,10 @@ int C_CONVENTION init_beamsource_(const int *i_par, const int *i_logunit,
   beamlib_motionsample_name = beamlib_motionsample_name2;
   beamlib_phspmotionsample_name = beamlib_phspmotionsample_name2;
   beamlib_maxenergy_name = beamlib_maxenergy_name2;
-  return init_beamsource(i_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
+  return init_beamsource(i_par,n_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
           ncn,nhh,neh,nbc,npf,nif);
 }
-int C_CONVENTION init_beamsource__(const int *i_par, const int *i_logunit,
+int C_CONVENTION init_beamsource__(const int *i_par, const int *n_par, const int *i_logunit,
         const char *config_name, const char *hhouse, const char *ehome,
         const char *beam_code, const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -517,10 +518,10 @@ int C_CONVENTION init_beamsource__(const int *i_par, const int *i_logunit,
   beamlib_motionsample_name = beamlib_motionsample_name3;
   beamlib_phspmotionsample_name = beamlib_phspmotionsample_name3;
   beamlib_maxenergy_name = beamlib_maxenergy_name3;
-  return init_beamsource(i_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
+  return init_beamsource(i_par,n_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
           ncn,nhh,neh,nbc,npf,nif);
 }
-int C_CONVENTION INIT_BEAMSOURCE(const int *i_par, const int *i_logunit,
+int C_CONVENTION INIT_BEAMSOURCE(const int *i_par, const int *n_par, const int *i_logunit,
         const char *config_name, const char *hhouse, const char *ehome,
         const char *beam_code, const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -530,10 +531,10 @@ int C_CONVENTION INIT_BEAMSOURCE(const int *i_par, const int *i_logunit,
   beamlib_motionsample_name = beamlib_motionsample_name4;
   beamlib_phspmotionsample_name = beamlib_phspmotionsample_name4;
   beamlib_maxenergy_name = beamlib_maxenergy_name4;
-  return init_beamsource(i_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
+  return init_beamsource(i_par,n_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
           ncn,nhh,neh,nbc,npf,nif);
 }
-int C_CONVENTION INIT_BEAMSOURCE_(const int *i_par, const int *i_logunit,
+int C_CONVENTION INIT_BEAMSOURCE_(const int *i_par, const int *n_par, const int *i_logunit,
         const char *config_name, const char *hhouse, const char *ehome,
         const char *beam_code, const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -543,10 +544,10 @@ int C_CONVENTION INIT_BEAMSOURCE_(const int *i_par, const int *i_logunit,
   beamlib_motionsample_name = beamlib_motionsample_name5;
   beamlib_phspmotionsample_name = beamlib_phspmotionsample_name5;
   beamlib_maxenergy_name = beamlib_maxenergy_name5;
-  return init_beamsource(i_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
+  return init_beamsource(i_par,n_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
           ncn,nhh,neh,nbc,npf,nif);
 }
-int C_CONVENTION INIT_BEAMSOURCE__(const int *i_par, const int *i_logunit,
+int C_CONVENTION INIT_BEAMSOURCE__(const int *i_par, const int *n_par, const int *i_logunit,
         const char *config_name, const char *hhouse, const char *ehome,
         const char *beam_code, const char *pfile, const char *ifile,
         int ncn, int nhh, int neh, int nbc, int npf, int nif) {
@@ -556,7 +557,7 @@ int C_CONVENTION INIT_BEAMSOURCE__(const int *i_par, const int *i_logunit,
   beamlib_motionsample_name = beamlib_motionsample_name6;
   beamlib_phspmotionsample_name = beamlib_phspmotionsample_name6;
   beamlib_maxenergy_name = beamlib_maxenergy_name6;
-  return init_beamsource(i_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
+  return init_beamsource(i_par,n_par,i_logunit,config_name,hhouse,ehome,beam_code,pfile,ifile,
           ncn,nhh,neh,nbc,npf,nif);
 }
 #endif

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -122,13 +122,14 @@ EGS_BeamSource::EGS_BeamSource(EGS_Input *input, EGS_ObjectFactory *f) :
         return;
     }
 
-    int ipar=0, ilog=6;
+    int ipar=0, ilog=6; int npar=0;
     EGS_Application *app = EGS_Application::activeApplication();
     if (app) {
         ipar = app->getIparallel();
+        npar = app->getNparallel();
     }
 
-    init(&ipar,&ilog,hen_house,egs_home,beam_code.c_str(),
+    init(&ipar,&npar,&ilog,hen_house,egs_home,beam_code.c_str(),
          pegs_file.c_str(),input_file.c_str(),
          strlen(hen_house), strlen(egs_home),
          beam_code.size(),pegs_file.size(),input_file.size());

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.h
@@ -69,7 +69,7 @@ using namespace std;
 #endif
 
 class EGS_Library;
-typedef void (*InitFunction)(const int *, const int *,
+typedef void (*InitFunction)(const int *, const int *, const int *,
                              const char *, const char *, const char *,
                              const char *, const char *, int,int,int,int,int);
 typedef void (*FinishFunction)();

--- a/HEN_HOUSE/omega/beamnrc/beam_lib.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beam_lib.mortran
@@ -58,6 +58,24 @@ REPLACE {$BEAM_WRITE_PHSP;} WITH {;
     bpc_nhist(bpc_np) = NHSTRY; bpc_iphat(bpc_np)=IPHAT(NP);
 };
 
+"If the beam source uses a phase space source and this is a parallel"
+"run, then simple-mindedly divide the phase space source up into"
+"n_parallel equal portions.  Each job is restricted to its portion of"
+"the phase space file, regardless of what chunk of the parallel run"
+"this is."
+REPLACE {$SET_INPHSP_BEAM_SOURCE_PARALLEL;} WITH {;
+    IF((ISOURC = 21 | ISOURC = 24) & n_parallel > 1) [
+      long_tmp = NNPHSP/n_parallel;
+      INPHSP_MIN = (i_parallel - 1)*long_tmp + 1;
+      IF(i_parallel = n_parallel) [INPHSP_MAX = NNPHSP;]
+      ELSE [INPHSP_MAX =  INPHSP_MIN + long_tmp -1;]
+      INPHSP = INPHSP_MIN-1;
+      IF(i_iaea_in=1) [
+        $IAEA_SET_PHSP_RECORD(IINSRC,INPHSP_MIN);
+      ]
+    ]
+};
+
 REPLACE {$BEAM_OPEN_PHSP_FOR_READ;} WITH {;};
 
 REPLACE {$BEAM_OPEN_PHSP_FOR_WRITE;} WITH {;};
@@ -84,9 +102,10 @@ REPLACE {;COMIN/my_times/;} WITH {;
       real             egs_tot_time,egs_etime;
 };
 
-subroutine beamlib_init(i_par,i_logunit,hhouse, ehome, beam_code, pfile, ifile);
+subroutine beamlib_init(i_par,n_par,i_logunit,hhouse, ehome, beam_code,
+                        pfile, ifile);
 implicit none;
-$INTEGER i_par, i_logunit;
+$INTEGER i_par, n_par,i_logunit;
 character*(*) hhouse, ehome, beam_code, pfile, ifile;
 
 ;COMIN/EGS-IO,my_times/;
@@ -98,6 +117,7 @@ $INTEGER i, lnblnk1, ircode;
 i_log = i_logunit;
 write(i_log,*) 'In beamlib_init!';
 write(i_log,*) 'i_par = ',i_par;
+write(i_log,*) 'n_par = ',n_par;
 write(i_log,'(a,a)') 'hen_house = ',$cstring(hhouse);
 write(i_log,'(a,a)') 'egs_home  = ',$cstring(ehome);
 write(i_log,'(a,a)') 'beam_code = ',$cstring(beam_code);
@@ -114,7 +134,7 @@ $set_string(user_code,' '); user_code = $cstring(beam_code);
 $set_string(pegs_file,' '); pegs_file = $cstring(pfile);
 $set_string(input_file,' '); input_file = $cstring(ifile);
 $set_string(output_file,' '); output_file = $cstring(ifile);
-is_batch = .true.; i_parallel = i_par; n_parallel = i_par;
+is_batch = .true.; i_parallel = i_par; n_parallel = n_par;
 IF($cstring(pegs_file)='pegsless')is_pegsless=.true.;
 
 call egs_init1;

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -4284,6 +4284,9 @@ IF((ISOURC=21 | ISOURC=24) & ~phsp_open)[
 ]
 "set the counter for the particle number being read from ph-sp file"
 
+"special case if this is a beam library source using a phase space file"
+$SET_INPHSP_BEAM_SOURCE_PARALLEL;
+
 JHSTRY = 0; "Reset counter for EGS_WINDOWS for ZLAST"
 
 IF(ISOURC < 21 | ISOURC=22) ["non-phase space input"
@@ -11117,7 +11120,7 @@ ELSEIF(ISOURC = 19) ["Gaussian parallel beam source"
 "***********
 ELSEIF(ISOURC = 23)[ "beam simulation source"
    OUTPUT 'About to call init_beamsource';(//a);
-   call init_beamsource(i_parallel,i_log,$CONFIGURATION_NAME,
+   call init_beamsource(i_parallel,n_parallel,i_log,$CONFIGURATION_NAME,
                         hen_house,egs_home,the_beam_code,
                         the_pegs_file,the_input_file);
    call maxenergy_beamsource(EKMAXSRC);
@@ -13907,10 +13910,10 @@ $HAVE_LOAD_DSO(#);
 
 #ifndef HAVE_LOAD_DSO;
 
-subroutine init_beamsource(i_parallel,i_log,conf_name,
+subroutine init_beamsource(i_parallel,n_parallel,i_log,conf_name,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
-$INTEGER i_parallel;
+$INTEGER i_parallel,n_parallel;
 character*(*) conf_name;
 character*(*) hen_house,egs_home,the_beam_code,the_pegs_file,the_input_file;
 write(6,*) 'You need a working C compiler to use source 9!';

--- a/HEN_HOUSE/omega/beamnrc/beamnrc_user_macros.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc_user_macros.mortran
@@ -176,6 +176,12 @@ REPLACE {$BEAMMODEL_SRCOUT} WITH {;}
 REPLACE {$BEAMMODEL_PASSING_VARIABLES} WITH {;}
 ;
 
+"If this is a beam shared library source that uses a phase space"
+"source and it is running in parallel, then the following macro"
+"gets replaced by code that specifies the portion of the phase"
+"space source to use"
+REPLACE {$SET_INPHSP_BEAM_SOURCE_PARALLEL;} WITH {;}
+
 ;
 
 "****************************************

--- a/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/srcxyznrc.mortran
@@ -2697,7 +2697,7 @@ ELSEIF(isource = 9 | isource=10)["Full BEAM treatment head simulation"
 "------------------------------------------------------------------------"
    dsource = -dsource;
    OUTPUT 'About to call init_beamsource';(//a);
-   call init_beamsource(i_parallel,i_log,$CONFIGURATION_NAME,
+   call init_beamsource(i_parallel,n_parallel,i_log,$CONFIGURATION_NAME,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
 ]
@@ -2717,7 +2717,7 @@ ELSEIF(isource = 20)["Phase Space Incident from multiple settings and "
      ]
      ELSE[
        OUTPUT 'About to initialise BEAM code..';(//a);
-       call init_beamsource(i_parallel,i_log,$CONFIGURATION_NAME,
+       call init_beamsource(i_parallel,n_parallel,i_log,$CONFIGURATION_NAME,
                          hen_house,egs_home,the_shared_lib,
                          the_pegs_file,the_input_file);
      ]
@@ -2748,7 +2748,7 @@ ELSEIF(isource = 21)["Full BEAM sim. incident from multiple settings and "
 "------------------------------------------------------------------------"
    dsource = -dsource;
    OUTPUT 'About to call init_beamsource';(//a);
-   call init_beamsource(i_parallel,i_log,$CONFIGURATION_NAME,
+   call init_beamsource(i_parallel,n_parallel,i_log,$CONFIGURATION_NAME,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
    OUTPUT 'Done initialization';(//a);
@@ -4476,10 +4476,10 @@ $HAVE_LOAD_DSO(#);
 
 #ifndef HAVE_LOAD_DSO;
 
-subroutine init_beamsource(i_parallel,i_log,conf_name,
+subroutine init_beamsource(i_parallel,n_parallel,i_log,conf_name,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
-$INTEGER i_parallel,i_log;
+$INTEGER i_parallel,n_parallel,i_log;
 character*(*) conf_name;
 character*(*) hen_house,egs_home,the_beam_code,the_pegs_file,the_input_file;
 write(6,*) 'You need a working C compiler to use source 9!';

--- a/HEN_HOUSE/utils/srcrz.mortran
+++ b/HEN_HOUSE/utils/srcrz.mortran
@@ -1643,7 +1643,7 @@ ELSEIF( ISOURC = 23 ) [ "A full treatment head simulation source using BEAM"
       '    X offset of phsp plane (before rotation)      : ',f10.4,' cm'/
       '    Y offset of phsp plane (before rotation)      : ',f10.4,' cm');
      write(6,'(//a)') 'About to call init_beamsource';
-     call init_beamsource(i_parallel,i_log,$CONFIGURATION_NAME,
+     call init_beamsource(i_parallel,n_parallel,i_log,$CONFIGURATION_NAME,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
      call maxenergy_beamsource(EKSRCM);
@@ -3249,10 +3249,10 @@ $HAVE_LOAD_DSO(#);
 
 #ifndef HAVE_LOAD_DSO;
 
-subroutine init_beamsource(i_parallel,i_log,conf_name,
+subroutine init_beamsource(i_parallel,n_parallel,i_log,conf_name,
                          hen_house,egs_home,the_beam_code,
                          the_pegs_file,the_input_file);
-$INTEGER i_parallel;
+$INTEGER i_parallel,n_parallel;
 character*(*) conf_name;
 character*(*) hen_house,egs_home,the_beam_code,the_pegs_file,the_input_file;
 write(6,*) 'You need a working C compiler to use source 23!';


### PR DESCRIPTION
Previously, a parallel run using a beam simulation source that used a
phase space source either hung or crashed due the fact that the
variables defining the record no. to be read from the phase space
source (INPHSP) and the segment of the phase space source considered
(INPHSP_MIN, INPHSP_MAX) were undefined.  Now, each parallel job is
uses a segment of the phase space source restricted by:

(i_parallel - 1)*(NNPHSP/n_parallel)+1 <= INPHSP <=
(i_parallel)*(NNPHSP/n_parallel)

where n_parallel is the no. of parallel jobs, i_parallel is the job
number, and NNPHSP is the total no. of particles in the phase space
source.