### PR TITLE
Fix windows compilation bug

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -119,10 +119,13 @@ $(DSO1)egs_object_factory.$(obje): egs_object_factory.cpp egs_object_factory.h \
 
 $(DSO1)egs_spectra.$(obje): egs_spectra.cpp egs_base_source.h $(config1h) \
     egs_rndm.h egs_object_factory.h egs_alias_table.h egs_vector.h \
-    egs_input.h egs_math.h
+    egs_input.h egs_math.h egs_ensdf.h
 
 $(DSO1)egs_base_source.$(obje): egs_base_source.cpp egs_base_source.h \
     egs_vector.h $(config1h) egs_object_factory.h egs_input.h
+
+$(DSO1)egs_ensdf.$(obje): egs_ensdf.cpp egs_ensdf.h \
+    $(config1h) egs_functions.h egs_math.h egs_alias_table.h egs_atomic_relaxations.h
 
 $(DSO1)egs_geometry_tester.$(obje): egs_geometry_tester.cpp \
     egs_geometry_tester.h egs_input.h egs_vector.h egs_base_geometry.h \

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/Makefile
@@ -32,7 +32,7 @@ include $(EGS_CONFIG)
 include $(SPEC_DIR)egspp.spec
 include $(SPEC_DIR)egspp_$(my_machine).conf
 
-DEFS = $(DEF1) -DBUILD_DOSE_SCORING_DLL
+DEFS = $(DEF1) -DBUILD_RADIATIVE_SPLITTING_DLL
 
 library = egs_radiative_splitting
 lib_files = egs_radiative_splitting

--- a/HEN_HOUSE/egs++/egs_ensdf.h
+++ b/HEN_HOUSE/egs++/egs_ensdf.h
@@ -238,7 +238,7 @@ public:
 };
 
 // Level Record
-class LevelRecord : public Record, public Branch<Leaf<LevelRecord> > {
+class EGS_EXPORT LevelRecord : public Record, public Branch<Leaf<LevelRecord> > {
 public:
     LevelRecord();
     LevelRecord(vector<string> ensdf);
@@ -266,7 +266,7 @@ public:
 };
 
 // Generic beta record
-class BetaRecordLeaf : public Record, public ParentRecordLeaf, public
+class EGS_EXPORT BetaRecordLeaf : public Record, public ParentRecordLeaf, public
     NormalizationRecordLeaf, public LevelRecordLeaf {
 public:
     BetaRecordLeaf(vector<string> ensdf, ParentRecord *myParent,
@@ -307,7 +307,7 @@ protected:
 };
 
 // Beta- record
-class BetaMinusRecord : public BetaRecordLeaf {
+class EGS_EXPORT BetaMinusRecord : public BetaRecordLeaf {
 public:
     BetaMinusRecord(vector<string> ensdf, ParentRecord *myParent,
                     NormalizationRecord *myNormalization, LevelRecord *myLevel);
@@ -321,7 +321,7 @@ private:
 };
 
 // Beta+ Record (and Electron Capture)
-class BetaPlusRecord : public BetaRecordLeaf {
+class EGS_EXPORT BetaPlusRecord : public BetaRecordLeaf {
 public:
     BetaPlusRecord(vector<string> ensdf, ParentRecord *myParent,
                    NormalizationRecord *myNormalization, LevelRecord *myLevel);
@@ -346,7 +346,7 @@ private:
 };
 
 // Gamma record
-class GammaRecord : public Record, public ParentRecordLeaf,
+class EGS_EXPORT GammaRecord : public Record, public ParentRecordLeaf,
     public NormalizationRecordLeaf, public LevelRecordLeaf {
 public:
     GammaRecord(vector<string> ensdf, ParentRecord *myParent,
@@ -388,7 +388,7 @@ private:
 };
 
 // Alpha record
-class AlphaRecord : public Record, public ParentRecordLeaf, public
+class EGS_EXPORT AlphaRecord : public Record, public ParentRecordLeaf, public
     NormalizationRecordLeaf, public LevelRecordLeaf {
 public:
     AlphaRecord(vector<string> ensdf, ParentRecord *myParent,


### PR DESCRIPTION
Fixes a bug where the egs++ library did not compile on windows. This bug did *not* make it into the `master` release, and has only been in the `develop` branch since commit 68a830d.

The failure was due to a typo in the radiative splitting ausgab Makefile, and due to some missing EGS_EXPORT flags in egs_ensdf for the radionuclide source.