### PR TITLE
Fix egs_view simulation geometry selection

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -75,13 +75,13 @@ extern "C" {
         // select geometry
         EGS_BaseGeometry *g;
         if (type == "EGS_XCylinders") {
-            g = new EGS_CylindersX(radii.size(),r,xo,"",EGS_XProjector(""));
+            g = new EGS_CylindersX(radii.size(),r,xo,"",EGS_XProjector("EGS_XCylinders"));
         }
         else if (type == "EGS_YCylinders") {
-            g = new EGS_CylindersY(radii.size(),r,xo,"",EGS_YProjector(""));
+            g = new EGS_CylindersY(radii.size(),r,xo,"",EGS_YProjector("EGS_YCylinders"));
         }
         else if (type == "EGS_ZCylinders") {
-            g = new EGS_CylindersZ(radii.size(),r,xo,"",EGS_ZProjector(""));
+            g = new EGS_CylindersZ(radii.size(),r,xo,"",EGS_ZProjector("EGS_ZCylinders"));
         }
         else {
             vector<EGS_Float> a;

--- a/HEN_HOUSE/egs++/view/renderworker.cpp
+++ b/HEN_HOUSE/egs++/view/renderworker.cpp
@@ -141,13 +141,13 @@ void RenderWorker::drawAxes(const RenderParameters &p) {
                 int sign = j1 > j0 ? 1 : -1;
                 deltax = sign*(float)(di) / (float)(dj);
                 deltay = sign;
-                n = abs(dj) > ny ? ny : abs(dj);
+                n = abs(dj);
             }
             else {
                 int sign = i1 > i0 ? 1 : -1;
                 deltax = sign;
                 deltay = sign*(float)(dj) / (float)(di);
-                n = abs(di) > nx ? nx : abs(di);
+                n = abs(di);
             }
             for (int t=0; t<=n; t++) {
                 i1 = (int)(i0+t*deltax);

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -198,6 +198,7 @@ private:
     bool    allowRegionSelection,
             energyScaling;
     vector<vector<EGS_Float>> scoreArrays;
+    vector<string> geometryNames;
     EGS_BaseGeometry *origSimGeom;
 
 protected slots:


### PR DESCRIPTION
Fix the egs_view simulation geometry selection so that only geometries that are actually named in the input file can be selected. When selecting the simulation geometry, the view window now resets the camera position to find a point within the new geometry.

Fix a bug where the axis did not display correctly at certain view angles when the geometry was not near the origin.

Fix a bug in egs_cylinders where the geometry type was not defined. This was only necessary so that the type was displayed correctly in egs_view.