### PR TITLE
Fix #176: relax C compiler selection and conf name

### DIFF
--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -170,7 +170,7 @@ echo "yes ($abs_make)" >&2
 # Now see which fortran compiler is to be used.
 # First check the availability of fortran compilers
 echo >&2;
-printf $format "Looking for installed fortran compilers ... " >&2
+printf $format "Looking for available fortran compilers ... " >&2
 f_compilers=
 f_first=
 for fc_prog in gfortran g77 f77 xlf cf77 cft77 frt pgf77 fl32 af77 fort77 f90 xlf90 pgf90 epcf90 f95 fort xlf95 lf95 g95 asf77 ifort; do
@@ -189,13 +189,10 @@ for fc_prog in gfortran g77 f77 xlf cf77 cft77 frt pgf77 fl32 af77 fort77 f90 xl
         break
     done
 done
-echo "OK" >&2
-echo >&2;
 if test "x$f_compilers" = x; then
-    echo "Did not find a FORTRAN compiler in your search path" >&2
+    echo "$none" >&2
 else
-    echo "Found the following FORTRAN compilers in your search path:" >&2
-    echo "    $f_compilers" >&2
+    echo "found: $f_compilers" >&2
 fi
 while true; do
     echo
@@ -239,10 +236,13 @@ while true; do
         found_F77=yes; break
     done
     if test "x$found_F77" = x; then
-        echo "No compiler with that name was found." >&2
-        echo "You must either give a full path name or include the directory" >&2
-        echo "where the compiler is installed in your search path or" >&2
-        echo "install a fortran compiler if you don't have one installed" >&2
+        cat >&2 <<EOF
+
+No compiler with that name was found. You must either give a full path name or
+include the directory where the compiler is installed in your search path or
+install a fortran compiler if none is installed.
+
+EOF
     else
         break
     fi
@@ -1327,7 +1327,7 @@ rm -f junk_file conftest.$test_ext conftest$test_exeext
 #
 #*****************************************************************************
 echo >&2;
-printf $format "Looking for C compilers installed on your system ... " >&2
+printf $format "Looking for available C compilers ... " >&2
 c_compilers=
 c_first=
 have_c_compiler=no
@@ -1349,53 +1349,79 @@ for cc_prog in gcc cc xlc cl c89 icc; do
 done
 
 if test "x$c_compilers" = x; then
-    echo "none found" >&2
+    echo "$none" >&2
     cat >&2 <<EOF
 
-You appear to not have a C compiler installed.
-A C compiler is not necessary for the core EGSnrc system but without it
-you will be not able to use extensions such as the parallel processing
-implementation provided with the system.
-If you have a C compiler with an unusual name (other than gcc cc xlc
-cl c89 icc), abort the configuration now and edit this script ($my_name)
-to look for your compiler.
+It appears that no C compiler is installed. A C compiler is not necessary for
+the core EGSnrc system but without it you will be not able to use extensions
+such as the parallel processing implementation provided with the system. If you
+have a C compiler with an unusual name (other than gcc cc xlc cl c89 icc), input
+command name if it is on your path, otherwise the full path to the executable.
 
 EOF
 else
+    echo "found: $c_compilers" >&2
+fi
 
-  echo "$c_compilers" >&2
-  if test "$c_compilers" = "$c_first"; then
-    CC=$c_first
-  else
-    echo >&2
-
-    while true; do
-      printf $format "Input the one you would like to use: " >&2
-      printf "[$c_first] " >&2
-      read response
-      if test "x$response" = x; then
-        CC=$c_first
-      elif test "x$response" = x$none; then
-        CC=$none
-        break
-      else
-        for cc_prog in $c_compilers; do
-          if test "x$cc_prog" = "x$response"; then
-            CC=$response
+while true; do
+    echo
+    printf $format "Input C compiler: " >&2
+    if test ! "x$c_compilers" = x; then
+        printf "[$c_first] " >&2
+    fi
+    read CC
+    if test "x$CC" = x; then
+        if test "x$c_first" = x; then
+          echo "You have to input a non-empty string here!" >&2
+        else
+          CC=$c_first
+          break
+        fi
+    else
+        found_CC=
+        # is the input in the list of found compilers ?
+        if test ! "x$c_compilers" = x; then
+            for cc_prog in $c_compilers; do
+                if test "x$cc_prog" = "x$CC"; then
+                    found_CC=$cc_prog
+                    break
+                fi
+            done
+            if test ! "x$found_CC" = x; then
+                break;
+            fi
+        fi
+        # is it an absolute path name ?
+        if test -f "$CC"; then
             break
-          fi
+        fi
+        # it is not from the list and it is not an absolute path name
+        # => must be a compiler name not in the check list.
+        # see if it is in the search path
+        save_IFS=$IFS; IFS=$path_separator; dummy="$PATH"
+        for cc_dir in $dummy; do
+            IFS=$save_IFS
+            $as_executable "$cc_dir/$CC" || continue
+            found_CC=yes; break
         done
-      fi
-      if test "x$CC" != x; then
-        break
-      fi
-    done
-  fi
+        if test "x$found_CC" = x; then
+            cat >&2 <<EOF
 
-  if test "x$CC" = x$none; then
-    have_c_compiler=no
-  else
-    have_c_compiler=yes
+No compiler with that name was found. You must either give a full path name or
+include the directory where the compiler is installed in your search path or
+install a C compiler if none is installed.
+
+EOF
+        else
+            break
+        fi
+    fi
+done
+
+if test "x$CC" = x$none; then
+  have_c_compiler=no
+else
+  have_c_compiler=yes
 
   default_cflags="-O2"
   if test ! "x$is_x86_64" = x; then default_cflags="-O2 -fPIC"; fi
@@ -1522,8 +1548,6 @@ _ACEOF
   fi
 
   rm -f conftest.$test_ext c_conftest.* conftest.$test_objext conftest$test_exeext
-  fi
-
 fi
 
 if test $have_c_compiler = no; then
@@ -1576,7 +1600,7 @@ fi
 while true; do
 
     # query configuration file name
-    printf $format "Choose a configuration file name: " >&2
+    printf $format "Choose a configuration name: " >&2
     if test ! "x$try_conf_file" = x; then
         printf "[$try_conf_file] ">&2
     fi
@@ -1606,7 +1630,7 @@ _ACEOF
         fi
     fi
 
-    conf_name=$(echo $response | sed "s/\.[^\.]*$//")
+    conf_name=$(echo $response | sed "s/\.conf$//")
     if $as_file $HEN_HOUSE/specs/$response || $as_directory $HEN_HOUSE/bin/$conf_name || $as_directory $HEN_HOUSE/lib/$conf_name; then
         echo >&2
         echo "The configuration $response or corresponding directories in bin/ or lib/ already exist!" >&2
@@ -1619,8 +1643,10 @@ _ACEOF
         break
      fi
 done
-conf_file="$response"
-conf_name=$(echo $response | sed "s/\.[^\.]*$//")
+
+# enforce the .conf extension
+conf_name=$(echo $response | sed "s/\.conf$//")
+conf_file=$conf_name.conf
 
 
 if test "x$system_name" = "x$conf_name"; then

--- a/HEN_HOUSE/scripts/configure.expect
+++ b/HEN_HOUSE/scripts/configure.expect
@@ -33,12 +33,12 @@ expect "Input flags for debugging:"                     { send "\n" }
 expect "Input libraries that your compiler may need:"   { send "\n" }
 
 # C compiler
-expect "Input the one you would like to use:"           { send "\n" }
+expect "Input C compiler:"                              { send "\n" }
 expect "Input C compiler flags to use:"                 { send "\n" }
 
 # Configuration
 expect "Input path to EGSnrc HEN_HOUSE directory:"      { send "\n" }
-expect "Choose a configuration file name:"              { send "$confname\n" }
+expect "Choose a configuration name:"                   { send "$confname\n" }
 set timeout 1
 expect "Do you want to overwrite ?"                     { puts "no\n"; exit }
 set timeout -1


### PR DESCRIPTION
Update the C compiler selection logic (to match the fortran compiler
selection logic) which allows the selection of any C compiler available
on the search path, or via a full path. Previously, the C compiler name
was constrained to a hard-coded list.

Also adjust the filtering of the configuration file name to enforce a
single .conf extension. Previously, the file name was taken as is, and
any extension starting from the last dot was removed to yield the
configuration base name. This proved error-prone when trying to use
names with version numbers, such as gcc-4.8 for example.