### PR TITLE
Geometry libraries for cubic and hexagonal lattice in egsnrc

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -42,7 +42,7 @@ egspp_files = egs_input egs_base_geometry egs_library egs_transformations \
              egs_base_source egs_functions egs_application egs_run_control \
              egs_scoring egs_interpolator egs_atomic_relaxations \
              egs_ausgab_object egs_particle_track egs_fortran_geometry \
-             egs_ensdf
+             egs_ensdf egs_hexagonal_lattice egs_cubic_lattice
 
 egspp_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(egspp_files)))
 config1h = $(IEGS1)$(DSEP)egs_config1.h egs_libconfig.h egs_functions.h

--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -42,7 +42,7 @@ egspp_files = egs_input egs_base_geometry egs_library egs_transformations \
              egs_base_source egs_functions egs_application egs_run_control \
              egs_scoring egs_interpolator egs_atomic_relaxations \
              egs_ausgab_object egs_particle_track egs_fortran_geometry \
-             egs_ensdf egs_hexagonal_lattice egs_cubic_lattice
+             egs_ensdf
 
 egspp_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(egspp_files)))
 config1h = $(IEGS1)$(DSEP)egs_config1.h egs_libconfig.h egs_functions.h
@@ -51,7 +51,8 @@ geometry_libs = egs_planes egs_cd_geometry egs_gtransformed egs_nd_geometry \
                egs_box egs_genvelope egs_spheres egs_cylinders egs_iplanes \
                egs_cones egs_gstack egs_prism egs_union egs_pyramid egs_conez\
                egs_space egs_elliptic_cylinders egs_smart_envelope \
-               egs_vhp_geometry egs_octree egs_roundrect_cylinders
+               egs_vhp_geometry egs_octree egs_roundrect_cylinders \
+			   egs_hexagonal_lattice egs_cubic_lattice
 
 source_libs = egs_collimated_source egs_isotropic_source egs_parallel_beam \
               egs_point_source egs_source_collection egs_transformed_source \

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/Makefile
@@ -1,0 +1,20 @@
+#*****************************************************************************
+#
+#  $Id: Makefile,v 1.2 2005/06/27 17:24:30 iwan Exp $
+#
+#*****************************************************************************
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_CUBIC_LATTICE_DLL
+
+library = egs_cubic_lattice
+lib_files = egs_cubic_lattice
+my_deps = egs_transformations.h geometry/egs_gtransformed/egs_gtransformed.h
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.cpp
@@ -1,0 +1,201 @@
+#include "egs_cubic_lattice.h"
+#include "egs_input.h"
+#include "egs_functions.h"
+
+void EGS_DummyGeometry::setMedia(EGS_Input *,int,const int *) {
+egsWarning("EGS_TransformedGeometry::setMedia: don't use this method. Use the\n"
+" setMedia() methods of the geometry objects that make up this geometry\n");
+}
+
+void EGS_DummyGeometry::setRelativeRho(int start, int end, EGS_Float rho){
+    setRelativeRho(0);
+}
+
+void EGS_DummyGeometry::setRelativeRho(EGS_Input *) {
+    egsWarning("EGS_TransformedGeometry::setRelativeRho(): don't use this "
+      "method. Use the \n setRelativeRho() methods of the underlying "
+      "geometry\n");
+}
+
+void EGS_SubGeometry::setMedia(EGS_Input *,int,const int *)
+{
+	egsWarning("EGS_SubGeometry::setMedia: don't use this method. Use the\n"
+	" setMedia() methods of the geometry objects that make up this geometry\n");
+}
+
+void EGS_SubGeometry::setRelativeRho(int start, int end, EGS_Float rho)
+{
+    setRelativeRho(0);
+}
+
+void EGS_SubGeometry::setRelativeRho(EGS_Input *)
+{
+    egsWarning("EGS_SubGeometry::setRelativeRho(): don't use this "
+    "method. Use the \n setRelativeRho() methods of the underlying "
+    "geometry\n");
+}
+
+extern "C" {
+
+EGS_CUBIC_LATTICE_EXPORT EGS_BaseGeometry* createGeometry(EGS_Input *input)
+{
+	// Honestly, this whole section is monkey see monkey do
+    int error = 0;
+	
+	// Get base geometry
+	EGS_Input *i = input->getInputItem("base geometry");
+    if( !i )
+	{
+        egsWarning("createGeometry(cubic_lattice): base geometry must be defined\n" 
+                   " using 'base geometry = some_geom'?\n"); return 0;
+    }
+    EGS_Input *ig = i->getInputItem("geometry");
+    EGS_BaseGeometry *b;
+    if( ig )
+	{
+		b = EGS_BaseGeometry::createSingleGeometry(ig);
+        delete ig;
+		if (!b)
+		{
+			egsWarning("createGeometry(cubic_lattice): incorrect base geometry definition\n");
+			delete i;  return 0;
+		}
+    }
+    else
+	{
+        string bgname;
+        int err = i->getInput("base geometry",bgname);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(cubic_lattice): missing/incorrect 'base geometry' input\n"); return 0;
+        }
+        b = EGS_BaseGeometry::getGeometry(bgname);
+        if( !b )
+		{
+            egsWarning("createGeometry(envelope geometry): no geometry with name %s defined\n",
+						bgname.c_str());
+			return 0;
+        }
+    }
+	
+	// Get subgeometry
+	i = input->getInputItem("subgeometry");
+    if( !i )
+	{
+        egsWarning("createGeometry(cubic_lattice): subgeometry must be defined\n" 
+                   " using 'subgeometry = some_geom'?\n"); return 0;
+    }
+    ig = i->getInputItem("geometry");
+    EGS_BaseGeometry *s;
+    if( ig )
+	{
+		s = EGS_BaseGeometry::createSingleGeometry(ig);
+        delete ig;
+		if (!s)
+		{
+			egsWarning("createGeometry(cubic_lattice): incorrect subgeometry definition\n");
+			delete i;  return 0;
+		}
+    }
+    else
+	{
+        string bgname;
+        int err = i->getInput("subgeometry",bgname);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(cubic_lattice): missing/incorrect 'subgeometry' input\n"); return 0;
+        }
+        s = EGS_BaseGeometry::getGeometry(bgname);
+        if( !s )
+		{
+            egsWarning("createGeometry(envelope geometry): no geometry with name %s defined\n",
+						bgname.c_str());
+			return 0;
+        }
+    }
+	
+	// Non-geometry parameters (ie, lattice part starts here)
+	int ind = -1;
+	i = input->getInputItem("subgeometry index");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(cubic_lattice): subgeometry index must be defined\n"
+               "  using 'subgeometry index = some_index'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("subgeometry index",ind);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(cubic_lattice): missing/incorrect 'subgeometry index' input\n"); return 0;
+        }
+        else if (ind < 0 || ind >= b->regions()) // Not a real index
+		{
+            egsWarning("createGeometry(cubic_lattice): subgeometry index %d"
+                       " is not valid, must be a region in base geometry\n",ind);
+			return 0;
+		}
+    }
+	
+	EGS_Float vd = -1;
+	i = input->getInputItem("volumetric density");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(cubic_lattice): density must be defined\n"
+               "  using 'volumetric density = some_vol_den_in_cm3'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("volumetric density",vd);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(cubic_lattice): missing/incorrect 'volumetric density' input\n"); return 0;
+        }
+        else if (vd <= 0) // Not a real volume density
+		{
+            egsWarning("createGeometry(cubic_lattice): volumetric density"
+                       " is not valid, must be greater than zero\n");
+			return 0;
+		}
+    }
+	
+	EGS_Float width = -1; // largest spacing, an arbitrary variable for egs_view purposes for too many howfar calls
+	i = input->getInputItem("largest spacing");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(cubic_lattice): largest spacing must be defined\n"
+               "  using 'largest spacing = some_distance'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("largest spacing",width);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(cubic_lattice): missing/incorrect 'largest spacing' input\n"); return 0;
+        }
+        else if (width <= 0) // Not a real distance
+		{
+            egsWarning("createGeometry(cubic_lattice): largest spacing"
+                       " is not valid, must be greater than zero\n");
+			return 0;
+		}
+	}
+	
+	// Final build
+    EGS_BaseGeometry *result;
+    result = new EGS_SubGeometry(b, s, ind, /*envelope,*/ vd, width);
+    result->setName(input);
+    return result;
+}
+}

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.cpp
@@ -1,3 +1,13 @@
+/*
+###############################################################################
+#
+# EGSnrc egs++ auto envelope geometry
+# Copyright (C) 2019 Martin Martinov
+#
+# This file is part of EGSnrc.
+#
+###############################################################################
+*/
 #include "egs_cubic_lattice.h"
 #include "egs_input.h"
 #include "egs_functions.h"

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
@@ -1,0 +1,613 @@
+#ifndef EGS_CUBIC_LATTICE_
+#define EGS_CUBIC_LATTICE_
+
+#include "egs_base_geometry.h"
+#include "egs_transformations.h"
+#include "egs_rndm.h"
+
+#ifdef WIN32
+
+#ifdef BUILD_CUBIC_LATTICE_DLL
+#define EGS_CUBIC_LATTICE_EXPORT __declspec(dllexport)
+#else
+#define EGS_CUBIC_LATTICE_EXPORT __declspec(dllimport)
+#endif
+#define EGS_CUBIC_LATTICE_LOCAL 
+
+#else
+
+#ifdef HAVE_VISIBILITY
+#define EGS_CUBIC_LATTICE_EXPORT __attribute__ ((visibility ("default")))
+#define EGS_CUBIC_LATTICE_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define EGS_CUBIC_LATTICE_EXPORT
+#define EGS_CUBIC_LATTICE_LOCAL
+#endif
+
+#endif
+
+/* Input Example
+:start geometry:
+	library            = egs_cubic_lattice
+	name               = phantom_w_microcavity
+	base geometry      = phantom
+	subgeometry        = microcavity
+	subgeometry index  = 0
+	volumetric density = 4.94782e+11
+    largest spacing    = 10000
+:stop geometry:
+*/
+
+class EGS_DummyGeometry : 
+            public EGS_BaseGeometry {
+
+protected:
+
+    EGS_BaseGeometry    *g;   //!< The geometry being transformed
+    EGS_AffineTransform T;    //!< The affine transformation
+    string              type; //!< The geometry type
+
+public:
+
+    /*! \brief Construct a geometry that is a copy of the geometry \a G 
+    transformed by \a t
+    */
+    EGS_DummyGeometry(EGS_BaseGeometry *G, const EGS_AffineTransform &t, 
+            const string &Name = "") : EGS_BaseGeometry(Name), g(G), T(t) {
+        type = g->getType(); type += "T"; nreg = g->regions();
+        is_convex = g->isConvex();
+        has_rho_scaling = g->hasRhoScaling();
+    };
+
+    ~EGS_DummyGeometry() { if( !g->deref() ) delete g; };
+
+    void setTransformation(const EGS_AffineTransform &t) {/*cout<<"\t\tTransformation changed to ["<<t.getTranslation().x<<","<<t.getTranslation().y<<","<<t.getTranslation().z<<"]\n";*/ T = t; };
+
+    int computeIntersections(int ireg, int n, const EGS_Vector &x,
+            const EGS_Vector &u, EGS_GeometryIntersections *isections) {
+        EGS_Vector xt(x), ut(u);
+        T.inverseTransform(xt); T.rotateInverse(ut);
+        return g->computeIntersections(ireg,n,xt,ut,isections);
+    };
+    bool isRealRegion(int ireg) const {
+        return g->isRealRegion(ireg);
+    };
+    bool isInside(const EGS_Vector &x) { 
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->isInside(xt);
+        //return g->isInside(x*T); 
+    };
+    int isWhere(const EGS_Vector &x) { 
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->isWhere(xt); 
+        //return g->isWhere(x*T); 
+    };
+    int inside(const EGS_Vector &x) { return isWhere(x); };
+
+    int medium(int ireg) const { return g->medium(ireg); };
+
+    EGS_Float howfarToOutside(int ireg, const EGS_Vector &x, 
+            const EGS_Vector &u) {
+        return ireg >= 0 ? g->howfarToOutside(ireg,x*T,u*T.getRotation()) : 0;
+    };
+    int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u, 
+           EGS_Float &t, int *newmed=0, EGS_Vector *normal=0) { 
+        EGS_Vector xt(x), ut(u);
+        T.inverseTransform(xt); T.rotateInverse(ut);
+        int inew = g->howfar(ireg,xt,ut,t,newmed,normal); 
+        //int inew = g->howfar(ireg,x*T,u*T.getRotation(),t,newmed,normal); 
+        if( inew != ireg && normal ) 
+            *normal = T.getRotation()*(*normal);
+        return inew;
+    };
+
+    EGS_Float hownear(int ireg, const EGS_Vector &x) {
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->hownear(ireg,xt);
+        //return g->hownear(ireg,x*T);
+    };
+
+    int getMaxStep() const { return g->getMaxStep(); };
+
+    // Not sure about the following.
+    // If I leave the implementation that way, all transformed copies of a 
+    // geometry share the same boolean properties. But that may not be 
+    // what the user wants. So, I should implement both options: 
+    // all copies share the same properties and the user has the options 
+    // to define separate properties for each copy.
+    bool hasBooleanProperty(int ireg, EGS_BPType prop) const {
+        return g->hasBooleanProperty(ireg,prop);
+    };
+    void setBooleanProperty(EGS_BPType prop) {
+        g->setBooleanProperty(prop);
+    };
+    void addBooleanProperty(int bit) {
+        g->addBooleanProperty(bit);
+    };
+    void setBooleanProperty(EGS_BPType prop, int start, int end, int step=1) {
+        g->setBooleanProperty(prop,start,end,step);
+    };
+    void addBooleanProperty(int bit, int start, int end, int step=1) {
+        g->addBooleanProperty(bit,start,end,step);
+    };
+
+    const string &getType() const { return type; };
+
+    EGS_Float getRelativeRho(int ireg) const {
+        return g->getRelativeRho(ireg);
+    }
+    void setRelativeRho(int start, int end, EGS_Float rho);
+    void setRelativeRho(EGS_Input *);
+
+protected:
+
+    /*! \brief Don't define media in the transformed geometry definition.
+
+    This function is re-implemented to warn the user to not define 
+    media in the definition of a transformed geometry. Instead, media should 
+    be defined when specifying the geometry to be transformed.
+    */
+    void setMedia(EGS_Input *inp,int,const int *);
+
+};
+
+class EGS_CUBIC_LATTICE_EXPORT EGS_SubGeometry : 
+            public EGS_BaseGeometry {
+protected:
+
+    EGS_BaseGeometry*  base;     //!< The geometry within which the sub geometry appears
+    EGS_DummyGeometry* sub;      //!< The sub geometry that could appear within base 
+	int                ind;      //!< The region in base geom where we could encounter sub geom
+	int                maxStep;  //!< The maximum number of steps
+	EGS_Float          spacing;  //!< The closest distance between two sub geoms
+	bool               virt;     //!< Tells us whether or not we are in the sub geom
+    string             type;     //!< The geometry type
+	/*
+	Added white space to sync up vertically with egs_hexagonal_lattice
+	*/
+
+public:
+
+    EGS_SubGeometry(EGS_BaseGeometry *B, EGS_BaseGeometry *S, int i, /*EGS_Float r,*/ EGS_Float vd, EGS_Float width, const string &Name = "")
+		: EGS_BaseGeometry(Name), base(B), ind(i), /*rad(r), rad2(r*r),*/ spacing(pow(vd,-1.0/3.0))
+	{
+		sub             = new EGS_DummyGeometry(S,EGS_Vector(0,0,0));
+        type            = base->getType(); type += " with "; type += sub->getType(); type += " in a cubic lattice";
+		nreg            = base->regions() + sub->regions();
+        is_convex       = false; //base->isConvex();
+        has_rho_scaling = base->hasRhoScaling();
+		virt            = false;
+		maxStep         = base->regions()+int(width/spacing)*sub->regions();
+    	/* Added white space to sync up vertically with egs_hexagonal_lattice */
+	};
+
+    ~EGS_SubGeometry()
+	{
+		if(!sub->deref())
+			delete sub;
+		if(!base->deref())
+			delete base;
+	};
+	
+	EGS_Vector closestPoint(const EGS_Vector &x)
+	{
+		int i, j, k;
+		
+		// Get the indices of the lattice point
+		i = int(round(x.x/spacing));
+		j = int(round(x.y/spacing));
+		k = int(round(x.z/spacing));
+		
+		//egsWarning("For %f,%f,%f nearest point is %f,%f,%f\n",x.x,x.y,x.z,i*spacing,j*spacing,k*spacing);
+		return EGS_Vector(i, j, k)*spacing;
+	};
+	
+	/*
+	Added white space to sync up vertically with egs_hexagonal_lattice
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	
+	*/
+		
+    int computeIntersections(int ireg, int n, const EGS_Vector &x, const EGS_Vector &u, EGS_GeometryIntersections *isections)
+	{
+		return base->computeIntersections(ireg,n,x,u,isections);
+    };
+	
+    bool isRealRegion(int ireg) const
+	{
+		if (ireg < base->regions()) // If ireg is less than base regions
+			return base->isRealRegion(ireg); // check against base regions
+		return sub->isRealRegion(ireg - base->regions()); // then check subregions
+    };
+	
+    bool isInside(const EGS_Vector &x)
+	{
+		return base->isInside(x);
+    };
+	
+    int isWhere(const EGS_Vector &x)
+	{
+		int temp = base->isWhere(x);
+		// Are we in the subgeom?
+		if (temp == ind)
+		{
+			//base->printInfo();
+			//egsWarning("\nChecking position!\n");
+			//egsWarning("\t[%e,%e,%e]\n",x.x, x.y, x.z);
+			//egsWarning("\twhere r = %e\n", sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+			//cout << "\tisWhere invoking setTransformation\n";
+			sub->setTransformation(closestPoint(x));
+			//egsWarning("\twith region = %d\n", sub->isWhere(x) + base->regions());
+			if (sub->isInside(x))
+				return sub->isWhere(x) + base->regions();
+		}
+		return temp; // otherwise base geom		
+    };
+	
+    int inside(const EGS_Vector &x)
+	{
+		return isWhere(x);
+	};
+
+    int medium(int ireg) const
+	{
+		if (ireg >= base->regions()) // If ireg is greater than base regions
+			return sub->medium(ireg-base->regions());
+		return base->medium(ireg); // If in base region
+	};
+
+    EGS_Float howfarToOutside(int ireg, const EGS_Vector &x, const EGS_Vector &u)
+	{
+		if (ireg < 0) // Error catch, not inside
+			return 0;
+			
+		// Are we in the subgeom
+		if (ireg >= base->regions())
+			return base->howfarToOutside(ind,x,u);
+		return base->howfarToOutside(ireg,x,u);	
+    };
+
+	// This is where things get messy, this function will be trimodal, whether we are in non-ind base, ind base or sub
+    int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u, EGS_Float &t, int *newmed=0, EGS_Vector *normal=0)
+	{
+		//egsWarning("%s howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+		//egsWarning("\t where r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+		
+		// Catch t=0 exception, which causes issues when making a lattice of lattices
+		if (t < epsilon)
+		{
+			t = 0.0;
+			return ireg;
+		}
+		
+		// Are we in the subgeom?
+		if (ireg >= base->regions())
+		{
+			sub->setTransformation(closestPoint(x));
+		
+			// Do the howfar call
+			EGS_Float tempT = t;
+			//egsWarning("%s sub->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg-base->regions(), x.x, x.y, x.z, u.x, u.y, u.z, tempT);
+			int tempReg = sub->howfar(ireg-base->regions(),x,u,tempT,newmed,normal);
+			
+			// If we do leave the subgeom, we want to return the index
+			// of the region of the base geometry we would be entering,
+			// which is not necessarily ind is subgeom is at the
+			// boundary
+			EGS_Vector newX = u; newX.normalize(); newX = x + (newX * tempT);
+			
+			//egsWarning("\tradius of new x %e\n",sqrt((newX.x*newX.x)+(newX.y*newX.y)+(newX.z*newX.z)));
+			if (!(tempReg+1) || base->isWhere(newX) != ind)
+			{
+				t = tempT;				
+				
+				//egsWarning("\tbase howfar(%6d, [%e,%e,%e], [%e,%e,%e], %e)\n",ind, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				tempReg = base->howfar(ind,x,u,t,0,normal);
+				if (newmed && tempReg >= 0)
+					*newmed = base->medium(tempReg);
+				//egsWarning("\treturn %d (%e)\n",tempReg,t);
+				//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+				
+				if (t<0)
+				{
+					egsWarning("Returning negative t from subgeom\n");
+					egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				}
+				return tempReg; 
+			}
+			
+			t = tempT;
+			if (newmed && tempReg >= 0)
+				*newmed = sub->medium(tempReg);
+			//egsWarning("\treturn %d (%e)\n",tempReg+base->regions(),t);
+			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			
+			if (t<0)
+			{
+				egsWarning("Returning negative t from subgeom\n");
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+			}
+			//egsWarning("\treturn %d (%e)\n",tempReg,t);
+			return tempReg+base->regions();
+		}
+		else if (ireg == ind) // If we are in the region that could contain subgeoms
+		{
+			// Determine the path travelled ------------------------------------------------ //
+			EGS_Float tempT = t;
+			//egsWarning("%s base->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg, x.x, x.y, x.z, u.x, u.y, u.z, tempT);
+			base->howfar(ireg,x,u,tempT); // Get how far it is in temp
+			EGS_Float max = tempT;
+			
+			// Iterate through the lattice ------------------------------------------------- //
+			EGS_Float min = max, minX = max, minY = max, minZ = max; // Distance to closest subgeom for three different cases
+			EGS_Vector unit = u; unit.normalize();
+			EGS_Vector xInt = unit*(spacing/2.0/fabs(unit.x)), yInt = unit*(spacing/2.0/fabs(unit.y)), zInt = unit*(spacing/2.0/fabs(unit.z));
+			EGS_Vector tempP; // Temporarily hold indices of subgeom we are testing against
+			EGS_Vector finalP, finalX, finalY, finalZ; // Current closest intersecting subgeom
+			
+			EGS_Vector x0;
+			EGS_Float max2 = max*max;
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minX;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if (tempT < max && tempT > 0)
+					{
+						finalX = tempP;
+						minX = tempT;
+						break;
+					}
+				x0 += xInt;
+			}
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minY;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if(tempT < max && tempT > 0)
+					{
+						finalY = tempP;
+						minY = tempT;
+						break;
+					}
+				x0 += yInt;
+			}
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minZ;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if(tempT < max && tempT > 0)
+					{
+						finalZ = tempP;
+						minZ = tempT;
+						break;
+					}
+				x0 += zInt;
+			}
+			
+			finalP = finalX; min = minX;
+			if (min > minY) {min = minY; finalP = finalY;}
+			if (min > minZ) {min = minZ; finalP = finalZ;}
+			
+			// Check last point
+			tempT = max;
+			sub->setTransformation(closestPoint(x+unit*tempT));
+			sub->howfar(-1,x,u,tempT);
+			if (tempT < min  && tempT > 0)
+			{
+				min = tempT;
+				finalP = closestPoint(x+unit*tempT);
+			}
+			
+			// We did intersect subgeom
+			if (min < max)
+			{
+				tempT = t;
+				sub->setTransformation(finalP);
+				int tempReg = sub->howfar(-1,x,u,tempT,newmed,normal);
+				if (tempReg+1)
+				{
+					if (newmed && tempReg >= 0)
+						*newmed = sub->medium(tempReg);
+					t = tempT;
+					//egsWarning("\treturn %d (%f)\n",tempReg+base->regions(),t);
+					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					if (t<0)
+					{
+						egsWarning("Returning negative t from region %d in base geom t\n", ind);
+						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+						//egsFatal("Break 1!\n");
+					}
+					return tempReg+base->regions();
+				}
+			}
+			
+			// We didn't intersect subgeom
+			int tempReg = base->howfar(ireg,x,u,t,newmed,normal);
+			if (t<0)
+			{
+				egsWarning("Returning negative t from region %d in base geom\n", ind);
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsFatal("Break 2!\n");
+			}
+			if (newmed && tempReg >= 0)
+				*newmed = base->medium(tempReg);
+			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			//egsWarning("\treturn %d (%f)\n",tempReg,t);
+			return tempReg;
+		}
+		else // Not in region containing subgeoms, then it is quite easy
+		{    // unless we enter directly into a subgeom when entering
+		     // region ind
+			int tempReg = base->howfar(ireg,x,u,t,newmed,normal);
+			
+			// If we enter region ind
+			if (tempReg == ind)
+			{
+				// newX is the point of entrance
+				EGS_Vector newX = u; newX.normalize(); newX = x + (newX * t); 
+				
+				sub->setTransformation(closestPoint(newX));
+				int newReg = sub->isWhere(newX); // see what region we are in
+				if (newReg+1)                    // in subgeom, if its not -1
+				{                                // then return the proper
+					if (newmed && newReg >= 0)   // media and region
+						*newmed = sub->medium(newReg);
+					//egsWarning("\treturn %d (%f)\n",newReg+base->regions(),t);
+					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					if (t<0)
+					{
+						egsWarning("Returning negative t from region not %d in base geom\n", ind);
+						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+						//egsFatal("Break 1!\n");
+					}
+					return newReg + base->regions();
+				}
+			}
+			
+			if (newmed && tempReg >= 0)
+				*newmed = base->medium(tempReg);
+			//egsWarning("\treturn %d (%e)\n",tempReg,t);
+			//egsWarning("new x should be[%e,%e,%e] %e\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			if (t<0)
+			{
+				egsWarning("Returning negative t from region not %d in base geom\n", ind);
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsFatal("Break 2!\n");
+			}
+			return tempReg;
+		}
+    };
+	
+    EGS_Float hownear(int ireg, const EGS_Vector &x)
+	{
+		//egsWarning("%s hownear(%6d,[%e,%e,%e])\n", getName().c_str(), ireg, x.x, x.y, x.z);
+		//egsWarning("\twhere r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+		EGS_Float temp, dist = base->hownear(ind,x);
+		if (ireg >= base->regions())
+		{
+			sub->setTransformation(closestPoint(x));
+			temp = sub->hownear(ireg-base->regions(),x);
+			//egsWarning("\treturn %e\n",sub->hownear(ireg-base->regions(),x));
+			return (temp<dist)?temp:dist;
+		}
+		else if (ireg == ind)
+		{
+			// Check all nearby geometries, in case of weird subgeom shapes
+			// with a 10% increased spacing/gap buffer to avoid roundoff
+			EGS_Vector x0[7] = {EGS_Vector(x.x-spacing/1.8,x.y,x.z),
+							    EGS_Vector(x.x+spacing/1.8,x.y,x.z),
+							    EGS_Vector(x.x,x.y-spacing/1.8,x.z),
+							    EGS_Vector(x.x,x.y+spacing/1.8,x.z),
+							    EGS_Vector(x.x,x.y,x.z-spacing/1.8),
+							    EGS_Vector(x.x,x.y,x.z+spacing/1.8),
+							    EGS_Vector(x)};	
+			for (int i = 0; i < 7; i++)
+			{
+				sub->setTransformation(closestPoint(x0[i]));
+				temp = sub->hownear(ireg-base->regions(),x);
+				if (temp < dist)
+					dist = temp;
+			}
+			//egsWarning("\treturn %e\n",dist);
+			return dist;
+		}
+		//egsWarning("\treturn %e\n",base->hownear(ireg,x));
+		return dist;
+    };
+
+    int getMaxStep() const
+	{
+		return maxStep;
+    };
+
+    // Not sure about the following.
+    // If I leave the implementation that way, all transformed copies of a 
+    // geometry share the same boolean properties. But that may not be 
+    // what the user wants. So, I should implement both options: 
+    // all copies share the same properties and the user has the options 
+    // to define separate properties for each copy.
+    bool hasBooleanProperty(int ireg, EGS_BPType prop) const
+	{
+		return base->hasBooleanProperty(ireg,prop);
+    };
+	
+    void setBooleanProperty(EGS_BPType prop)
+	{
+		base->setBooleanProperty(prop);
+    };
+	
+    void addBooleanProperty(int bit)
+	{
+		base->addBooleanProperty(bit);
+    };
+	
+    void setBooleanProperty(EGS_BPType prop, int start, int end, int step=1)
+	{
+		base->setBooleanProperty(prop,start,end,step);
+    };
+	
+    void addBooleanProperty(int bit, int start, int end, int step=1)
+	{
+		base->addBooleanProperty(bit,start,end,step);
+    };
+
+    const string &getType() const
+	{
+		return type;
+	};
+
+    EGS_Float getRelativeRho(int ireg) const
+	{
+		return base->getRelativeRho(ireg);
+    }
+    void setRelativeRho(int start, int end, EGS_Float rho);
+    void setRelativeRho(EGS_Input *);
+
+protected:
+
+    /*! \brief Don't define media in the transformed geometry definition.
+
+    This function is re-implemented to warn the user to not define 
+    media in the definition of a transformed geometry. Instead, media should 
+    be defined when specifying the geometry to be transformed.
+    */
+    void setMedia(EGS_Input *inp,int,const int *);
+
+};
+
+#endif

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
@@ -3,6 +3,7 @@
 
 #include "egs_base_geometry.h"
 #include "egs_transformations.h"
+
 #include "egs_rndm.h"
 
 #ifdef WIN32
@@ -44,7 +45,6 @@ class EGS_DummyGeometry :
 protected:
 
     EGS_BaseGeometry    *g;   //!< The geometry being transformed
-    EGS_AffineTransform T;    //!< The affine transformation
     string              type; //!< The geometry type
 
 public:
@@ -52,6 +52,7 @@ public:
     /*! \brief Construct a geometry that is a copy of the geometry \a G 
     transformed by \a t
     */
+    EGS_AffineTransform T;    //!< The affine transformation, no longer protected for quick debug
     EGS_DummyGeometry(EGS_BaseGeometry *G, const EGS_AffineTransform &t, 
             const string &Name = "") : EGS_BaseGeometry(Name), g(G), T(t) {
         type = g->getType(); type += "T"; nreg = g->regions();
@@ -162,8 +163,7 @@ protected:
 	EGS_Float          spacing;  //!< The closest distance between two sub geoms
 	bool               virt;     //!< Tells us whether or not we are in the sub geom
     string             type;     //!< The geometry type
-	/*
-	Added white space to sync up vertically with egs_hexagonal_lattice
+	/* Added white space to sync up vertically with egs_hexagonal_lattice
 	*/
 
 public:
@@ -294,9 +294,8 @@ public:
     int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u, EGS_Float &t, int *newmed=0, EGS_Vector *normal=0)
 	{
 		//egsWarning("%s howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
-		//egsWarning("\t where r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
 		
-		// Catch t=0 exception, which causes issues when making a lattice of lattices
+		// Catch t=0 exception, which sometimes causes issues when making a lattice of lattices
 		if (t < epsilon)
 		{
 			t = 0.0;
@@ -310,47 +309,54 @@ public:
 		
 			// Do the howfar call
 			EGS_Float tempT = t;
-			//egsWarning("%s sub->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg-base->regions(), x.x, x.y, x.z, u.x, u.y, u.z, tempT);
+			//{EGS_Vector xt(x); sub->T.inverseTransform(xt);egsWarning("%s sub->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg-base->regions(), xt.x, xt.y, xt.z, u.x, u.y, u.z, tempT);}
 			int tempReg = sub->howfar(ireg-base->regions(),x,u,tempT,newmed,normal);
 			
 			// If we do leave the subgeom, we want to return the index
 			// of the region of the base geometry we would be entering,
-			// which is not necessarily ind is subgeom is at the
-			// boundary
+			// which is not necessarily ind if subgeom is at a boundary
 			EGS_Vector newX = u; newX.normalize(); newX = x + (newX * tempT);
 			
-			//egsWarning("\tradius of new x %e\n",sqrt((newX.x*newX.x)+(newX.y*newX.y)+(newX.z*newX.z)));
-			if (!(tempReg+1) || base->isWhere(newX) != ind)
+			if (base->isWhere(newX) != ind) // If we leave ind region of base
 			{
 				t = tempT;				
 				
-				//egsWarning("\tbase howfar(%6d, [%e,%e,%e], [%e,%e,%e], %e)\n",ind, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsWarning("\tbase->howfar(%6d, [%e,%e,%e], [%e,%e,%e], %e)\n",ind, x.x, x.y, x.z, u.x, u.y, u.z, t);
 				tempReg = base->howfar(ind,x,u,t,0,normal);
 				if (newmed && tempReg >= 0)
 					*newmed = base->medium(tempReg);
 				//egsWarning("\treturn %d (%e)\n",tempReg,t);
-				//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+				//egsWarning("\tnew x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 				
 				if (t<0)
 				{
-					egsWarning("Returning negative t from subgeom\n");
+					egsWarning("Returning negative t from subgeom of %s\n",getName().c_str());
 					egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+					//egsFatal("Break 1!\n");
 				}
 				return tempReg; 
 			}
 			
-			t = tempT;
-			if (newmed && tempReg >= 0)
-				*newmed = sub->medium(tempReg);
-			//egsWarning("\treturn %d (%e)\n",tempReg+base->regions(),t);
-			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			if (!(tempReg+1)) // If we leave sub geom entirely
+			{
+				//egsWarning("\treturn %d (%e)\n",tempReg+base->regions(),t);
+				//egsWarning("\tnew x should be [%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+				if (newmed)
+					*newmed = base->medium(ind);
+				t = tempT;
+				return ind;
+			}
 			
+			// else we stay in sub geom
+			t = tempT;
+			//egsWarning("\treturn %d (%e)\n",tempReg,t);
+			//egsWarning("\tnew x should be [%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);			
 			if (t<0)
 			{
-				egsWarning("Returning negative t from subgeom\n");
+				egsWarning("Returning negative t from subgeom of %s\n",getName().c_str());
 				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsFatal("Break 2!\n");
 			}
-			//egsWarning("\treturn %d (%e)\n",tempReg,t);
 			return tempReg+base->regions();
 		}
 		else if (ireg == ind) // If we are in the region that could contain subgeoms
@@ -445,10 +451,10 @@ public:
 						*newmed = sub->medium(tempReg);
 					t = tempT;
 					//egsWarning("\treturn %d (%f)\n",tempReg+base->regions(),t);
-					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					//egsWarning("\tnew x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 					if (t<0)
 					{
-						egsWarning("Returning negative t from region %d in base geom t\n", ind);
+						egsWarning("Returning negative t from region %d in base geom of %s\n", ind, getName().c_str());
 						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
 						//egsFatal("Break 1!\n");
 					}
@@ -460,14 +466,14 @@ public:
 			int tempReg = base->howfar(ireg,x,u,t,newmed,normal);
 			if (t<0)
 			{
-				egsWarning("Returning negative t from region %d in base geom\n", ind);
+				egsWarning("Returning negative t from region %d in base geom of %s\n", ind, getName().c_str());
 				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
 				//egsFatal("Break 2!\n");
 			}
 			if (newmed && tempReg >= 0)
 				*newmed = base->medium(tempReg);
-			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 			//egsWarning("\treturn %d (%f)\n",tempReg,t);
+			//egsWarning("\tnew x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 			return tempReg;
 		}
 		else // Not in region containing subgeoms, then it is quite easy
@@ -488,10 +494,10 @@ public:
 					if (newmed && newReg >= 0)   // media and region
 						*newmed = sub->medium(newReg);
 					//egsWarning("\treturn %d (%f)\n",newReg+base->regions(),t);
-					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					//egsWarning("\tnew x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 					if (t<0)
 					{
-						egsWarning("Returning negative t from region not %d in base geom\n", ind);
+						egsWarning("Returning negative t from region not %d in base geom of %s\n", ind, getName().c_str());
 						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
 						//egsFatal("Break 1!\n");
 					}
@@ -502,10 +508,10 @@ public:
 			if (newmed && tempReg >= 0)
 				*newmed = base->medium(tempReg);
 			//egsWarning("\treturn %d (%e)\n",tempReg,t);
-			//egsWarning("new x should be[%e,%e,%e] %e\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			//egsWarning("\tnew x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
 			if (t<0)
 			{
-				egsWarning("Returning negative t from region not %d in base geom\n", ind);
+				egsWarning("Returning negative t from region not %d in base geom of %s\n", ind, getName().c_str());
 				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
 				//egsFatal("Break 2!\n");
 			}
@@ -516,13 +522,13 @@ public:
     EGS_Float hownear(int ireg, const EGS_Vector &x)
 	{
 		//egsWarning("%s hownear(%6d,[%e,%e,%e])\n", getName().c_str(), ireg, x.x, x.y, x.z);
-		//egsWarning("\twhere r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+			
 		EGS_Float temp, dist = base->hownear(ind,x);
 		if (ireg >= base->regions())
 		{
 			sub->setTransformation(closestPoint(x));
 			temp = sub->hownear(ireg-base->regions(),x);
-			//egsWarning("\treturn %e\n",sub->hownear(ireg-base->regions(),x));
+			//{EGS_Vector xt(x); sub->T.inverseTransform(xt);egsWarning("\t%s sub->hownear(%6d,[%e,%e,%e])\n",getName().c_str(), ireg-base->regions(), xt.x, xt.y, xt.z);}
 			return (temp<dist)?temp:dist;
 		}
 		else if (ireg == ind)

--- a/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cubic_lattice/egs_cubic_lattice.h
@@ -1,3 +1,13 @@
+/*
+###############################################################################
+#
+# EGSnrc egs++ auto envelope geometry
+# Copyright (C) 2019 Martin Martinov
+#
+# This file is part of EGSnrc.
+#
+###############################################################################
+*/
 #ifndef EGS_CUBIC_LATTICE_
 #define EGS_CUBIC_LATTICE_
 

--- a/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/Makefile
@@ -1,0 +1,20 @@
+#*****************************************************************************
+#
+#  $Id: Makefile,v 1.2 2005/06/27 17:24:30 iwan Exp $
+#
+#*****************************************************************************
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_HEXAGONAL_LATTICE_DLL
+
+library = egs_hexagonal_lattice
+lib_files = egs_hexagonal_lattice
+my_deps = egs_transformations.h geometry/egs_gtransformed/egs_gtransformed.h
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.cpp
@@ -1,3 +1,14 @@
+/*
+###############################################################################
+#
+# EGSnrc egs++ auto envelope geometry
+# Copyright (C) 2019 Martin Martinov
+#
+# This file is part of EGSnrc.
+#
+###############################################################################
+*/
+
 #include "egs_hexagonal_lattice.h"
 #include "egs_input.h"
 #include "egs_functions.h"

--- a/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.cpp
@@ -1,0 +1,201 @@
+#include "egs_hexagonal_lattice.h"
+#include "egs_input.h"
+#include "egs_functions.h"
+
+void EGS_DummyGeometry::setMedia(EGS_Input *,int,const int *) {
+egsWarning("EGS_TransformedGeometry::setMedia: don't use this method. Use the\n"
+" setMedia() methods of the geometry objects that make up this geometry\n");
+}
+
+void EGS_DummyGeometry::setRelativeRho(int start, int end, EGS_Float rho){
+    setRelativeRho(0);
+}
+
+void EGS_DummyGeometry::setRelativeRho(EGS_Input *) {
+    egsWarning("EGS_TransformedGeometry::setRelativeRho(): don't use this "
+      "method. Use the \n setRelativeRho() methods of the underlying "
+      "geometry\n");
+}
+
+void EGS_SubGeometry::setMedia(EGS_Input *,int,const int *)
+{
+	egsWarning("EGS_SubGeometry::setMedia: don't use this method. Use the\n"
+	" setMedia() methods of the geometry objects that make up this geometry\n");
+}
+
+void EGS_SubGeometry::setRelativeRho(int start, int end, EGS_Float rho)
+{
+    setRelativeRho(0);
+}
+
+void EGS_SubGeometry::setRelativeRho(EGS_Input *)
+{
+    egsWarning("EGS_SubGeometry::setRelativeRho(): don't use this "
+    "method. Use the \n setRelativeRho() methods of the underlying "
+    "geometry\n");
+}
+
+extern "C" {
+
+EGS_HEXAGONAL_LATTICE_EXPORT EGS_BaseGeometry* createGeometry(EGS_Input *input)
+{
+	// Honestly, this whole section is monkey see monkey do
+    int error = 0;
+	
+	// Get base geometry
+	EGS_Input *i = input->getInputItem("base geometry");
+    if( !i )
+	{
+        egsWarning("createGeometry(hexagonal_lattice): base geometry must be defined\n" 
+                   " using 'base geometry = some_geom'?\n"); return 0;
+    }
+    EGS_Input *ig = i->getInputItem("geometry");
+    EGS_BaseGeometry *b;
+    if( ig )
+	{
+		b = EGS_BaseGeometry::createSingleGeometry(ig);
+        delete ig;
+		if (!b)
+		{
+			egsWarning("createGeometry(hexagonal_lattice): incorrect base geometry definition\n");
+			delete i;  return 0;
+		}
+    }
+    else
+	{
+        string bgname;
+        int err = i->getInput("base geometry",bgname);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(hexagonal_lattice): missing/incorrect 'base geometry' input\n"); return 0;
+        }
+        b = EGS_BaseGeometry::getGeometry(bgname);
+        if( !b )
+		{
+            egsWarning("createGeometry(envelope geometry): no geometry with name %s defined\n",
+						bgname.c_str());
+			return 0;
+        }
+    }
+	
+	// Get subgeometry
+	i = input->getInputItem("subgeometry");
+    if( !i )
+	{
+        egsWarning("createGeometry(hexagonal_lattice): subgeometry must be defined\n" 
+                   " using 'subgeometry = some_geom'?\n"); return 0;
+    }
+    ig = i->getInputItem("geometry");
+    EGS_BaseGeometry *s;
+    if( ig )
+	{
+		s = EGS_BaseGeometry::createSingleGeometry(ig);
+        delete ig;
+		if (!s)
+		{
+			egsWarning("createGeometry(hexagonal_lattice): incorrect subgeometry definition\n");
+			delete i;  return 0;
+		}
+    }
+    else
+	{
+        string bgname;
+        int err = i->getInput("subgeometry",bgname);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(hexagonal_lattice): missing/incorrect 'subgeometry' input\n"); return 0;
+        }
+        s = EGS_BaseGeometry::getGeometry(bgname);
+        if( !s )
+		{
+            egsWarning("createGeometry(envelope geometry): no geometry with name %s defined\n",
+						bgname.c_str());
+			return 0;
+        }
+    }
+	
+	// Non-geometry parameters (ie, lattice part starts here)
+	int ind = -1;
+	i = input->getInputItem("subgeometry index");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(hexagonal_lattice): subgeometry index must be defined\n"
+               "  using 'subgeometry index = some_index'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("subgeometry index",ind);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(hexagonal_lattice): missing/incorrect 'subgeometry index' input\n"); return 0;
+        }
+        else if (ind < 0 || ind >= b->regions()) // Not a real index
+		{
+            egsWarning("createGeometry(hexagonal_lattice): subgeometry index %d"
+                       " is not valid, must be a region in base geometry\n",ind);
+			return 0;
+		}
+    }
+	
+	EGS_Float vd = -1;
+	i = input->getInputItem("volumetric density");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(hexagonal_lattice): density must be defined\n"
+               "  using 'volumetric density = some_vol_den_in_cm3'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("volumetric density",vd);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(hexagonal_lattice): missing/incorrect 'volumetric density' input\n"); return 0;
+        }
+        else if (vd <= 0) // Not a real volume density
+		{
+            egsWarning("createGeometry(hexagonal_lattice): volumetric density"
+                       " is not valid, must be greater than zero\n");
+			return 0;
+		}
+    }
+	
+	EGS_Float width = -1; // largest spacing, an arbitrary variable for egs_view purposes for too many howfar calls
+	i = input->getInputItem("largest spacing");
+    if( !i )
+	{
+        egsWarning(
+               "createGeometry(hexagonal_lattice): largest spacing must be defined\n"
+               "  using 'largest spacing = some_distance'\n");
+        return 0;
+	}
+	else
+	{
+		int err = i->getInput("largest spacing",width);
+        delete i;
+        if( err )
+		{
+            egsWarning("createGeometry(hexagonal_lattice): missing/incorrect 'largest spacing' input\n"); return 0;
+        }
+        else if (width <= 0) // Not a real distance
+		{
+            egsWarning("createGeometry(hexagonal_lattice): largest spacing"
+                       " is not valid, must be greater than zero\n");
+			return 0;
+		}
+	}
+	
+	// Final build
+    EGS_BaseGeometry *result;
+    result = new EGS_SubGeometry(b, s, ind, /*envelope,*/ vd, width);
+    result->setName(input);
+    return result;
+}
+}

--- a/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.h
+++ b/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.h
@@ -1,0 +1,612 @@
+#ifndef EGS_HEXAGONAL_LATTICE_
+#define EGS_HEXAGONAL_LATTICE_
+
+#include "egs_base_geometry.h"
+#include "egs_transformations.h"
+#include "geometry/egs_gtransformed/egs_gtransformed.h"
+#include "egs_rndm.h"
+
+#ifdef WIN32
+
+#ifdef BUILD_HEXAGONAL_LATTICE_DLL
+#define EGS_HEXAGONAL_LATTICE_EXPORT __declspec(dllexport)
+#else
+#define EGS_HEXAGONAL_LATTICE_EXPORT __declspec(dllimport)
+#endif
+#define EGS_HEXAGONAL_LATTICE_LOCAL 
+
+#else
+
+#ifdef HAVE_VISIBILITY
+#define EGS_HEXAGONAL_LATTICE_EXPORT __attribute__ ((visibility ("default")))
+#define EGS_HEXAGONAL_LATTICE_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define EGS_HEXAGONAL_LATTICE_EXPORT
+#define EGS_HEXAGONAL_LATTICE_LOCAL
+#endif
+
+#endif
+
+/* Input Example
+:start geometry:
+	library            = egs_hexagonal_lattice
+	name               = phantom_w_microcavity
+	base geometry      = phantom
+	subgeometry        = microcavity
+	subgeometry index  = 0
+	volumetric density = 4.94782e+11
+    largest spacing    = 10000
+:stop geometry:
+*/
+
+class EGS_DummyGeometry : 
+            public EGS_BaseGeometry {
+
+protected:
+
+    EGS_BaseGeometry    *g;   //!< The geometry being transformed
+    EGS_AffineTransform T;    //!< The affine transformation
+    string              type; //!< The geometry type
+
+public:
+
+    /*! \brief Construct a geometry that is a copy of the geometry \a G 
+    transformed by \a t
+    */
+    EGS_DummyGeometry(EGS_BaseGeometry *G, const EGS_AffineTransform &t, 
+            const string &Name = "") : EGS_BaseGeometry(Name), g(G), T(t) {
+        type = g->getType(); type += "T"; nreg = g->regions();
+        is_convex = g->isConvex();
+        has_rho_scaling = g->hasRhoScaling();
+    };
+
+    ~EGS_DummyGeometry() { if( !g->deref() ) delete g; };
+
+    void setTransformation(const EGS_AffineTransform &t) { T = t; };
+
+    int computeIntersections(int ireg, int n, const EGS_Vector &x,
+            const EGS_Vector &u, EGS_GeometryIntersections *isections) {
+        EGS_Vector xt(x), ut(u);
+        T.inverseTransform(xt); T.rotateInverse(ut);
+        return g->computeIntersections(ireg,n,xt,ut,isections);
+    };
+    bool isRealRegion(int ireg) const {
+        return g->isRealRegion(ireg);
+    };
+    bool isInside(const EGS_Vector &x) { 
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->isInside(xt);
+        //return g->isInside(x*T); 
+    };
+    int isWhere(const EGS_Vector &x) { 
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->isWhere(xt); 
+        //return g->isWhere(x*T); 
+    };
+    int inside(const EGS_Vector &x) { return isWhere(x); };
+
+    int medium(int ireg) const { return g->medium(ireg); };
+
+    EGS_Float howfarToOutside(int ireg, const EGS_Vector &x, 
+            const EGS_Vector &u) {
+        return ireg >= 0 ? g->howfarToOutside(ireg,x*T,u*T.getRotation()) : 0;
+    };
+    int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u, 
+           EGS_Float &t, int *newmed=0, EGS_Vector *normal=0) { 
+        EGS_Vector xt(x), ut(u);
+        T.inverseTransform(xt); T.rotateInverse(ut);
+        int inew = g->howfar(ireg,xt,ut,t,newmed,normal); 
+        //int inew = g->howfar(ireg,x*T,u*T.getRotation(),t,newmed,normal); 
+        if( inew != ireg && normal ) 
+            *normal = T.getRotation()*(*normal);
+        return inew;
+    };
+
+    EGS_Float hownear(int ireg, const EGS_Vector &x) {
+        EGS_Vector xt(x); T.inverseTransform(xt);
+        return g->hownear(ireg,xt);
+        //return g->hownear(ireg,x*T);
+    };
+
+    int getMaxStep() const { return g->getMaxStep(); };
+
+    // Not sure about the following.
+    // If I leave the implementation that way, all transformed copies of a 
+    // geometry share the same boolean properties. But that may not be 
+    // what the user wants. So, I should implement both options: 
+    // all copies share the same properties and the user has the options 
+    // to define separate properties for each copy.
+    bool hasBooleanProperty(int ireg, EGS_BPType prop) const {
+        return g->hasBooleanProperty(ireg,prop);
+    };
+    void setBooleanProperty(EGS_BPType prop) {
+        g->setBooleanProperty(prop);
+    };
+    void addBooleanProperty(int bit) {
+        g->addBooleanProperty(bit);
+    };
+    void setBooleanProperty(EGS_BPType prop, int start, int end, int step=1) {
+        g->setBooleanProperty(prop,start,end,step);
+    };
+    void addBooleanProperty(int bit, int start, int end, int step=1) {
+        g->addBooleanProperty(bit,start,end,step);
+    };
+
+    const string &getType() const { return type; };
+
+    EGS_Float getRelativeRho(int ireg) const {
+        return g->getRelativeRho(ireg);
+    }
+    void setRelativeRho(int start, int end, EGS_Float rho);
+    void setRelativeRho(EGS_Input *);
+
+protected:
+
+    /*! \brief Don't define media in the transformed geometry definition.
+
+    This function is re-implemented to warn the user to not define 
+    media in the definition of a transformed geometry. Instead, media should 
+    be defined when specifying the geometry to be transformed.
+    */
+    void setMedia(EGS_Input *inp,int,const int *);
+
+};
+
+class EGS_HEXAGONAL_LATTICE_EXPORT EGS_SubGeometry : 
+            public EGS_BaseGeometry {
+protected:
+
+    EGS_BaseGeometry*  base;     //!< The geometry within which the sub geometry appears
+    EGS_DummyGeometry* sub;      //!< The sub geometry that could appear within base 
+	int                ind;      //!< The region in base geom where we could encounter sub geom
+	int                maxStep;  //!< The maximum number of steps
+	EGS_Float          spacing;  //!< The closest distance between two neighbouring sub geoms
+	EGS_Float          gap;      //!< The closest distance between two non-neighbouring sub geoms
+	EGS_Float          halfGap;  //!< Half the closest distance between two non-neighbouring sub geoms
+	bool               virt;     //!< Tells us whether or not we are in the sub geom
+    string             type;     //!< The geometry type
+
+public:
+
+    EGS_SubGeometry(EGS_BaseGeometry *B, EGS_BaseGeometry *S, int i, /*EGS_Float r,*/ EGS_Float vd, EGS_Float width, const string &Name = "")
+		: EGS_BaseGeometry(Name), base(B), ind(i), spacing(pow(4.0*sqrt(2.0)*vd,-1.0/3.0)*2.0)
+	{
+		sub             = new EGS_DummyGeometry(S,EGS_Vector(0,0,0));
+        type            = base->getType(); type += " with "; type += sub->getType(); type += " in a hexagonal lattice";
+		nreg            = base->regions() + sub->regions();
+        is_convex       = false; //base->isConvex();
+        has_rho_scaling = base->hasRhoScaling();
+		virt            = false;
+		maxStep         = width;
+		gap             = spacing*sqrt(3.0);
+    };
+
+    ~EGS_SubGeometry()
+	{
+		if(!sub->deref())
+			delete sub;
+		if(!base->deref())
+			delete base;
+	};
+	
+	EGS_Vector closestPoint(const EGS_Vector &x)
+	{
+		double i1, j1, k1, i2, j2, k2, j3, j4;
+		
+		i1 = spacing*(round(x.x/spacing));
+		j1 = gap*(round(x.y/gap));
+		k1 = gap*(round(x.z/gap));
+		i2 = spacing*(0.5+round(x.x/spacing-0.5));
+		j2 = gap*(0.5+round(x.y/gap-0.5));
+		k2 = gap*(0.5+round(x.z/gap-0.5));
+		j3 = gap*(-0.25+round(x.y/gap+0.25));
+		j4 = gap*(0.25+round(x.y/gap-0.25));
+		
+		EGS_Vector p1(i1,j1,k1);
+		EGS_Vector p2(i1,j3,k2);
+		EGS_Vector p3(i2,j2,k1);
+		EGS_Vector p4(i2,j4,k2);
+		
+		EGS_Float dist1 = (x-p1).length2();
+		EGS_Float dist2 = (x-p2).length2();
+		EGS_Float dist3 = (x-p3).length2();
+		EGS_Float dist4 = (x-p4).length2();
+		
+		if (dist1 < dist2 && dist1 < dist3 && dist1 < dist4)
+		{
+			//egsWarning("For %f,%f,%f nearest point is %f,%f,%f\n",x.x,x.y,x.z,p1.x,p1.y,p1.z);
+			return p1;
+		}
+		if (dist2 < dist3 && dist2 < dist4)
+		{
+			//egsWarning("For %f,%f,%f nearest point is %f,%f,%f\n",x.x,x.y,x.z,p2.x,p2.y,p2.z);
+			return p2;
+		}
+		if (dist3 < dist4)
+		{
+			//egsWarning("For %f,%f,%f nearest point is %f,%f,%f\n",x.x,x.y,x.z,p3.x,p3.y,p3.z);
+			return p3;
+		}
+		//egsWarning("For %f,%f,%f nearest point is %f,%f,%f\n",x.x,x.y,x.z,p4.x,p4.y,p4.z);
+		return p4;
+	};
+	
+    int computeIntersections(int ireg, int n, const EGS_Vector &x, const EGS_Vector &u, EGS_GeometryIntersections *isections)
+	{
+		return base->computeIntersections(ireg,n,x,u,isections);
+    };
+	
+    bool isRealRegion(int ireg) const
+	{
+		if (ireg < base->regions()) // If ireg is less than base regions
+			return base->isRealRegion(ireg); // check against base regions
+		return sub->isRealRegion(ireg - base->regions()); // then check subregions
+    };
+	
+    bool isInside(const EGS_Vector &x)
+	{
+		return base->isInside(x);
+    };
+	
+    int isWhere(const EGS_Vector &x)
+	{
+		int temp = base->isWhere(x);
+		// Are we in the subgeom?
+		if (temp == ind)
+		{
+			//base->printInfo();
+			//egsWarning("\nChecking position!\n");
+			//egsWarning("\t[%e,%e,%e]\n",x.x, x.y, x.z);
+			//egsWarning("\twhere r = %e\n", sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+			//cout << "\tisWhere invoking setTransformation\n";
+			sub->setTransformation(closestPoint(x));
+			//egsWarning("\twith region = %d\n", sub->isWhere(x) + base->regions());
+			if (sub->isInside(x))
+				return sub->isWhere(x) + base->regions();
+		}
+		return temp; // otherwise base geom		
+    };
+	
+    int inside(const EGS_Vector &x)
+	{
+		return isWhere(x);
+	};
+
+    int medium(int ireg) const
+	{
+		if (ireg >= base->regions()) // If ireg is greater than base regions
+			return sub->medium(ireg-base->regions());
+		return base->medium(ireg); // If in base region
+	};
+
+    EGS_Float howfarToOutside(int ireg, const EGS_Vector &x, const EGS_Vector &u)
+	{
+		if (ireg < 0) // Error catch, not inside
+			return 0;
+			
+		// Are we in the subgeom
+		if (ireg >= base->regions())
+			return base->howfarToOutside(ind,x,u);
+		return base->howfarToOutside(ireg,x,u);	
+    };
+
+	// This is where things get messy, this function will be trimodal, whether we are in non-ind base, ind base or sub
+    int howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u, EGS_Float &t, int *newmed=0, EGS_Vector *normal=0)
+	{
+		//egsWarning("%s howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+		//egsWarning("\t where r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+		
+		// Catch t=0 exception, which causes issues when making a lattice of lattices
+		if (t < epsilon)
+		{
+			t = 0.0;
+			return ireg;
+		}
+		
+		// Are we in the subgeom?
+		if (ireg >= base->regions())
+		{
+			sub->setTransformation(closestPoint(x));
+		
+			// Do the howfar call
+			EGS_Float tempT = t;
+			//egsWarning("%s sub->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg-base->regions(), x.x, x.y, x.z, u.x, u.y, u.z, tempT);
+			int tempReg = sub->howfar(ireg-base->regions(),x,u,tempT,newmed,normal);
+			
+			// If we do leave the subgeom, we want to return the index
+			// of the region of the base geometry we would be entering,
+			// which is not necessarily ind if subgeom is at the
+			// boundary
+			EGS_Vector newX = u; newX.normalize(); newX = x + (newX * tempT);
+			
+			//egsWarning("\tradius of new x %e\n",sqrt((newX.x*newX.x)+(newX.y*newX.y)+(newX.z*newX.z)));
+			if (!(tempReg+1) || base->isWhere(newX) != ind)
+			{
+				t = tempT;				
+				
+				//egsWarning("\tbase howfar(%6d, [%e,%e,%e], [%e,%e,%e], %e)\n",ind, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				tempReg = base->howfar(base->isWhere(x),x,u,t,0,normal);
+				if (newmed && tempReg >= 0)
+					*newmed = base->medium(tempReg);
+				//egsWarning("\treturn %d (%e)\n",tempReg,t);
+				//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+				
+				if (t<0)
+				{
+					egsWarning("Returning negative t from subgeom\n");
+					egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				}
+				return tempReg;
+			}
+			
+			t = tempT;
+			if (newmed && tempReg >= 0)
+				*newmed = sub->medium(tempReg);
+			//egsWarning("\treturn %d (%e)\n",tempReg+base->regions(),t);
+			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			
+			if (t<0)
+			{
+				egsWarning("Returning negative t from subgeom\n");
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+			}
+			//egsWarning("\treturn %d (%e)\n",tempReg,t);
+			return tempReg+base->regions();
+		}
+		else if (ireg == ind) // If we are in the region that could contain subgeoms
+		{
+			// Determine the path travelled ------------------------------------------------ //
+			EGS_Float tempT = t;
+			//egsWarning("%s base->howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",getName().c_str(),ireg, x.x, x.y, x.z, u.x, u.y, u.z, tempT);
+			base->howfar(ireg,x,u,tempT); // Get how far it is in temp
+			EGS_Float max = tempT;
+			
+			// Iterate through the lattice ------------------------------------------------- //
+			EGS_Float min = max, minX = max, minY = max, minZ = max; // Distance to closest subgeom for three different cases
+			EGS_Vector unit = u; unit.normalize();
+			EGS_Vector xInt = unit*(spacing/8.0/fabs(unit.x)), yInt = unit*(gap/8.0/fabs(unit.y)), zInt = unit*(gap/8.0/fabs(unit.z));
+			EGS_Vector tempP; // Temporarily hold indices of subgeom we are testing against
+			EGS_Vector finalP, finalX, finalY, finalZ; // Current closest intersecting subgeom
+			
+			EGS_Vector x0;
+			EGS_Float max2 = max*max;
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minX;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if(tempT < minX && tempT > 0)
+					{
+						finalX = tempP;
+						minX = tempT;
+						break;
+					}
+				x0 += xInt;
+			}
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minY;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if(tempT < minY && tempT > 0)
+					{
+						finalY = tempP;
+						minY = tempT;
+						break;
+					}
+				x0 += yInt;
+			}
+			
+			x0 = x;
+			while ((x-x0).length2() < max2) // Quit as soon as our testing position is beyond current closest intersection (which could be tempT)
+			{
+				tempT = minZ;
+				tempP = closestPoint(x0);
+				sub->setTransformation(tempP);
+				if (sub->howfar(-1,x,u,tempT)+1) // Intersection!
+					if(tempT < minZ && tempT > 0)
+					{
+						finalZ = tempP;
+						minZ = tempT;
+						break;
+					}
+				x0 += zInt;
+			}
+			
+			finalP = finalX; min = minX;
+			if (min > minY) {min = minY; finalP = finalY;}
+			if (min > minZ) {min = minZ; finalP = finalZ;}
+			
+			// Check last point
+			tempT = max;
+			sub->setTransformation(closestPoint(x+unit*tempT));
+			sub->howfar(-1,x,u,tempT);
+			if (tempT < min  && tempT > 0)
+			{
+				min = tempT;
+				finalP = closestPoint(x+unit*tempT);
+			}
+			
+			// We did intersect subgeom
+			if (min < max)
+			{
+				tempT = t;
+				sub->setTransformation(finalP);
+				int tempReg = sub->howfar(-1,x,u,t,newmed,normal);
+				if (tempReg+1)
+				{
+					if (newmed && tempReg >= 0)
+						*newmed = sub->medium(tempReg);
+					//egsWarning("\treturn %d (%f)\n",tempReg+base->regions(),t);
+					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					if (t<0)
+					{
+						egsWarning("Returning negative t from region %d in base geom t\n", ind);
+						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+						//egsFatal("Break 1!\n");
+					}
+					return tempReg+base->regions();
+				}
+			}
+			
+			// We didn't intersect subgeom
+			int tempReg = base->howfar(ireg,x,u,t,newmed,normal);
+			if (t<0)
+			{
+				egsWarning("Returning negative t from region %d in base geom\n", ind);
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsFatal("Break 2!\n");
+			}
+			if (newmed && tempReg >= 0)
+				*newmed = base->medium(tempReg);
+			//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			//egsWarning("\treturn %d (%f)\n",tempReg,t);
+			return tempReg;
+		}
+		else // Not in region containing subgeoms, then it is quite easy
+		{    // unless we enter directly into a subgeom when entering
+		     // region ind
+			int tempReg = base->howfar(ireg,x,u,t,newmed,normal);
+			
+			// If we enter region ind
+			if (tempReg == ind)
+			{
+				// newX is the point of entrance
+				EGS_Vector newX = u; newX.normalize(); newX = x + (newX * t); 
+				
+				sub->setTransformation(closestPoint(newX));
+				int newReg = sub->isWhere(newX); // see what region we are in
+				if (newReg+1)                    // in subgeom, if its not -1
+				{                                // then return the proper
+					if (newmed && newReg >= 0)   // media and region
+						*newmed = sub->medium(newReg);
+					//egsWarning("\treturn %d (%f)\n",newReg+base->regions(),t);
+					//egsWarning("new x should be[%e,%e,%e]\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+					if (t<0)
+					{
+						egsWarning("Returning negative t from region not %d in base geom\n", ind);
+						egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+						//egsFatal("Break 1!\n");
+					}
+					return newReg + base->regions();
+				}
+			}
+			
+			if (newmed && tempReg >= 0)
+				*newmed = base->medium(tempReg);
+			//egsWarning("\treturn %d (%e)\n",tempReg,t);
+			//egsWarning("new x should be[%e,%e,%e] %e\n",x.x+t*u.x,x.y+t*u.y,x.z+t*u.z);
+			if (t<0)
+			{
+				egsWarning("Returning negative t from region not %d in base geom\n", ind);
+				egsWarning("howfar(%7d,[%e,%e,%e],[%e,%e,%e],%e)\n",ireg, x.x, x.y, x.z, u.x, u.y, u.z, t);
+				//egsFatal("Break 2!\n");
+			}
+			return tempReg;
+		}
+    };
+	
+    EGS_Float hownear(int ireg, const EGS_Vector &x)
+	{
+		//egsWarning("%s hownear(%6d,[%e,%e,%e])\n", getName().c_str(), ireg, x.x, x.y, x.z);
+		//egsWarning("\twhere r = %e\n",sqrt((x.x*x.x)+(x.y*x.y)+(x.z*x.z)));
+		EGS_Float temp, dist = base->hownear(ind,x);
+		if (ireg >= base->regions())
+		{
+			sub->setTransformation(closestPoint(x));
+			temp = sub->hownear(ireg-base->regions(),x);
+			//egsWarning("\treturn %e\n",sub->hownear(ireg-base->regions(),x));
+			return (temp<dist)?temp:dist;
+		}
+		else if (ireg == ind)
+		{
+			// Check all nearby geometries, in case of weird subgeom shapes
+			// with a 10% increased spacing/gap buffer to avoid roundoff
+			EGS_Vector x0[7] = {EGS_Vector(x.x-gap*1.1,x.y,x.z),
+							    EGS_Vector(x.x+gap*1.1,x.y,x.z),
+							    EGS_Vector(x.x,x.y-gap*1.1,x.z),
+							    EGS_Vector(x.x,x.y+gap*1.1,x.z),
+							    EGS_Vector(x.x,x.y,x.z-gap*1.1),
+							    EGS_Vector(x.x,x.y,x.z+gap*1.1),
+							    EGS_Vector(x)};
+			for (int i = 0; i < 7; i++)
+			{
+				sub->setTransformation(closestPoint(x0[i]));
+				temp = sub->hownear(ireg-base->regions(),x);
+				if (temp < dist)
+					dist = temp;
+			}
+			//egsWarning("\treturn %e\n",dist);
+			return dist;
+		}
+		//egsWarning("\treturn %e\n",base->hownear(ireg,x));
+		return dist;
+    };
+
+    int getMaxStep() const
+	{
+		return maxStep;
+    };
+
+    // Not sure about the following.
+    // If I leave the implementation that way, all transformed copies of a 
+    // geometry share the same boolean properties. But that may not be 
+    // what the user wants. So, I should implement both options: 
+    // all copies share the same properties and the user has the options 
+    // to define separate properties for each copy.
+    bool hasBooleanProperty(int ireg, EGS_BPType prop) const
+	{
+		return base->hasBooleanProperty(ireg,prop);
+    };
+	
+    void setBooleanProperty(EGS_BPType prop)
+	{
+		base->setBooleanProperty(prop);
+    };
+	
+    void addBooleanProperty(int bit)
+	{
+		base->addBooleanProperty(bit);
+    };
+	
+    void setBooleanProperty(EGS_BPType prop, int start, int end, int step=1)
+	{
+		base->setBooleanProperty(prop,start,end,step);
+    };
+	
+    void addBooleanProperty(int bit, int start, int end, int step=1)
+	{
+		base->addBooleanProperty(bit,start,end,step);
+    };
+
+    const string &getType() const
+	{
+		return type;
+	};
+
+    EGS_Float getRelativeRho(int ireg) const
+	{
+		return base->getRelativeRho(ireg);
+    }
+    void setRelativeRho(int start, int end, EGS_Float rho);
+    void setRelativeRho(EGS_Input *);
+
+protected:
+
+    /*! \brief Don't define media in the transformed geometry definition.
+
+    This function is re-implemented to warn the user to not define 
+    media in the definition of a transformed geometry. Instead, media should 
+    be defined when specifying the geometry to be transformed.
+    */
+    void setMedia(EGS_Input *inp,int,const int *);
+
+};
+
+#endif

--- a/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.h
+++ b/HEN_HOUSE/egs++/geometry/egs_hexagonal_lattice/egs_hexagonal_lattice.h
@@ -1,3 +1,13 @@
+/*
+###############################################################################
+#
+# EGSnrc egs++ auto envelope geometry
+# Copyright (C) 2019 Martin Martinov
+#
+# This file is part of EGSnrc.
+#
+###############################################################################
+*/
 #ifndef EGS_HEXAGONAL_LATTICE_
 #define EGS_HEXAGONAL_LATTICE_
 


### PR DESCRIPTION
Add lattice geometries to the egs++ geometry distribution in either the hexagonal close-packed or cubic lattice configurations.  These lattice geometries take in two geometries, and embeds one of them into a chosen region of the other for a chosen number density.  The geometry recursed to form the lattice only has one set of regions repeated everywhere, hence embedded geometries cannot be distinguished.