### PR TITLE
Add a flag to specify if EM fields are on or off

### DIFF
--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -758,6 +758,10 @@ int EGS_AdvancedApplication::helpInit(EGS_Input *transportp, bool do_hatch) {
         the_emf->ExIN=efield_v[0];
         the_emf->EyIN=efield_v[1];
         the_emf->EzIN=efield_v[2];
+        if (efield_v[0]*efield_v[0]+efield_v[1]*efield_v[1]+efield_v[2]*efield_v[2] > 0) {
+            the_emf->emfield_on = true;
+        }
+
     }
     if (bfield.size()==3) {
         bfield.info(nc);
@@ -770,6 +774,9 @@ int EGS_AdvancedApplication::helpInit(EGS_Input *transportp, bool do_hatch) {
     }
     if (efield.size()==3 || bfield.size()==3) {
         estepem.info(nc);
+        if (bfield_v[0]*bfield_v[0]+bfield_v[1]*bfield_v[1]+bfield_v[2]*bfield_v[2] > 0) {
+            the_emf->emfield_on = true;
+        }
     }
     egsInformation("==============================================\n\n");
 
@@ -1283,5 +1290,3 @@ extern __extc__ void egsStartParticle() {
     //egsInformation("start particle: ir=%d medium=%d\n",ir,the_useful->medium);
     app->startNewParticle();
 }
-
-

--- a/HEN_HOUSE/interface/egs_interface2.h
+++ b/HEN_HOUSE/interface/egs_interface2.h
@@ -637,6 +637,7 @@ struct EGS_emfInputs {
     /*! Input values for static electric and magnetic fields */
     EGS_Float ExIN, EyIN, EzIN, EMLMTIN,
     BxIN, ByIN, BzIN, Bx, By, Bz, Bx_new, By_new, Bz_new;
+    bool emfield_on;
 };
 
 /*! \brief The address of the mortran \c STACK common block as a

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -915,6 +915,10 @@ ExIN=$ExDEF;EyIN=$EyDEF;EzIN=$EzDEF;
 BxIN=$BxDEF;ByIN=$ByDEF;BzIN=$BzDEF; EMLMTIN=$EMLMTDEF;
 Bx=BxIN;    By=ByIN;    Bz=BzIN;
 Bx_new=Bx;  By_new=By;  Bz_new=Bz;
+emfield_on=.false.;
+IF( ExIN**2+EyIN**2+EzIN**2 + BxIN**2+ByIN**2+BzIN**2 > 0 ) [
+    emfield_on=.true.
+]
 
 DO i=1,$MXMED [
     iraylm(i) = 0; "Rayleigh data available?"

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -633,13 +633,15 @@ REPLACE {;COMIN/EMF-INPUTS/;} WITH {;
                      EMLMTIN,         "Ekin, u, E fractional maximum change"
                      BxIN, ByIN, BzIN,       "B field: initial region"
                      Bx, By, Bz,             "B field: current region"
-                     Bx_new, By_new, Bz_new; "B field: in new region"
+                     Bx_new, By_new, Bz_new, "B field: in new region"
+                     emfield_on;             "true if EM fields not null"
 
    $REAL    ExIN,EyIN,EzIN,
             EMLMTIN,
             BxIN,ByIN,BzIN,
             Bx,By,Bz,
             Bx_new,By_new,Bz_new;
+   $LOGICAL emfield_on;
 };
 ;  "---------- BUFFER FLUSH SEMICOLON ----------"
 " The following common block is made available to the user so that  "
@@ -1633,7 +1635,7 @@ REPLACE {$SET-RHOF;} WITH {RHOF=RHOR(IRL)/RHO(MEDIUM);}  "DEFAULT"
 "TEMPLATES FOR PERFORMING CHARGED PARTICLE TRANSPORT IN EM FIELD"
 REPLACE {$SET-TUSTEP-EM-FIELD;} WITH {;}
 REPLACE {$SET-USTEP-EM-FIELD;} WITH {;}
-REPLACE {$VACUUM-TRANSPORT-EM-FIELD;} WITH {;}
+REPLACE {$VACUUM-ADD-WORK-EM-FIELD;} WITH {;}
 REPLACE {$SET-ANGLES-EM-FIELD;} WITH {;}
 REPLACE {$SET-TVSTEP-EM-FIELD;} WITH {;}
 REPLACE {$ADD-WORK-EM-FIELD;} WITH {;}

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1370,7 +1370,7 @@ $start_new_particle;
                     "( vstep is ustep truncated (possibly) by howfar
                     " tvstep is the total curved path associated with vstep)
                     edep = pzero; "no energy loss in vacuum
-                    $VACUUM-TRANSPORT-EM-FIELD;
+                    $VACUUM-ADD-WORK-EM-FIELD;
                         "additional vacuum transport in em field
                     e_range = vacdst;
                     $AUSCALL($TRANAUSB);

--- a/HEN_HOUSE/src/emf_macros.mortran
+++ b/HEN_HOUSE/src/emf_macros.mortran
@@ -134,6 +134,7 @@ REPLACE {$EMMLMT} WITH {0.20}
 "IF THE FIELDS ARE WEAK ENOUGH THEY SHOULDN'T AFFECT THE TRANSPORT.           "
 "                                                                             "
 REPLACE {$SET-TUSTEP-EM-FIELD;} WITH {;
+IF (emfield_on) [
 TUSTP0=TUSTEP;
 X0=X(NP);Y0=Y(NP);Z0=Z(NP);
 $GET-EM-FIELD(E,B,X0,Y0,Z0);
@@ -163,6 +164,7 @@ $SET-TUSTEP-DIRECTION-VECTOR-CHANGE-EM-FIELD;
 $SET-TUSTEP-ENERGY-CHANGE-EM-FIELD;
 $SET-TUSTEP-CHANGE-OF-EM-FIELD;
 $SET-TUSTEP-DIRECTION-VECTOR-CHANGE-BY-MULTIPLE-SCATTERING;
+]
 }
 ;
 "                                                                             "
@@ -240,6 +242,7 @@ REPLACE {$SET-USTEP-EM-FIELD;} WITH {;}
 "                                                                             "
 "THIS MACRO SETS THE NEW DIRECTION COSINES IN THE PRESENCE OF THE EM FIELD"
 REPLACE {$SET-ANGLES-EM-FIELD;} WITH {;
+IF (emfield_on) [
 IF(TVSTEP.NE.0.0)[
     IF(BPERP2.NE.0.0)[
 
@@ -272,6 +275,7 @@ IF(TVSTEP.NE.0.0)[
         W(NP)=(W(NP)+TVSTEP*DPERPZ)/FNORM;
         ]
     ]
+]
 }
 ;
 "                                                                             "
@@ -286,21 +290,12 @@ REPLACE {$SET-TVSTEP-EM-FIELD;} WITH {;}
 "*****************************************************************************"
 "                                                                             "
 "THIS MACRO IS USED TO SET THE ANGLES AND PATHLENGTH CORRECTION IN VACUUM     "
-REPLACE {$VACUUM-TRANSPORT-EM-FIELD;} WITH {;
-IF(MEDIUM.EQ.0)[
-"$SET-TVSTEP-EM-FIELD;--this is for higher order corrections"
-"do first order corrections for now--BW"
-IF(ExIN~=0.0 | EyIN~=0.0 | EzIN~=0.0 | BxIN~=0.0 | ByIN~=0.0 | BzIN~=0)[
+REPLACE {$VACUUM-ADD-WORK-EM-FIELD;} WITH {;
+IF (emfield_on) [
 DE=0.0;
 $ADD-WORK-EM-FIELD;
 PEIE=PEIE-DE;EIE=PEIE;E(NP)=PEIE;
 "done first order corrections"
-]
-ELSE[
-BPERP2=0.0;
-DPERP2=0.0;
-"so we do not change direction cosines to nonsense"
-]
 ]
 }
 ;
@@ -309,11 +304,13 @@ DPERP2=0.0;
 "                                                                             "
 "THIS MACRO ADJUSTS DE TO INCORPORATE THE POTENTIAL CHANGE IN THE E FIELD     "
 REPLACE {$ADD-WORK-EM-FIELD;} WITH {;
+IF (emfield_on) [
 $GET-POTENTIAL(POT1,X0,Y0,Z0);
 X1=X0+USTEP*U(NP);Y1=Y0+USTEP*V(NP);Z1=Z0+USTEP*W(NP);
 $GET-POTENTIAL(POT2,X1,Y1,Z1);
 POTDIF=POT2-POT1;
 DE=DE+POTDIF;
+]
 }
 ;
 "                                                                             "

--- a/HEN_HOUSE/src/get_inputs.mortran
+++ b/HEN_HOUSE/src/get_inputs.mortran
@@ -1604,12 +1604,16 @@ IF( error_flags(num_cxsec) = 0 ) [
 IF( error_flags(num_photonuc_xsec) = 0 ) [
     photonuc_xsections = char_value(num_photonuc_xsec,1);
 ]
+
 IF( error_flags(num_efield) = 0 ) [
     ExIN = value(num_efield,1);
     EyIN = value(num_efield,2);
     EzIN = value(num_efield,3);
     IF( error_flags(num_emlmt) = 0 )[
        EMLMTIN=value(num_emlmt,1);
+    ]
+    IF( ExIN**2+EyIN**2+EzIN**2 > 0 ) [
+        emfield_on=.true.
     ]
 ]
 " Initially set to input values, could change with regions"
@@ -1624,7 +1628,12 @@ IF( error_flags(num_bfield) = 0 ) [
     IF( error_flags(num_emlmt) = 0 )[
        EMLMTIN=value(num_emlmt,1);
     ]
+    IF( BxIN**2+ByIN**2+BzIN**2 > 0 ) [
+        emfield_on=.true.
+    ]
 ]
+
+
 /***************************************************************/
 /* Get media for which to read custom ff and the ff file names */
 /***************************************************************/


### PR DESCRIPTION
Add the boolean variable emfield_on which is set to true if the
electromagnetic field (emf) is not null. This flag is used in the
emf_macros to skip all field related computations when there is no
field.

Ideally the file emf_macros.mortran would not be included at all in the
compilation when there is no field, but it proves impractical and error
prone to change the Makefile and recompile upon changing the input
parameters. The emfield_on flag allows the emf_macros to be integrated
by default, yet not waste time at each step when the field is 0.