### PR TITLE
Fix bug in atomic relaxation of some actinides

### DIFF
--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -674,6 +674,7 @@ REPLACE {$MXESHLL} WITH {30}  "max. number of shells for an element"
 REPLACE {$MAXSHELL} WITH {3000}"max. number of shells"
 REPLACE {$MAXRELAX} WITH {10000}"max. number of relaxations channels"
 REPLACE {$MAXVAC} WITH {100}   "max. number of vacancies"
+REPLACE {$MAXTRANS} WITH {300}  "max. number of transitions per element"
 "============================================================"
 " Set input key 'Atomic relaxations' to 'simple' to recover original
 " implementation which allows photoelectric interactions with <M> and

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -5825,9 +5825,8 @@ character  data_dir*128,relax_file*144;
 $INTEGER  ish,medio,iZ,ntran;
 $REAL     Ec, Pc, tmp, min_be, sumw,Ex;
 $LOGICAL  is_open, is_there;
-REPLACE {$MAXTMP} WITH {250}
-$REAL     wtmp($MAXTMP);
-$INTEGER  itmp($MAXTMP);
+$REAL     wtmp($MAXTRANS);
+$INTEGER  itmp($MAXTRANS);
 
 integer*4 pos, curr_rec, sh_eadl;
 integer*4 nz, nshell, tr_type;


### PR DESCRIPTION
This PR fixes the following bug:

**Symptoms:** Simulations crashing (segmentation fault) for Pa, U, Np,
          and Cm when using EADL atomic relaxation.

**BUG:** Number of maximum transitions was fixed in egs_init_relax to 250
     via the local macro $MAXTMP. However some elements have a larger
     number of transitions, the maximum being 270 for curium (Cm).

**FIX:** Increase size of the arrays to 300.

**CHANGE:** Using now global macro $MAXTRANS

> Thanks to Jason Bolton from Nordion who encountered the segmentation fault and to @rtownson who tracked it back to being related to relaxations.