### PR TITLE
Fix egs_prism number of regions set to zero

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -64,7 +64,7 @@ EGS_PlaneCollection::EGS_PlaneCollection(int Np, const EGS_Float *pos,
 }
 
 EGS_PlaneCollection::~EGS_PlaneCollection() {
-    egsWarning("Deleting ~EGS_PlaneCollection at 0x%x\n",this);
+    //egsWarning("Deleting ~EGS_PlaneCollection at 0x%x\n",this);
     for (int j=0; j<np; j++) if (!planes[j]->deref()) {
             delete planes[j];
         }

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
@@ -143,6 +143,7 @@ public:
     EGS_PrismT(T *P, const string &Name="") :
         EGS_BaseGeometry(Name), p(P), a(p->getNormal()), open(true) {
         is_convex = p->isConvex();
+        nreg = 1;
     };
 
     /*! \brief Construct a closed prism using \a P as the base polygon
@@ -159,6 +160,7 @@ public:
             d2 = D1;
         }
         is_convex = p->isConvex();
+        nreg = 1;
     };
 
     /*! \brief Desctructor, deletes the base polygon */

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -125,7 +125,7 @@ extern "C" {
         if (!err && is_closed == 1) {
             o = false;
         }
-        egsWarning("%s: open = %d\n",type.c_str(),o);
+        //egsWarning("%s: open = %d\n",type.c_str(),o);
         if (input->compare(type,__pyrX) || input->compare(type,__pyrY) ||
                 input->compare(type,__pyrZ)) {
             int np = p.size()/2;


### PR DESCRIPTION
Fixes the number of regions assigned to egs_prism geometries. Now nreg is set to 1 instead of defaulting to 0. Previously, this would result in region labels not working.

Comments out two warning messages that always occurred for `egs_planes` and `egs_pyramids.` This does not change any functionality.