### PR TITLE
Fix #388, #383: concave CD, XYZ inside CD, conestack, and box geometry errors

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -431,6 +431,8 @@ EGS_BaseGeometry::EGS_BaseGeometry(const string &Name) : nreg(0), name(Name),
     has_B_scaling(false), has_Ref_rho(false), bfactor(0), rhoRef(1.0),
     nref(0), debug(false), is_convex(true), bproperty(0), bp_array(0),
     boundaryTolerance(epsilon) {
+
+    halfBoundaryTolerance = boundaryTolerance/2.;
     if (!egs_geometries.size()) {
         egs_geometries.addList(new EGS_GeometryPrivate);
     }
@@ -716,7 +718,9 @@ void EGS_BaseGeometry::setBoundaryTolerance(EGS_Input *i) {
     int err = i->getInput("boundary tolerance", boundaryTolerance);
     if (err > 0) {
         egsWarning("EGS_BaseGeometry::setBoundaryTolerance(): error while reading 'boundary tolerance' input\n");
+        return;
     }
+    halfBoundaryTolerance = boundaryTolerance/2.;
 }
 
 void EGS_BaseGeometry::printInfo() const {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -604,6 +604,7 @@ public:
      */
     void    setBoundaryTolerance(EGS_Float tol) {
         boundaryTolerance = tol;
+        halfBoundaryTolerance = tol/2.;
     }
 
     /*! \brief Is the boolean property \a prop set for region \a ireg ?
@@ -833,7 +834,7 @@ protected:
     EGS_BPType   *bp_array;
 
     /*! \brief Boundary tolerance for geometries that need it */
-    EGS_Float boundaryTolerance;
+    EGS_Float boundaryTolerance, halfBoundaryTolerance;
 
     /*! \brief Set to non-zero status if a geometry problem is encountered */
     static int       error_flag;

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
@@ -236,8 +236,8 @@ public:
         }
         if (t1 < t) {
             EGS_Float y1 = xp.y + up.y*t1, z1 = xp.z + up.z*t1;
-            if (2*y1 + ay >= 0 && 2*y1 - ay <= 0 &&
-                    2*z1 + az >= 0 && 2*z1 - az <= 0) {
+            if (2*y1 + ay > 0 && 2*y1 - ay < 0 &&
+                    2*z1 + az > 0 && 2*z1 - az < 0) {
                 t = t1;
                 if (newmed) {
                     *newmed = med;
@@ -273,8 +273,8 @@ public:
         }
         if (t1 < t) {
             EGS_Float x1 = xp.x + up.x*t1, z1 = xp.z + up.z*t1;
-            if (2*x1 + ax >= 0 && 2*x1 - ax <= 0 &&
-                    2*z1 + az >= 0 && 2*z1 - az <= 0) {
+            if (2*x1 + ax > 0 && 2*x1 - ax < 0 &&
+                    2*z1 + az > 0 && 2*z1 - az < 0) {
                 t = t1;
                 if (newmed) {
                     *newmed = med;
@@ -310,8 +310,8 @@ public:
         }
         if (t1 < t) {
             EGS_Float x1 = xp.x + up.x*t1, y1 = xp.y + up.y*t1;
-            if (2*x1 + ax >= 0 && 2*x1 - ax <= 0 &&
-                    2*y1 + ay >= 0 && 2*y1 - ay <= 0) {
+            if (2*x1 + ax > 0 && 2*x1 - ax < 0 &&
+                    2*y1 + ay > 0 && 2*y1 - ay < 0) {
                 t = t1;
                 if (newmed) {
                     *newmed = med;

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -565,11 +565,15 @@ public:
                 }
                 // Skip for concave geometries: particles can reenter the CD geometry after leaving.
                 // Check 2. below will catch these cases.
-                else if ((ixnew < 0 && tb <= boundaryTolerance) && (bg->isConvex()  &&
-                         (g[ibase] && g[ibase]->isConvex()))) {
-                    // (a) is true
-                    return ixnew;
-                }
+                // This follow has been commented out because it fails in cases
+                // where the inscribe geometries are themselves convex but
+                // form a concave shape. Instead, just continue to do more checks.
+//                 else if ((ixnew < 0 && tb <= boundaryTolerance) && (bg->isConvex()  &&
+//                          (g[ibase] && g[ibase]->isConvex()))) {
+//                     // (a) is true
+//                     return ixnew;
+//                 }
+
                 // If a particle approaching the geometry sits on a boundary, we look back to see
                 // if we just entered the geometry (the previous checks fail to catch this case).
                 EGS_Float tb_neg = veryFar;

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -1554,6 +1554,12 @@ public:
                 t = tp;                             // set t = distance to plane
             }
 
+            // If we are right on a plane, return -1
+            if(tp < boundaryTolerance) {
+                t = 0;
+                return -1;
+            }
+
             // distance to outer cone
             int ir = ireg - il*nmax;                // cone index in current layer
             bool hitc = false;                      // assume we don't hit the cone

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.h
@@ -333,7 +333,7 @@ public:
                         egsWarning("t=%g d=%g\n",last_t,last_d);
 #endif
                     }
-                    d = boundaryTolerance;
+                    d = halfBoundaryTolerance;
                 }
             }
 
@@ -377,7 +377,7 @@ public:
                         if (C < -boundaryTolerance) egsWarning("EGS_CylindersT::howfar(): "
                                                                    "the particle may not be in the region we think it "
                                                                    "is as Cin = %g\n",C);
-                        d = boundaryTolerance;
+                        d = halfBoundaryTolerance;
                     }
                 }
             }
@@ -401,7 +401,7 @@ public:
                             egsWarning("  ireg=%d x=(%g,%g,%g) u=(%g,%g,%g)\n",
                                        ireg,x.x,x.y,x.z,u.x,u.y,u.z);
                         }
-                        d = boundaryTolerance;
+                        d = halfBoundaryTolerance;
                     }
                 }
             }

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -901,7 +901,13 @@ public:
             if (u.x > 0) {
                 EGS_Float d = (xpos[ix+1]-x.x)/u.x;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        // t=0 works on most cases but can result in
+                        // getting stuck on an edge, so use boundaryTolerance
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((++ix) < nx) {
                         inew = ireg + 1;
                     }
@@ -916,7 +922,11 @@ public:
             else if (u.x < 0) {
                 EGS_Float d = (xpos[ix]-x.x)/u.x;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((--ix) >= 0) {
                         inew = ireg - 1;
                     }
@@ -931,7 +941,11 @@ public:
             if (u.y > 0) {
                 EGS_Float d = (ypos[iy+1]-x.y)/u.y;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((++iy) < ny) {
                         inew = ireg + nx;
                     }
@@ -946,7 +960,11 @@ public:
             else if (u.y < 0) {
                 EGS_Float d = (ypos[iy]-x.y)/u.y;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((--iy) >= 0) {
                         inew = ireg - nx;
                     }
@@ -961,7 +979,11 @@ public:
             if (u.z > 0) {
                 EGS_Float d = (zpos[iz+1]-x.z)/u.z;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((++iz) < nz) {
                         inew = ireg+nxy;
                     }
@@ -976,7 +998,11 @@ public:
             else if (u.z < 0) {
                 EGS_Float d = (zpos[iz]-x.z)/u.z;
                 if (d <= t) {
-                    t = d;
+                    if(d <= boundaryTolerance) {
+                        t = boundaryTolerance;
+                    } else {
+                        t = d;
+                    }
                     if ((--iz) >= 0) {
                         inew = ireg-nxy;
                     }

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -173,7 +173,7 @@ int EGS_cSpheres::howfar(int ireg, const EGS_Vector &x,
              */
             R2b2 = R2[ireg] - bb2;
             if (R2b2 <= 0 && aa > 0) {
-                d = boundaryTolerance;    // hopefully a truncation problem
+                d = halfBoundaryTolerance;    // hopefully a truncation problem
             }
             else {
                 tmp = aa2 + R2b2;


### PR DESCRIPTION
1. Fix a special case of geometry error where geometries that are convex individually result in a concave cd geometries when combined (issue #388). These geometry errors could be created using a radius-mismatched cylinder and sphere in a cd geometry. Also fix where a small step is taken in cylinder or sphere howfar routines to step by boundaryTolerance/2 instead of boundaryTolerance. This resulted in checks against the boundaryTolerance to fail in the cd geometry.

2. Fix a geometry error where particles could get stuck on an edge of an XYZ geometry used as the base geometry for a CD inscribed in an envelope (issue #383).

3. Fix an infinite loop that could occur in long simulations with a conestack with more than one layer. Previously, particles could get stuck on the surface between layers of the conestack. Example that would crash when simulating 1e7 particles:
```
:start geometry definition:
    :start geometry:
        library = egs_cones
        type = EGS_ConeStack
        name = inner
        axis = 0 0 -2.5545 0 0 1
        :start layer:
            thickness = .321
            top radii = 1.9
            bottom radii = 1.9
            media = air
        :stop layer:
        :start layer:
            thickness = 2.0585
            top radii = 1.9
            bottom radii = 1.9
            media = air
        :stop layer:
    :stop geometry:
    simulation geometry = inner
:stop geometry definition:
:start source definition:
    :start source:
        name    = isotropic_point_source
        library = egs_isotropic_source
        charge  = -1
        :start shape:
           type = sphere
            midpoint = 0 0 -2.5
            radius = 0.01
       :stop shape:
        :start spectrum:
           type = monoenergetic
           energy = 1.1
       :stop spectrum:
    :stop source:
    simulation source = isotropic_point_source
:stop source definition:
```

4. Fix a geometry error where a particle could get stuck in the corner of an egs_box. The error could be produced using:
```
:start geometry definition: 
     :start geometry: 
         library = egs_box 
         name    = the_world 
         box size = 50 50 50
         :start media input: 
             media = air 
         :stop media input: 
     :stop geometry: 
     :start geometry: 
      library = egs_box 
       box size =   2.8 2.8 2.8
          :start transformation:
            translation =    0, 9, 9
          :stop transformation: 
          name = my_box 
          :start media input: 
              media = water 
          :stop media input: 
      :stop geometry: 
      :start geometry: 
         library = egs_genvelope 
         name = the_scenario 
         base geometry = the_world 
         inscribed geometries =  my_box
      :stop geometry: 
simulation geometry =  the_scenario 
:stop geometry definition:
```