### PR TITLE
Fix #485: string size mismatch in media inputs

### DIFF
--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -3387,7 +3387,7 @@ REPLACE {COMIN/GetInput/;} WITH
         ERROR_FLAG,                "0 for no errors, 1 for errors      "
         DELIMETER;                 "Name of the delimeter              "
    character ALLOWED_INPUTS*$STRING32,VALUES_SOUGHT*$STRING32,
-             CHAR_VALUE*$STRING80,DELIMETER*$STRING32;
+             CHAR_VALUE*$STRING256,DELIMETER*$STRING32;
    $REAL     VALUE,DEFAULT,VALUE_MIN,VALUE_MAX;
    $INTEGER  NVALUE,TYPE,NMIN,NMAX,ERROR_FLAG,ERROR_FLAGS,i_errors;
 }

--- a/HEN_HOUSE/src/get_inputs.mortran
+++ b/HEN_HOUSE/src/get_inputs.mortran
@@ -219,7 +219,7 @@ COMIN/GetInput,EGS-IO/;
 CHARACTER*$STRING256 TEXT;      "Used to read in each line of the input file   "
 CHARACTER*$STRING256 KEEPTEXT;  "Used to keep an old line of TEXT              "
 CHARACTER*$STRING256 ORIGTEXT;  "The text without conversion to upper case     "
-CHARACTER*$STRING80  TEXTPIECE; "Used to read a piece of TEXT                  "
+CHARACTER*$STRING256  TEXTPIECE; "Used to read a piece of TEXT                  "
 CHARACTER*$STRING40  DELIM_START;"Start of the delimeter                       "
 CHARACTER*$STRING40  DELIM_END;  "End of the delimeter                         "
 CHARACTER*$STRING32  VNAME;      "The name of the variable being extracted.    "
@@ -422,7 +422,7 @@ DO I = NMIN, NMAX  [ "for each value_sought"
    [
         IF (vname(:ivname)='TITLE')
         [
-           READ (UNITNUM,FMT='(A80)') TEXTPIECE;
+           READ (UNITNUM,FMT='(A256)') TEXTPIECE;
            IF (lnblnk1(TEXTPIECE)~=0) [
               TEXT=TEXTPIECE(:lnblnk1(TEXTPIECE));
               $SKIP LEADING BLANKS IN text;
@@ -624,7 +624,7 @@ DO I = NMIN, NMAX  [ "for each value_sought"
                       "for e.g. media names                          "
            :READ-IT:
            CONTINUE;
-           READ(TEXTPIECE,ERR=:GI1008:,FMT='(A80)') CHAR_VALUE(I,IVAL);
+           READ(TEXTPIECE,ERR=:GI1008:,FMT='(A256)') CHAR_VALUE(I,IVAL);
            $SKIP LEADING BLANKS IN CHAR_VALUE(I,IVAL);
            IF( idebug ) [
              write(i_log,*) ' Read the following char string: ';


### PR DESCRIPTION
**Please review this PR carefully - will the `CHAR_VALUE` change cause problems elsewhere?**

Fixed a bug where simulations would not read the input for the density correction file if specified in a material file. The error looked like this:

```
***************** Error:
Error: Cannot open density correction file:
.density
 
***************** Quiting now.
```

This error only occurred on certain systems. It was due to a string assignment mismatch between 256 and 80 characters, resulting in an empty string. The bug only existed since PR #445, which extended one string to 256 characters.

The error can be produced by adding the following to the EX10MeVe.egsinp example, and running on a gcc 4.5.1 system.

```
:start media definition:
 AE=0.521
 UE=18.021
 AP=0.01
 UP=18.5
 material data file=/home/yourUsername/EGSnrc/HEN_HOUSE/pegs4/data/material.dat
:stop media definition:
```