### PR TITLE
Radiative splitting ausgab object (AO)

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -62,7 +62,7 @@ shape_libs = egs_circle egs_ellipse egs_extended_shape egs_gaussian_shape \
              egs_line_shape egs_polygon_shape egs_rectangle egs_shape_collection \
              egs_voxelized_shape
 
-aobject_libs = egs_track_scoring egs_dose_scoring
+aobject_libs = egs_track_scoring egs_dose_scoring egs_radiative_splitting
 
 all_libs = $(geometry_libs) $(source_libs) $(shape_libs) $(aobject_libs)
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/Makefile
@@ -1,0 +1,48 @@
+
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build radiative splitting object
+#  Copyright (C) 2018 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2018
+#
+#  Contributors:
+#
+###############################################################################
+
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_DOSE_SCORING_DLL
+
+library = egs_radiative_splitting
+lib_files = egs_radiative_splitting
+my_deps = $(common_ausgab_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)
+
+test:
+	@echo "common_h2: $(common_h2)"
+	@echo "extra_dep: $(extra_dep)"

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
@@ -1,0 +1,117 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ radiative splitting object
+#  Copyright (C) 2018 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2018
+#
+#  Contributors:
+#
+###############################################################################
+#
+#  A general radiative splitting tool.
+#
+#  TODO:
+#
+#  - Add directional radiative splitting (DRS)
+#
+###############################################################################
+*/
+
+
+/*! \file egs_radiative_splitting.cpp
+ *  \brief A radiative splitting ausgab object: implementation
+ *  \EM
+ */
+
+#include <fstream>
+#include <string>
+#include <cstdlib>
+
+#include "egs_radiative_splitting.h"
+#include "egs_input.h"
+#include "egs_functions.h"
+
+EGS_RadiativeSplitting::EGS_RadiativeSplitting(const string &Name,
+        EGS_ObjectFactory *f) :
+    nsplit(1) {
+    otype = "EGS_RadiativeSplitting";
+}
+
+EGS_RadiativeSplitting::~EGS_RadiativeSplitting() {
+}
+
+void EGS_RadiativeSplitting::setApplication(EGS_Application *App) {
+    EGS_AusgabObject::setApplication(App);
+    if (!app) {
+        return;
+    }
+
+    char buf[32];
+
+    // Set EGSnrc internal radiative splitting number .
+    app->setRadiativeSplitting(nsplit);
+
+    description = "\n===========================================\n";
+    description +=  "Radiative splitting Object (";
+    description += name;
+    description += ")\n";
+    description += "===========================================\n";
+    if (nsplit > 1) {
+        description +="\n - Splitting radiative events in ";
+        sprintf(buf,"%d\n\n",nsplit);
+        description += buf;
+    }
+    else if (nsplit == 1) {
+        description +="\n - NO radiative splitting";
+    }
+    else {
+        description +="\n - BEWARE: Turning OFF radiative events !!!";
+    }
+    description += "\n===========================================\n\n";
+}
+
+//*********************************************************************
+// Process input for this ausgab object
+//
+//**********************************************************************
+extern "C" {
+
+    EGS_RADIATIVE_SPLITTING_EXPORT EGS_AusgabObject *createAusgabObject(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        const static char *func = "createAusgabObject(radiative_splitting)";
+        if (!input) {
+            egsWarning("%s: null input?\n",func);
+            return 0;
+        }
+
+        EGS_Float nsplit = 1.0;
+        int err = input->getInput("splitting",nsplit);
+
+        //=================================================
+
+        /* Setup radiative splitting object with input parameters */
+        EGS_RadiativeSplitting *result = new EGS_RadiativeSplitting("",f);
+        result->setSplitting(nsplit);
+        result->setName(input);
+        return result;
+    }
+}

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
@@ -1,0 +1,127 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ radiative splitting object headers
+#  Copyright (C) 2018 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2018
+#
+#  Contributors:
+#
+###############################################################################
+#
+#  A general radiative splitting tool.
+#
+#  TODO:
+#
+#  - Add directional radiative splitting (DRS)
+#
+###############################################################################
+*/
+
+
+/*! \file egs_radiative_splitting.h
+ *  \brief A radiative splitting ausgab object: header
+ *  \EM
+ */
+
+#ifndef EGS_RADIATIVE_SPLITTING_
+#define EGS_RADIATIVE_SPLITTING_
+
+#include "egs_ausgab_object.h"
+#include "egs_application.h"
+#include "egs_scoring.h"
+#include "egs_base_geometry.h"
+
+#ifdef WIN32
+
+    #ifdef BUILD_RADIATIVE_SPLITTING_DLL
+        #define EGS_RADIATIVE_SPLITTING_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_RADIATIVE_SPLITTING_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_RADIATIVE_SPLITTING_LOCAL
+
+#else
+
+    #ifdef HAVE_VISIBILITY
+        #define EGS_RADIATIVE_SPLITTING_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_RADIATIVE_SPLITTING_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_RADIATIVE_SPLITTING_EXPORT
+        #define EGS_RADIATIVE_SPLITTING_LOCAL
+    #endif
+
+#endif
+
+/*! \brief A radiative splitting object: header
+
+\ingroup AusgabObjects
+
+This ausgab object can be used to increase the efficiency of radiative
+events. This ausgab object is specified via:
+\verbatim
+:start ausgab object:
+    library   = egs_radiative_splitting
+    name      = some_name
+    splitting = n_split
+:stop ausgab object:
+\endverbatim
+
+TODO:
+ - Add directional radiative splitting (DRS)
+
+*/
+
+class EGS_RADIATIVE_SPLITTING_EXPORT EGS_RadiativeSplitting : public EGS_AusgabObject {
+
+public:
+
+    /*! Splitting algortihm type */
+    enum Type {
+        URS, // EGSnrc Uniform Radiative Splitting
+        DRS, // Directional Radiative Splitting
+        DRSf // Directional Radiative Splitting (BEAMnrc)
+    };
+
+    EGS_RadiativeSplitting(const string &Name="", EGS_ObjectFactory *f = 0);
+
+    ~EGS_RadiativeSplitting();
+
+    void setApplication(EGS_Application *App);
+
+    void setSplitting(const int &n_s) {
+        nsplit = n_s;
+    };
+
+    int processEvent(EGS_Application::AusgabCall iarg) {
+        return 0;
+    };
+    int processEvent(EGS_Application::AusgabCall iarg, int ir) {
+        return 0;
+    };
+
+protected:
+    /* Maximum splitting limited to 2,147,483,647 */
+    int nsplit;
+
+};
+
+#endif

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1186,6 +1186,10 @@ EGS_Float EGS_AdvancedApplication::getPcut() {
 EGS_Float EGS_AdvancedApplication::getRM() {
     return the_useful->rm;
 }
+// Turns ON/OFF radiative splitting
+void EGS_AdvancedApplication::setRadiativeSplitting(const EGS_Float &nsplit) {
+    the_egsvr->nbr_split = nsplit;
+}
 
 extern __extc__ void egsHowfar() {
     CHECK_GET_APPLICATION(app,"egsHowfar()");

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -213,6 +213,8 @@ public:
     EGS_Float getPcut();
     /* Needed by some sources */
     EGS_Float getRM();
+    /* Turn ON/OFF radiative splitting */
+    void setRadiativeSplitting(const EGS_Float &nsplit);
 
 protected:
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1111,6 +1111,7 @@ public:
     virtual EGS_Float getRM() {
         return -1.0;
     };
+    virtual void setRadiativeSplitting(const EGS_Float &nsplit) {};
 };
 
 #define APP_MAIN(app_name) \


### PR DESCRIPTION
A first step for implementing the variance reduction technique (VRT) _radiative splitting_ via an AO making this VRT available to any C++ application. It simply turns on the intrinsic _uniform radiative splitting_ in `EGSnrc` by setting `nbr_split` to a user-defined value which can have the following effects:

- If `nbr_split > 1`: uniform radiative splitting (URS) is ON
- If `nbr_split = 1`: no radiative splitting
- If `nbr_split < 1`: Radiative events OFF !!!

This should make possible the efficient simulation of electronic brachytherapy sources. It will also allow modelling x-ray tubes and linacs albeit less efficiently than the DBS technique as implemented in `BEAMnrc`. The next step is to implement _directional radiative splitting_ which would increase the efficiency in the simulation of x-ray tubes and linacs.

The syntax to define this AO is simply:

```
:start ausgab object:
  library   = egs_radiative_splitting
  name      = some_name
  splitting = n_split
:stop ausgab object:
```