### PR TITLE
Fix Win egs_system function

### DIFF
--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -1744,6 +1744,15 @@ void MTest::execute(){
     if ( exeTimes < args.count() ){
         QStringList the_arg; the_arg << QString( args[exeTimes] );
         QString command = QString("./") + t[currentTask].exeName();
+
+        QString criterion = t[currentTask].checkMode();
+        if ( criterion.toLower() == "exitstatus"){
+            exeProc->setProcessChannelMode(QProcess::MergedChannels);
+        }
+        else if (  criterion.toLower() == "output"){
+            exeProc->setProcessChannelMode(QProcess::SeparateChannels);
+		}
+
         exeProc->start(command,the_arg);
         if(exeProc->error()==QProcess::FailedToStart){
 	//if ( ! exeProc->start() ) {

--- a/HEN_HOUSE/pieces/tests_win.xml
+++ b/HEN_HOUSE/pieces/tests_win.xml
@@ -173,7 +173,7 @@ void EGS_EXIT__(int *status){my_exit(status);}
  <opt> </opt>
  <map>
   <key>OUTSTRING</key>
-  <body>echo hallo</body>
+  <body>echo off</body>           <!-- parse only test output using silent cmd -->
   <body>blah__blah</body>
  </map>
  <arg>0</arg>
@@ -190,7 +190,7 @@ void EGS_EXIT__(int *status){my_exit(status);}
       do i=1,len(command)
         command(i:i) = ' '
       end do
-      command = 'echo hallo'
+      command = 'echo off'          <!-- parse only test output using silent cmd -->
       command(11:11) = char(0)
       istat = 222222
       call system(command,istat)


### PR DESCRIPTION
**Bug:** Parallel runs on Windows were failing to combine `*.egsdat `files. Reported by Alex Bielajew.

**Cause:** check for exit status from the `system` function and subroutine was failing on Windows. 
As a consequence, a dummy `egs_system `funtion always returned a successful command execution status.

One can now submit parallel jobs on Windows to all available cores on a given PC and get the combined results.