### PR TITLE
Add a simple template egs++ application egs_app

### DIFF
--- a/HEN_HOUSE/scripts/finalize_egs_foruser
+++ b/HEN_HOUSE/scripts/finalize_egs_foruser
@@ -75,7 +75,7 @@ else
     test_egs_home=$(cd $my_dir/../..; pwd)/egs_home
 fi
 
-cpp_user_codes="cavity egs_cbct egs_chamber egs_fac tutor2pp tutor7pp"
+cpp_user_codes="egs_app cavity egs_cbct egs_chamber egs_fac tutor2pp tutor7pp"
 # Now explain to the user what this script is going to do.
 #
 cat >&2 <<_ACEOF
@@ -463,4 +463,3 @@ cat >&2 <<EOF
 EOF
 
 exit 0
-

--- a/HEN_HOUSE/user_codes/egs_app/Makefile
+++ b/HEN_HOUSE/user_codes/egs_app/Makefile
@@ -1,0 +1,75 @@
+
+###############################################################################
+#
+#  EGSnrc makefile to build an egs++ application
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Iwan Kawrakow, 2007
+#
+#  Contributors:
+#
+###############################################################################
+#
+#  As long as your own application is derived from EGS_AdvancedApplication and
+#  there is a single C++ source file named $(USER_CODE).cpp, you can simply
+#  use this Makefile by copying it into the application directory and changing
+#  the USER_CODE variable below to the name of your application.
+#
+###############################################################################
+
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp1.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+# Specify the name of the application. The name of the executable is determined
+# from this variable.
+
+USER_CODE = egs_app
+
+
+# The following can be used to add user macros and mortran subroutines. The
+# file(s) specified here are added after egsnrc.macros, machine.macros and
+# egs_c_interface2.macros but before any files that have executable code.
+
+EGSPP_USER_MACROS = # egs_app.macros (for example)
+
+
+# Specify from which base class this application is being derived. This has the
+# effect of automatically compiling the base application class and including it
+# into the list of object files.
+
+EGS_BASE_APPLICATION = egs_advanced_application
+
+
+# Specify the set of mortran sources used. Here we simply use the standard set
+# defined in $HEN_HOUSE/specs/egspp1.spec
+
+CPP_SOURCES = $(C_ADVANCED_SOURCES)
+
+
+# Specify here other header files that your user code depends upon.
+
+other_dep_user_code = $(ABS_EGSPP)egs_scoring.h
+
+
+# Include the default EGSnrc c++ skeleton makefile
+
+include $(HEN_HOUSE)makefiles$(DSEP)cpp_makefile

--- a/HEN_HOUSE/user_codes/egs_app/array_sizes.h
+++ b/HEN_HOUSE/user_codes/egs_app/array_sizes.h
@@ -1,0 +1,47 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ egs_app application array sizes headers
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Iwan Kawrakow, 2007
+#
+#  Contributors:
+#
+###############################################################################
+#
+#  Defines he maximum number of media (MXMED) and the maximum number of
+#  particles on the stack (MXSTACK). This file gets included by the EGSnrc
+#  fortran subroutines (egsnrc_$my_machine.F), the base application
+#  (egs_simple_application.cpp or egs_advanced_application.cpp in
+#  $HEN_HOUSE/egs++), and perhaps also the application, if it uses the particle
+#  stack or one of the structures that depends on the maximum number of media.
+#
+###############################################################################
+*/
+
+
+#ifndef ARRAY_SIZES_
+#define ARRAY_SIZES_
+
+#define MXMED   100
+#define MXSTACK 10000
+
+#endif

--- a/HEN_HOUSE/user_codes/egs_app/egs_app.cpp
+++ b/HEN_HOUSE/user_codes/egs_app/egs_app.cpp
@@ -1,0 +1,108 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ egs_app template application
+#  Copyright (C) 2018 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Authors:         Frederic Tessier, 2018
+#
+#  Contributors:
+#
+###############################################################################
+#
+#  The simplest possible EGSnrc application, which relies on the implementation
+#  of EGS_AdvancedApplication, to run a simulation described in an egs++ input
+#  file (the provided slab.egsinp, for example).
+#
+#  The code commented below APP_MAIN can serve as a template for deriving an
+#  application class from EGS_AdvancedApplication, and re-implementing the
+#  initScoring method to select ausgab call triggers, and the ausgab method
+#  to handle those calls.
+#
+###############################################################################
+*/
+
+#include "egs_advanced_application.h"
+#include "egs_interface2.h"
+
+// main
+APP_MAIN (EGS_AdvancedApplication);
+
+
+
+
+/*
+class APP_EXPORT myapp : public EGS_AdvancedApplication {
+    public:
+        myapp(int argc, char **argv) :
+            EGS_AdvancedApplication(argc,argv) {}
+        int initScoring();
+        int ausgab(int iarg);
+};
+
+
+// initScoring
+int myapp::initScoring() {
+
+    // call ausgab for all energy deposition events
+    for (int call=BeforeTransport; call<=ExtraEnergy; ++call) {
+        setAusgabCall((AusgabCall)call, true);
+    }
+
+    // don't call ausgab for other events
+    for (int call=AfterTransport; call<UnknownCall; ++call) {
+        setAusgabCall((AusgabCall)call, false);
+    }
+
+    // activate individual ausgab triggers (full list in myapplication.h). e.g.,
+    setAusgabCall((AusgabCall) BeforeBrems, true);
+    setAusgabCall((AusgabCall) AfterBrems,  true);
+
+    return 0;
+}
+
+
+// ausgab
+int myapp::ausgab(int iarg) {
+
+    // stack index variables
+    int np = the_stack->np - 1;
+    int npold  = the_stack->npold - 1;
+    int region = the_stack->ir[np]-2;
+
+    // stack phase space variables
+    double E = the_stack->E[np];
+    double x = the_stack->x[np];
+    double y = the_stack->y[np];
+    double z = the_stack->z[np];
+    double u = the_stack->u[np];
+    double v = the_stack->v[np];
+    double w = the_stack->w[np];
+    double weight = the_stack->wt[np];
+    int iq = the_stack->iq[np];
+
+    // latch stack variable
+    int latch  = the_stack->latch[np];
+
+    // handle the ausgab call
+
+    return 0;
+}
+*/

--- a/HEN_HOUSE/user_codes/egs_app/slab.egsinp
+++ b/HEN_HOUSE/user_codes/egs_app/slab.egsinp
@@ -1,0 +1,122 @@
+##############################################################################
+#
+# Simple egs++ plate simulation
+#
+##############################################################################
+
+
+##############################################################################
+### Run control
+##############################################################################
+:start run control:
+    ncase = 1e5
+:stop run control:
+
+
+##############################################################################
+### Geometry
+##############################################################################
+:start geometry definition:
+
+    ### a simple slab geometry
+    :start geometry:
+        name     = plate
+        library  = egs_ndgeometry
+        type     = EGS_XYZGeometry
+        x-planes = -5, 5                        # cm
+        y-planes = -5, 5                        # cm
+        z-planes = -10, 0, 1, 10                # cm
+        :start media input:
+            media = air water
+            set medium = 1 1
+        :stop media input:
+    :stop geometry:
+
+    ### Simulation geometry
+    simulation geometry = plate
+
+:stop geometry definition:
+
+
+##############################################################################
+### Media
+##############################################################################
+:start media definition:
+
+    ### particle production thresholds
+    ae = 0.521                                  # MeV
+    ap = 0.010                                  # MeV
+    ue = 50.511                                 # MeV
+    up = 50                                     # MeV
+
+    ### air
+    :start air:
+        density correction file = air_dry_nearsealevel
+    :stop air:
+
+    ### water
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+
+    ### See $HEN_HOUSE/pegs4/density_corrections/ for more materials, or create
+    ### you own: https://github.com/nrc-cnrc/EGSnrc/wiki/Generating-density-correction-files
+
+:stop media definition:
+
+
+##############################################################################
+### Source
+##############################################################################
+:start source definition:
+
+    ### pencil beam
+    :start source:
+        name      = pencil_beam
+        library   = egs_parallel_beam
+        charge    = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 20                         # MeV
+        :stop spectrum:
+        :start shape:
+            type     = point
+            position = 0 0 -8                   # cm
+        :stop shape:
+    :stop source:
+
+    ### use this source for the simulation
+    simulation source = pencil_beam
+
+:stop source definition:
+
+
+##############################################################################
+### Ausgab objects
+##############################################################################
+:start ausgab object definition:
+
+    ### generate particle tracks
+    :start ausgab object:
+        name    = tracks
+        library = egs_track_scoring
+    :stop ausgab object:
+
+    ### report dose in all regions
+    :start ausgab object:
+        name    = dose
+        library = egs_dose_scoring
+        volume  = 1000, 100, 900
+    :stop ausgab object:
+
+:stop ausgab object definition:
+
+
+##############################################################################
+### Viewer control
+##############################################################################
+:start view control:
+    set color = air    0 200  50  50               # r g b alpha
+    set color = water  0 220 255 200
+:stop view control:


### PR DESCRIPTION
Provide the simplest possible EGSnrc application, which relies on the
implementation of EGS_AdvancedApplication, to run a simulation described
in an egs++ input file (the provided slab.egsinp, for example).

The code commented below APP_MAIN can serve as a template for deriving an
application class from EGS_AdvancedApplication, and re-implementing the
initScoring method to select ausgab call triggers, and the ausgab method
to handle those calls.