### PR TITLE
EGSnrc parallelization using MPI

### DIFF
--- a/HEN_HOUSE/makefiles/beam_makefile
+++ b/HEN_HOUSE/makefiles/beam_makefile
@@ -115,7 +115,7 @@ $(FORTRAN_FILE).$(FEXT): $(SOURCES) sources.make
 	       -o8 $(FORTRAN_FILE).mortlst
 
 #*******************************************************************************
-# #PARALLEL_EGS -   Disable PJOB functionality for BEAMnrc libraries due to  
+# #PARALLEL_EGS -   Disable PJOB functionality for BEAMnrc libraries due to
 #                   locking problems when used from dosxyznrc parallel execution
 #*******************************************************************************
 library: $(LIB_FILE)

--- a/HEN_HOUSE/makefiles/beam_makefile
+++ b/HEN_HOUSE/makefiles/beam_makefile
@@ -114,13 +114,17 @@ $(FORTRAN_FILE).$(FEXT): $(SOURCES) sources.make
 	@$(MORTRAN_EXE) -d $(MORTRAN_DATA) -f $(SOURCES) -o7 $@ \
 	       -o8 $(FORTRAN_FILE).mortlst
 
+#*******************************************************************************
+# #PARALLEL_EGS -   Disable PJOB functionality for BEAMnrc libraries due to  
+#                   locking problems when used from dosxyznrc parallel execution
+#*******************************************************************************
 library: $(LIB_FILE)
 
 $(LIB_FILE): $(LIB_FORTRAN_FILE).$(FOBJE)
-	$(F77_LINK) $(SHLIB_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FOBJE) $(BEAM_EXTRA_OBJECTS) $(FLIBS) $(SHLIB_LIBS)
+	$(F77_LINK) $(SHLIB_FLAGS) $(FCFLAGS) -D_NOPJOB $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FOBJE) $(BEAM_EXTRA_OBJECTS) $(FLIBS) $(SHLIB_LIBS)
 
 $(LIB_FORTRAN_FILE).$(FOBJE): $(LIB_FORTRAN_FILE).$(FEXT)
-	$(F77) -c $(FCFLAGS) $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FEXT)
+	$(F77) -c $(FCFLAGS) -D_NOPJOB $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FEXT)
 
 $(LIB_FORTRAN_FILE).$(FEXT): $(LIB_SOURCES) sources.make
 	@echo "Mortran compilation for $@"
@@ -154,15 +158,22 @@ noopt:
 debug:
 	@$(MAKE) WHAT=_debug OPTLEVEL_F="$(FDEBUG)" OPTLEVEL_C="$(CDEBUG)"
 
+#*******************************************************************************
+# #PARALLEL_EGS -   Build a optimized user code with MPI support
+#*******************************************************************************
+mpi:
+	@$(MAKE) -s WHAT=_mpi F77=mpif90 FCFLAGS="$(FCFLAGS) -D_MPI"
+
 clean:
 	@echo "$(REMOVE) mortjob.mortran $(FORTRAN_FILE).$(FEXT) $(FORTRAN_FILE).mortlst"
 	@$(REMOVE) mortjob.mortran $(FORTRAN_FILE).$(FEXT) $(FORTRAN_FILE).mortlst
 	@$(MAKE) -s WHAT=_debug execlean
 	@$(MAKE) -s WHAT=_noopt execlean
+	@$(MAKE) -s WHAT=_mpi execlean
 	@$(MAKE) -s WHAT= execlean
 
 execlean:
 	@echo "$(REMOVE) $(EXE_FILE)"
 	$(REMOVE) $(EXE_FILE)
 
-.PHONY: opt noopt debug clean execlean
+.PHONY: opt noopt debug mpi clean execlean

--- a/HEN_HOUSE/makefiles/standard_makefile
+++ b/HEN_HOUSE/makefiles/standard_makefile
@@ -182,7 +182,7 @@ opt:
 
 # Build a user code without optimization
 noopt:
-	@$(MAKE) -s WHAT=_noopt OPTLEVEL_F= OPTLEVEL_C=
+	@$(MAKE) -s WHAT=_mpi OPTLEVEL_F= OPTLEVEL_C=
 #	@($(MAKE) -s WHAT=_noopt OPTLEVEL_F= OPTLEVEL_C= && echo $(ok_message)) || echo $(failed_message)
 
 # Build a user code for debugging
@@ -190,12 +190,19 @@ debug:
 	@$(MAKE) -s WHAT=_debug OPTLEVEL_F="$(FDEBUG)" OPTLEVEL_C="$(CDEBUG)"
 #@($(MAKE) -s WHAT=_debug OPTLEVEL_F="$(FDEBUG)" OPTLEVEL_C="$(CDEBUG)" && echo $(ok_message)) || echo $(failed_message)
 
+#*******************************************************************************
+# #PARALLEL_EGS -   Build a optimized user code with MPI support
+#*******************************************************************************
+mpi:
+	@$(MAKE) -s WHAT=_mpi F77=mpif90 FCFLAGS="$(FCFLAGS) -D_MPI"
+
 # Clean-up the user code directory.
 clean:
 	@echo "$(REMOVE) mortjob.mortran $(FORTRAN_FILE).$(FEXT) $(FORTRAN_FILE).mortlst"
 	@$(REMOVE) mortjob.mortran $(FORTRAN_FILE).$(FEXT) $(FORTRAN_FILE).mortlst
 	@$(MAKE) -s WHAT=_debug execlean
 	@$(MAKE) -s WHAT=_noopt execlean
+	@$(MAKE) -s WHAT=_mpi execlean
 	@$(MAKE) -s WHAT= execlean
 	@echo $(ok_message)
 
@@ -208,4 +215,4 @@ execlean:
 # execlean have no list of prerequisits so that make can determine whether
 # they need to be remade, we declare them as phony.
 #
-.PHONY: opt noopt debug clean execlean
+.PHONY: opt noopt debug mpi clean execlean

--- a/HEN_HOUSE/omega/beamnrc/beam_main.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beam_main.mortran
@@ -40,8 +40,8 @@
 PROGRAM beam_main;
 
 "*******************************************************************************
-" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
-"                   is used only if the user specifies the _MPI macro during 
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It
+"                   is used only if the user specifies the _MPI macro during
 "                   compilation.
 "*******************************************************************************
 $IFDEF(#,_MPI);
@@ -53,7 +53,7 @@ $IMPLICIT-NONE;
 $INTEGER ircode;
 
 "*******************************************************************************
-" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here 
+" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here
 "                   in order to create one *.egslst file per MPI process.
 "*******************************************************************************
 $INTEGER ierr;  "error code returned by MPI subroutines"
@@ -81,4 +81,3 @@ $MPI{#, call MPI_FINALIZE(ierr)};
 
 $CALL_EXIT(0);
 end;
-

--- a/HEN_HOUSE/omega/beamnrc/beam_main.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beam_main.mortran
@@ -34,12 +34,31 @@
 "                                                                             "
 "#############################################################################"
 
+"*******************************************************************************
+" #PARALLEL_EGS -   start of the program.
+"*******************************************************************************
+PROGRAM beam_main;
 
-program beam_main;
+"*******************************************************************************
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
+"                   is used only if the user specifies the _MPI macro during 
+"                   compilation.
+"*******************************************************************************
+$IFDEF(#,_MPI);
+  USE MPI;
+$ENDIF(#);
 
-implicit none;
+$IMPLICIT-NONE;
 
 $INTEGER ircode;
+
+"*******************************************************************************
+" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here 
+"                   in order to create one *.egslst file per MPI process.
+"*******************************************************************************
+$INTEGER ierr;  "error code returned by MPI subroutines"
+
+$MPI{#, call MPI_INIT(ierr)};
 
 call egs_init;
 call beam_init(ircode);
@@ -54,6 +73,12 @@ IF( ircode < 0 ) [ $CALL_EXIT(1); ]
 IF( ircode = 0 ) call beam_shower_loop;
 IF( ircode = 2 ) [ call beam_finish(1); ]
 ELSE             [ call beam_finish(0); ]
+
+"*******************************************************************************
+" #PARALLEL_EGS - Terminate the MPI environment.
+"*******************************************************************************
+$MPI{#, call MPI_FINALIZE(ierr)};
+
 $CALL_EXIT(0);
 end;
 

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -5558,7 +5558,7 @@ $IF(#,_NOPJOB);
            AMASS(ID)=0.; "zero these since they get summed again in ISUMRY"
         ]
         CALL ISUMRY;
-        "call egs_combine_runs(combine_results,'.egsdat');"
+        call egs_combine_runs(combine_results,'.egsdat');
         NCASET=NCASEO;  IHSTRY=NCASET; NCASE=0;
         CALL SRCOTO(WEIGHT);
         goto :TIME-PLUS-ANAL:;

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -4776,11 +4776,11 @@ write(i_log,*) '*********** jcase = ',jcase;
 
 :start_parallel_loop:;
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and divide
-"                   particle histories evenly among MPI processes.
+" #PARALLEL_EGS -   If NOPJOB is defined disable job control file logic and
+"                   divide particle histories evenly among MPI processes.
 "*******************************************************************************
 IF( n_parallel > 0 ) [  "Job is part of a parallel run "
-$IF(#,_MPI);
+$IF(#,_NOPJOB);
    n_run = ncase/n_parallel;
    jcase = n_run/$NBATCH;
    IF( jcase < 1 ) [ jcase = 1; n_run = jcase*$NBATCH; ]
@@ -4946,10 +4946,10 @@ ELSE[
 #ifdef HAVE_C_COMPILER;
 ;
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable original parallelization logic.
+" #PARALLEL_EGS -   If NOPJOB is defined disable original parallelization logic.
 "*******************************************************************************
 IF( n_parallel > 0 ) [
-$IFNDEF(#,_MPI);
+$IFNDEF(#,_NOPJOB);
    goto :start_parallel_loop:;
 $ENDIF(#);
 ]
@@ -5047,14 +5047,7 @@ ITMAX=3+LNEXC+LNINC;
 
 return; end;
 
-<<<<<<< HEAD
 subroutine beam_finish(i_entry);
-implicit none;
-||||||| parent of d2fed915... mpi support in BEAMnrc
-subroutine beam_finish(ientry);
-implicit none;
-=======
-subroutine beam_finish(ientry);
 
 "*******************************************************************************
 " #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It
@@ -5066,7 +5059,6 @@ $IFDEF(#,_MPI);
 $ENDIF(#);
 
 $IMPLICIT-NONE;
->>>>>>> d2fed915... mpi support in BEAMnrc
 
 $INTEGER i_entry, ientry, egs_open_file;
 
@@ -5547,11 +5539,11 @@ call egs_finish;     " Finish the simulation "
 #ifdef HAVE_C_COMPILER;
 ;
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and combine
-"                   runs of MPI processes.
+" #PARALLEL_EGS -   If NOPJOB is enabled disable job control file logic and
+"                   combine runs of MPI processes.
 "*******************************************************************************
 IF( n_parallel > 0 & ~is_finished & ~is_beam_src ) [
-$IF(#,_MPI);
+$IF(#,_NOPJOB);
    "Get sure that all MPI processes have reached this point "
     $MPI{#, call MPI_BARRIER(MPI_COMM_WORLD, ierr)};
     IOUTLIST=egs_open_file(IOUTLIST,0,1,'.egslst');

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -4775,8 +4775,31 @@ n_tot = ncaseo; first_time = .true.;
 write(i_log,*) '*********** jcase = ',jcase;
 
 :start_parallel_loop:;
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and divide
+"                   particle histories evenly among MPI processes.
+"*******************************************************************************
 IF( n_parallel > 0 ) [  "Job is part of a parallel run "
-
+$IF(#,_MPI);
+   n_run = ncase/n_parallel;
+   jcase = n_run/$NBATCH;
+   IF( jcase < 1 ) [ jcase = 1; n_run = jcase*$NBATCH; ]
+   IF(ISOURC=21 | ISOURC=24)[
+"    figure out where to start in the phase space file"
+        p_per_phsp_chunk=NNPHSP/n_parallel;
+        INPHSP_MIN=(i_parallel-1)*p_per_phsp_chunk+1;
+        INPHSP_MAX=INPHSP_MIN+p_per_phsp_chunk-1;
+        INPHSP=INPHSP_MIN-1; "src routine adds 1 to INPHSP"
+        "need to set position in IAEA source, if applicable"
+        IF(i_iaea_in=1)[$IAEA_SET_PHSP_RECORD(IINSRC,INPHSP_MIN);]
+        CYCLNUM=0; "reset NRCYCL counter"
+        write(i_log,'(/a/,a,i12,a,i12/,a//)')
+  '      This simulation uses a phase space source.',
+  '      This run will use from particle',INPHSP_MIN,' to particle ',
+         INPHSP_MAX,
+  '      in the source file.';
+    ]
+$ELSE(#);
     call egs_pjob_control(ncase,n_run,n_left,n_tot,part_dose,part2_dose,
                           current_result, current_uncertainty);
     IF( n_run = 0 ) [
@@ -4825,6 +4848,7 @@ IF( n_parallel > 0 ) [  "Job is part of a parallel run "
          INPHSP_MAX,
   '      in the source file.';
     ]
+$ENDIF(#);
 ]
 #endif;
 
@@ -4921,7 +4945,14 @@ ELSE[
 
 #ifdef HAVE_C_COMPILER;
 ;
-IF( n_parallel > 0 ) [ goto :start_parallel_loop:; ]
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable original parallelization logic.
+"*******************************************************************************
+IF( n_parallel > 0 ) [
+$IFNDEF(#,_MPI);
+   goto :start_parallel_loop:;
+$ENDIF(#);
+]
 
 #endif;
 
@@ -5016,8 +5047,26 @@ ITMAX=3+LNEXC+LNINC;
 
 return; end;
 
+<<<<<<< HEAD
 subroutine beam_finish(i_entry);
 implicit none;
+||||||| parent of d2fed915... mpi support in BEAMnrc
+subroutine beam_finish(ientry);
+implicit none;
+=======
+subroutine beam_finish(ientry);
+
+"*******************************************************************************
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It
+"                   is used only if the user specifies the _MPI macro during
+"                   compilation.
+"*******************************************************************************
+$IFDEF(#,_MPI);
+  USE MPI;
+$ENDIF(#);
+
+$IMPLICIT-NONE;
+>>>>>>> d2fed915... mpi support in BEAMnrc
 
 $INTEGER i_entry, ientry, egs_open_file;
 
@@ -5497,7 +5546,32 @@ call egs_finish;     " Finish the simulation "
 
 #ifdef HAVE_C_COMPILER;
 ;
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and combine
+"                   runs of MPI processes.
+"*******************************************************************************
 IF( n_parallel > 0 & ~is_finished & ~is_beam_src ) [
+$IF(#,_MPI);
+   "Get sure that all MPI processes have reached this point "
+    $MPI{#, call MPI_BARRIER(MPI_COMM_WORLD, ierr)};
+    IOUTLIST=egs_open_file(IOUTLIST,0,1,'.egslst');
+    IF( i_parallel = 1 ) [
+        " Open again the list file. This is actually done in egs_pjob_finish() "
+        " subroutine. Reset i_parallel and open again list file. "
+        i_parallel = 0;
+        call egs_open_units(.false.);
+
+        is_finished = .true.;
+        DO ID=1,NDOSE_ZONE[
+           AMASS(ID)=0.; "zero these since they get summed again in ISUMRY"
+        ]
+        CALL ISUMRY;
+        "call egs_combine_runs(combine_results,'.egsdat');"
+        NCASET=NCASEO;  IHSTRY=NCASET; NCASE=0;
+        CALL SRCOTO(WEIGHT);
+        goto :TIME-PLUS-ANAL:;
+    ]
+$ELSE(#);
     call egs_pjob_finish(n_job);
     IOUTLIST=egs_open_file(IOUTLIST,0,1,'.egslst');
     IF( n_job = 0 ) [
@@ -5511,6 +5585,7 @@ IF( n_parallel > 0 & ~is_finished & ~is_beam_src ) [
         CALL SRCOTO(WEIGHT);
         goto :TIME-PLUS-ANAL:;
     ]
+$ENDIF(#);
 ]
 #endif;
 

--- a/HEN_HOUSE/specs/all_common.spec
+++ b/HEN_HOUSE/specs/all_common.spec
@@ -180,4 +180,3 @@ C_SOURCES =   $(EGS_SOURCEDIR)egsnrc.macros \
 		$(MACHINE_MORTRAN) \
 		$(EGS_SOURCEDIR)egs_utilities.mortran \
 		$(EGS_SOURCEDIR)egsnrc.mortran
-

--- a/HEN_HOUSE/specs/all_common.spec
+++ b/HEN_HOUSE/specs/all_common.spec
@@ -127,7 +127,7 @@ EGS_COMPILE = $(EGS_BINDIR)egs_compile$(EXE)
 
 # The fortran file extension
 #
-FEXT = f
+FEXT = F
 
 # The git hash and branch
 GIT_HASH =

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -482,6 +482,16 @@ return; end;
 "*****************************************************************************
 subroutine egs_check_arguments;
 "*****************************************************************************
+
+"*******************************************************************************
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
+"                   is used only if the user specifies the _MPI macro during 
+"                   compilation.
+"*******************************************************************************
+$IFDEF(#,_MPI);
+    USE MPI;
+$ENDIF(#);
+
 implicit none;
 
 ;COMIN/EGS-IO/;
@@ -491,6 +501,11 @@ $LOGICAL  have_arg,egs_isdir,egs_strip_extension,ex,
           on_egs_home;
 integer   narg, iargc, i, lnblnk1, l, l2,i_help,egs_get_unit;
 $declare_write_buffer;
+
+"*******************************************************************************
+" #PARALLEL_EGS - Error code returned by MPI subroutines
+"*******************************************************************************
+$INTEGER ierr;
 
 narg = iargc();
 IF( narg < 1 ) return;
@@ -542,6 +557,27 @@ IF( have_arg ) [
   $egs_fatal(*,'Did not find the help_message file!');
 ]
 
+"*******************************************************************************
+" #PARALLEL_EGS -   Here MPI is integrated in EGSnrc into parallelization logic.
+"                   If MPI is enabled the number of processes and process id is
+"                   extracted using MPI routines.
+"*******************************************************************************
+$IF(#,_MPI);
+
+" Set batch option "
+is_batch = .true.;
+
+" Now get number of MPI processes "
+$MPI{#, call MPI_COMM_SIZE(MPI_COMM_WORLD, n_parallel, ierr)};
+
+" And MPI process rank "
+$MPI{#, call MPI_COMM_RANK(MPI_COMM_WORLD, i_parallel, ierr)};
+
+" Increment i_parallel by one to match EGSnrc parallel standard "
+i_parallel = i_parallel + 1;
+
+$ELSE(#);
+
 " Check for batch option "
 $check_argument('-b','--batch',arg);
 IF( have_arg ) is_batch = .true.;
@@ -580,6 +616,7 @@ IF( have_arg ) [
     first_parallel = 1;
     :ok_first_job_arg:;
 ]
+$ENDIF(#);
 
 IF( n_parallel > 0 | i_parallel > 0 ) [
     IF( n_parallel*i_parallel = 0 ) [

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -484,8 +484,8 @@ subroutine egs_check_arguments;
 "*****************************************************************************
 
 "*******************************************************************************
-" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
-"                   is used only if the user specifies the _MPI macro during 
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It
+"                   is used only if the user specifies the _MPI macro during
 "                   compilation.
 "*******************************************************************************
 $IFDEF(#,_MPI);
@@ -2369,4 +2369,3 @@ $INTEGER function ibsearch(a, nsh, b);
  ]
  ibsearch = min;
  return;end;
-

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -1549,6 +1549,12 @@ IF( arg(l-5:l) = '_debug' ) [
 IF( arg(l-5:l) = '_noopt' ) [
     arg(l-5:l) = ' '; l = l-5;
 ]
+"*******************************************************************************
+" #PARALLEL_EGS -   Added IF sentence when user code is compiled with MPI.
+"*******************************************************************************
+IF( arg(l-3:l) = '_mpi' ) [
+    arg(l-3:l) = ' '; l = l - 4;
+]
 l1 = len(ucode);
 IF( l > l1 ) [
     $egs_fatal(*,' user code name is too long (',l,' chars)');

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -59,6 +59,38 @@
 %C80        "Allow 80 columns of source/line (default is 72)
 %L          "Turn on listing
 
+"*******************************************************************************
+" #HYBRID_EGS - MACROS and definitions needed for MPI/OpenMP parallel 
+"            implementation.
+"*******************************************************************************
+
+" MACRO TO USE MPI CALLS. THE USER MUST DEFINE _MPI MACRO DURING COMPILATION"
+REPLACE {$MPI{#,#};} WITH{;
+$IFDEF({P1},_MPI);
+{P2};
+$ENDIF({P1});
+}
+;
+
+" MACROS TO ADD PREPROCESSOR CONDITIONAL DIRECTIVES"
+" mortran3 gets confused by the # char => we need to pass it as an "
+" argument to the macro. "
+REPLACE {$IFDEF(#,#);} WITH {{EMIT;{P1}ifdef {P2};};}
+;
+REPLACE {$IFNDEF(#,#);} WITH {{EMIT;{P1}ifndef {P2};};}
+;
+REPLACE {$ELSEIF(#,#);} WITH {{EMIT;{P1}elif {P2};};}
+;
+REPLACE {$ELSE(#);} WITH {{EMIT;{P1}else;};}
+;
+REPLACE {$IF(#,#);} WITH {{EMIT;{P1}if {P2};};}
+;
+REPLACE {$ENDIF(#);} WITH {{EMIT;{P1}endif;};}
+;
+
+"*******************************************************************************
+" #OMP_EGS - End of MACROS and definitions for MPI/OpenMP implementation.
+"*******************************************************************************
 
 "=================================================================="
 " Macros to implement implicit data types                          "

--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -60,8 +60,7 @@
 %L          "Turn on listing
 
 "*******************************************************************************
-" #HYBRID_EGS - MACROS and definitions needed for MPI/OpenMP parallel 
-"            implementation.
+" #PARALLEL_EGS - MACROS and definitions needed for MPI parallel implementation.
 "*******************************************************************************
 
 " MACRO TO USE MPI CALLS. THE USER MUST DEFINE _MPI MACRO DURING COMPILATION"
@@ -89,7 +88,7 @@ REPLACE {$ENDIF(#);} WITH {{EMIT;{P1}endif;};}
 ;
 
 "*******************************************************************************
-" #OMP_EGS - End of MACROS and definitions for MPI/OpenMP implementation.
+" #PARALLEL_EGS - End of MACROS and definitions for MPI implementation.
 "*******************************************************************************
 
 "=================================================================="

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -1249,6 +1249,21 @@ $LONG_INT nnphsp_max, nnphsp_min; } TO
 
 "  start of coding                 ""toc:
 
+"*******************************************************************************
+" #PARALLEL_EGS -   PROGRAM statement added to clearly define the start 
+"                   of the program.
+"*******************************************************************************
+PROGRAM dosxyznrc;
+
+"*******************************************************************************
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
+"                   is used only if the user specifies the _MPI macro during 
+"                   compilation.
+"*******************************************************************************
+$IFDEF(#,_MPI);
+  USE MPI;
+$ENDIF(#);
+
 $IMPLICIT-NONE;
 
 ;COMIN/ BOUNDS,BREMPR,ELECIN,GEOM,MEDIA,MISC,PHSPFILE,SCORE,SOURCE,
@@ -1371,6 +1386,13 @@ $DECLARE_TIMING_VARIABLES;
 "cput1 is cputime at start of simulations"
 "cput2 is cputime when asked for so elapsed cpu is cput2-cput0 or -cput1"
 
+"*******************************************************************************
+" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here 
+"                   in order to create one *.egslst file per MPI process.
+"*******************************************************************************
+$INTEGER ierr;  "error code returned by MPI subroutines"
+
+$MPI{#, call MPI_INIT(ierr)};
 
 call egs_init; "initialize EGSnrc system"
 
@@ -1963,7 +1985,6 @@ IF(i_phsp_out=1 | i_phsp_out=2) iausfl(6)=1;
 
 $INITIALIZE RNG USING IXXIN AND JXXIN;
 
-
 "=========================================================================="
 " Moved here by Ernesto Mainegra-Hing Dec 2011                             "
 " Opening same pegs4 file with two different units gives an error in gcc   "
@@ -2501,7 +2522,6 @@ OUTPUT61;(/ ' ***************************************************************');
 
 "Step 8   shower call                                   ""toc:
 "====================
-
 "open the .egsdat file if called for"
 IF(IDAT=0 | IDAT=2)[
   i_par_temp=i_parallel;
@@ -2542,8 +2562,35 @@ IF(isource = 20 | isource = 21)["reset more_in_cont and MU index for every"
 	   more_in_cont=0;
 	   frMU_indx=-1.0;
 ]
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and divide
+"                   particle histories evenly among MPI processes.
+"*******************************************************************************
 IF( n_parallel > 0 ) [  "Job is part of a parallel run "
+$IF(#,_MPI);
+    n_run = ncase/n_parallel;
+    jcase = n_run/$NBATCH;
+    IF( jcase < 1 ) [ jcase = 1; n_run = jcase*$NBATCH; ]
 
+    write(6,'(//a,i12,a//)') '****** Running ',n_run,' histories';
+
+    IF(isource=2|isource=8|isource=20)[
+        " Figure out where to start in the phase space file "
+        p_per_phsp_chunk=nshist/n_parallel;
+        nnphsp_min=(i_parallel-1)*p_per_phsp_chunk+1;
+        nnphsp_max=nnphsp_min+p_per_phsp_chunk-1;        
+        nnphsp=nnphsp_min;
+        IF(i_iaea_in=1)[
+           $IAEA_SET_PHSP_RECORD(i_unit_in,nnphsp);
+        ]
+        CYCLNUM=0; "reset NRCYCL counter"
+        write(6,'(/a/,a,i12,a,i12/,a//)')
+  '      This simulation uses a phase space source.',
+  '      This run will use from particle',nnphsp_min,' to particle ',
+         nnphsp_max,
+  '      in the source file.';
+    ]
+$ELSE(#);
     call egs_pjob_control(ncase,n_run,n_left,n_tot,part_dose,part2_dose,
                           current_result, current_uncertainty);
     IF( n_run = 0 ) [
@@ -2598,7 +2645,9 @@ IF( n_parallel > 0 ) [  "Job is part of a parallel run "
          nnphsp_max,
   '      in the source file.';
     ]
+$ENDIF(#);
 ]
+
 #endif;
 
 DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
@@ -2777,7 +2826,14 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
 
 #ifdef HAVE_C_COMPILER;
 ;
-IF( n_parallel > 0 ) [ goto :start_parallel_loop:; ]
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable original parallelization logic.
+"*******************************************************************************
+IF( n_parallel > 0 ) [ 
+$IFNDEF(#,_MPI);    
+    goto :start_parallel_loop:; 
+$ENDIF(#);    
+]
 
 #endif;
 
@@ -3381,7 +3437,29 @@ call egs_finish;     " Finish the simulation "
 
 #ifdef HAVE_C_COMPILER;
 ;
+"*******************************************************************************
+" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and combine
+"                   runs of MPI processes.
+"*******************************************************************************
 IF( n_parallel > 0 & ~is_finished ) [
+$IF(#,_MPI);
+    "Get sure that all MPI processes have reached this point "
+    $MPI{#, call MPI_BARRIER(MPI_COMM_WORLD, ierr)};
+    IF( i_parallel = 1 ) [
+        " Open again the list file. This is actually done in egs_pjob_finish() "
+        " subroutine. Reset i_parallel and open again list file. "
+        i_parallel = 0;
+        call egs_open_units(.false.);
+        
+        is_finished = .true.;
+        call egs_combine_runs(combine_results,'.pardose');
+        ainflu=temp2; "need to define this because it is used to normalize dose"
+        IF((isource = 0 | isource = 1 | isource = 3 | isource = 7) &
+           beamarea>0.) ainflu=ainflu/beamarea;
+        goto :ANALYZE-PARALLEL:;
+    ]
+
+$ELSE(#);
     call egs_pjob_finish(n_job);
     IF( n_job = 0 ) [
         is_finished = .true.;
@@ -3393,6 +3471,7 @@ IF( n_parallel > 0 & ~is_finished ) [
         call srcout;
         goto :ANALYZE-PARALLEL:;
     ]
+$ENDIF(#);
 ]
 #endif;
 
@@ -3400,6 +3479,11 @@ IF(isource=9 | isource=21 | (isource=20 &
 SHLflag=1 & MLCflag=0)) call finish_beamsource;
 
 IF((isource=20 | isource = 21) & MLCflag=1) [call finish_vcusource;]
+
+"*******************************************************************************
+" #PARALLEL_EGS - Terminate the MPI environment.
+"*******************************************************************************
+$MPI{#, call MPI_FINALIZE(ierr)};
 
 $CALL_EXIT(0);
 

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -1250,14 +1250,14 @@ $LONG_INT nnphsp_max, nnphsp_min; } TO
 "  start of coding                 ""toc:
 
 "*******************************************************************************
-" #PARALLEL_EGS -   PROGRAM statement added to clearly define the start 
+" #PARALLEL_EGS -   PROGRAM statement added to clearly define the start
 "                   of the program.
 "*******************************************************************************
 PROGRAM dosxyznrc;
 
 "*******************************************************************************
-" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It 
-"                   is used only if the user specifies the _MPI macro during 
+" #PARALLEL_EGS -   Include the MPI module to access MPI runtime subroutines. It
+"                   is used only if the user specifies the _MPI macro during
 "                   compilation.
 "*******************************************************************************
 $IFDEF(#,_MPI);
@@ -1387,7 +1387,7 @@ $DECLARE_TIMING_VARIABLES;
 "cput2 is cputime when asked for so elapsed cpu is cput2-cput0 or -cput1"
 
 "*******************************************************************************
-" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here 
+" #PARALLEL_EGS -   Establish the MPI environment. It must be initialized here
 "                   in order to create one *.egslst file per MPI process.
 "*******************************************************************************
 $INTEGER ierr;  "error code returned by MPI subroutines"
@@ -2563,7 +2563,7 @@ IF(isource = 20 | isource = 21)["reset more_in_cont and MU index for every"
 	   frMU_indx=-1.0;
 ]
 "*******************************************************************************
-" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and 
+" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and
 "                   divide particle histories evenly among processes.
 "*******************************************************************************
 IF( n_parallel > 0 ) [  "Job is part of a parallel run "
@@ -2578,7 +2578,7 @@ $IF(#,_NOPJOB);
         " Figure out where to start in the phase space file "
         p_per_phsp_chunk=nshist/n_parallel;
         nnphsp_min=(i_parallel-1)*p_per_phsp_chunk+1;
-        nnphsp_max=nnphsp_min+p_per_phsp_chunk-1;        
+        nnphsp_max=nnphsp_min+p_per_phsp_chunk-1;
         nnphsp=nnphsp_min;
         IF(i_iaea_in=1)[
            $IAEA_SET_PHSP_RECORD(i_unit_in,nnphsp);
@@ -2829,10 +2829,10 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
 "*******************************************************************************
 " #PARALLEL_EGS -   If PJOB is undefined disable original parallelization logic.
 "*******************************************************************************
-IF( n_parallel > 0 ) [ 
-$IFNDEF(#,_NOPJOB);    
-    goto :start_parallel_loop:; 
-$ENDIF(#);    
+IF( n_parallel > 0 ) [
+$IFNDEF(#,_NOPJOB);
+    goto :start_parallel_loop:;
+$ENDIF(#);
 ]
 
 #endif;
@@ -3438,7 +3438,7 @@ call egs_finish;     " Finish the simulation "
 #ifdef HAVE_C_COMPILER;
 ;
 "*******************************************************************************
-" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and 
+" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and
 "                   combine runs of MPI processes.
 "*******************************************************************************
 IF( n_parallel > 0 & ~is_finished ) [
@@ -3450,7 +3450,7 @@ $IF(#,_NOPJOB);
         " subroutine. Reset i_parallel and open again list file. "
         i_parallel = 0;
         call egs_open_units(.false.);
-        
+
         is_finished = .true.;
         call egs_combine_runs(combine_results,'.pardose');
         ainflu=temp2; "need to define this because it is used to normalize dose"

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -2563,11 +2563,11 @@ IF(isource = 20 | isource = 21)["reset more_in_cont and MU index for every"
 	   frMU_indx=-1.0;
 ]
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and divide
-"                   particle histories evenly among MPI processes.
+" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and 
+"                   divide particle histories evenly among processes.
 "*******************************************************************************
 IF( n_parallel > 0 ) [  "Job is part of a parallel run "
-$IF(#,_MPI);
+$IF(#,_NOPJOB);
     n_run = ncase/n_parallel;
     jcase = n_run/$NBATCH;
     IF( jcase < 1 ) [ jcase = 1; n_run = jcase*$NBATCH; ]
@@ -2827,10 +2827,10 @@ DO ibatch = 1,$NBATCH["Break into $NBATCH batches"
 #ifdef HAVE_C_COMPILER;
 ;
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable original parallelization logic.
+" #PARALLEL_EGS -   If PJOB is undefined disable original parallelization logic.
 "*******************************************************************************
 IF( n_parallel > 0 ) [ 
-$IFNDEF(#,_MPI);    
+$IFNDEF(#,_NOPJOB);    
     goto :start_parallel_loop:; 
 $ENDIF(#);    
 ]
@@ -3438,11 +3438,11 @@ call egs_finish;     " Finish the simulation "
 #ifdef HAVE_C_COMPILER;
 ;
 "*******************************************************************************
-" #PARALLEL_EGS -   If MPI is enabled disable job control file logic and combine
-"                   runs of MPI processes.
+" #PARALLEL_EGS -   If PJOB is undefined disable job control file logic and 
+"                   combine runs of MPI processes.
 "*******************************************************************************
 IF( n_parallel > 0 & ~is_finished ) [
-$IF(#,_MPI);
+$IF(#,_NOPJOB);
     "Get sure that all MPI processes have reached this point "
     $MPI{#, call MPI_BARRIER(MPI_COMM_WORLD, ierr)};
     IF( i_parallel = 1 ) [

--- a/README_MPI.txt
+++ b/README_MPI.txt
@@ -1,0 +1,132 @@
+## An MPI parallel implementation for EGSnrc
+
+The purpose of this contribution is to present a parallel solution for the 
+EGSnrc Monte Carlo code system using the MPI programming model as an alternative 
+to the provided implementation, based on the use of a batch-queueing system.
+
+Currently, the BEAMnrc and DOSXYZnrc user codes support this parallel solution 
+based on MPI. In the case of DOSXYZnrc, both the use of a phase space file 
+and BEAM shared library as sources has been tested. Both codes can be used 
+as models to introduce MPI features to other EGSnrc user codes.
+
+## Authors
+
+Edgardo Doerner (edoerner at fis.puc.cl)
+Paola Caprile
+
+Institute of Physics
+Pontificia Universidad Catolica de Chile
+
+## Method
+
+This work incorporates MPI features to distribute the simulation between the 
+available compute units. These features are introduced through properly defined 
+macros, which are enabled depending on the compilation flags given by the user.
+The workload balance is controlled by default via a 'job control file' as the 
+original implementation.
+
+In order to ease the integration of MPI in EGSnrc, the compilation flags 
+needed to enable the MPI parallelization are added through the 'mpi' target, 
+defined in both the EGSnrc standard makefile (standard_makefile) and BEAMnrc 
+makefile (beam_makefile) inside $HEN_HOUSE/makefiles folder. 
+
+The result is a dedicated executable with MPI support that can be called by the 
+user. The advantage is that there is no need to modify or add the needed 
+compilation flags to the *.conf file during the installation process.
+
+By default, it is expected that OpenMPI is installed in the system. If another 
+MPI implementation is desired, change the F77 macro inside the 'mpi' target to 
+the desired MPI compiler in the following Makefiles:
+
+$HEN_HOUSE/makefiles/standard_makefile (line 169)
+$HEN_HOUSE/makefiles/beam_makefile (line 165)
+
+by default F77=mpif90 in both files.
+
+## Usage
+
+In order to compile an user code $(user_code) with MPI support go to 
+the $EGS_HOME/$(user_code) folder and type:
+
+make mpi
+
+This will enable the MPI features in the user code and will create an executable 
+called $(user_code)_mpi (i.e. the normal user code executable name with the 
+'_mpi' suffix attached to it). Then, use mpirun or similar to execute it with 
+MPI support:
+
+mpirun -np #NUM_PROCS $(user_code)_mpi -i input_file -p pegs_file
+
+## Issues
+
+Two small issues remains in the following contribution:
+
+1. When the DOSXYZnrc user code is used with a BEAM shared library as a source, 
+an error appears regarding the inability of locking the *.lock file used 
+to distribute the workload in the parallel simulation. This is triggered by the 
+shared library, not the dosxyznrc jobs or MPI processes involved. 
+
+This issue is inherited from the develop branch on EGSnrc, and causes all the 
+MPI processes to halt. As a temporal solution, the use of the file locking 
+mechanism is disabled in the BEAM shared library at compile time through a 
+proper compilation flag.
+
+2. When the BEAMnrc user code is compiled with MPI support or DOSXYZnrc is 
+used with a BEAM shared library as a source, a console message 
+appears at the end of the simulation:
+
+ls: ~/$EGS_HOME/BEAM_myaccel/myaccel_w*.egsdat: No such file or directory
+
+Of course, it is expected to not have egsdat files if data arrays are not 
+stored during simulation. The presence of such files is tested in the 
+egs_combine_runs subroutine at the end of the simulation. When MPI support is 
+enabled, and in contrast with the standard compilation, the result of the 
+system command is echoed to the terminal. This does not affect the results 
+and it means only a minor annoyance during execution.
+
+## Disabling Parallel Jobs functionality
+
+Some systems (such as the National Laboratory of High Performance Computing 
+(NLHPC) in Chile) does not allow the use of a lock-file mechanism needed by the 
+EGSnrc parallel implementation and this MPI contribution to control access to
+the job control file. 
+
+In such a case, the user can define the _NOPJOB macro during compilation to 
+disable the use of the control file. For example, in the following Makefiles add 
+the _NOPJOB macro definition as:
+
+standard_makefile (line 169): FCFLAGS="$(FCFLAGS) -D_MPI -D_NOPJOB"
+beam_makefile (line 165): FCFLAGS="$(FCFLAGS) -D_MPI -D_NOPJOB"
+
+The result is that the simulation workload is now evenly distributed among 
+computing units, and therefore no job control file is needed.
+
+## OpenMP features
+
+The introduction of OpenMP features has been tested in the DOSXYZnrc user 
+code, with interesting results (see references below). However, some important 
+issues remains unsolved and definitely will need a more extended modification 
+of the user codes, namely:
+
+1. The support of shared library sources in DOSXYZnrc when OpenMP is enabled.
+2. The OpenMP implementation in BEAMnrc, considering the output to phase space 
+files.
+
+An hybrid implementation, combining MPI and OpenMP features can be seen in the 
+pull request #341 (https://github.com/nrc-cnrc/EGSnrc/pull/341). For this 
+reason, it was decided to offer first a polished MPI implementation to the 
+EGSnrc community.
+
+## References
+
+This MPI implementation is contained in the following work:
+
+Doerner E, Caprile P. An hybrid parallel implementation for EGSnrc Monte Carlo 
+user codes. Med. Phys. 45 (8), August 2018.
+
+The aforementioned publication was based on an OpenMP-only solution which can be 
+reviewed in:
+
+Doerner E, Caprile P. Parallel implementation of the EGSnrc Monte Carlo 
+simulation of ionizing radiation transport using OpenMP. Med. Phys. 44 (12), 
+December 2017

--- a/README_MPI.txt
+++ b/README_MPI.txt
@@ -1,12 +1,12 @@
 ## An MPI parallel implementation for EGSnrc
 
-The purpose of this contribution is to present a parallel solution for the 
-EGSnrc Monte Carlo code system using the MPI programming model as an alternative 
+The purpose of this contribution is to present a parallel solution for the
+EGSnrc Monte Carlo code system using the MPI programming model as an alternative
 to the provided implementation, based on the use of a batch-queueing system.
 
-Currently, the BEAMnrc and DOSXYZnrc user codes support this parallel solution 
-based on MPI. In the case of DOSXYZnrc, both the use of a phase space file 
-and BEAM shared library as sources has been tested. Both codes can be used 
+Currently, the BEAMnrc and DOSXYZnrc user codes support this parallel solution
+based on MPI. In the case of DOSXYZnrc, both the use of a phase space file
+and BEAM shared library as sources has been tested. Both codes can be used
 as models to introduce MPI features to other EGSnrc user codes.
 
 ## Authors
@@ -19,23 +19,23 @@ Pontificia Universidad Catolica de Chile
 
 ## Method
 
-This work incorporates MPI features to distribute the simulation between the 
-available compute units. These features are introduced through properly defined 
+This work incorporates MPI features to distribute the simulation between the
+available compute units. These features are introduced through properly defined
 macros, which are enabled depending on the compilation flags given by the user.
-The workload balance is controlled by default via a 'job control file' as the 
+The workload balance is controlled by default via a 'job control file' as the
 original implementation.
 
-In order to ease the integration of MPI in EGSnrc, the compilation flags 
-needed to enable the MPI parallelization are added through the 'mpi' target, 
-defined in both the EGSnrc standard makefile (standard_makefile) and BEAMnrc 
-makefile (beam_makefile) inside $HEN_HOUSE/makefiles folder. 
+In order to ease the integration of MPI in EGSnrc, the compilation flags
+needed to enable the MPI parallelization are added through the 'mpi' target,
+defined in both the EGSnrc standard makefile (standard_makefile) and BEAMnrc
+makefile (beam_makefile) inside $HEN_HOUSE/makefiles folder.
 
-The result is a dedicated executable with MPI support that can be called by the 
-user. The advantage is that there is no need to modify or add the needed 
+The result is a dedicated executable with MPI support that can be called by the
+user. The advantage is that there is no need to modify or add the needed
 compilation flags to the *.conf file during the installation process.
 
-By default, it is expected that OpenMPI is installed in the system. If another 
-MPI implementation is desired, change the F77 macro inside the 'mpi' target to 
+By default, it is expected that OpenMPI is installed in the system. If another
+MPI implementation is desired, change the F77 macro inside the 'mpi' target to
 the desired MPI compiler in the following Makefiles:
 
 $HEN_HOUSE/makefiles/standard_makefile (line 169)
@@ -45,14 +45,14 @@ by default F77=mpif90 in both files.
 
 ## Usage
 
-In order to compile an user code $(user_code) with MPI support go to 
+In order to compile an user code $(user_code) with MPI support go to
 the $EGS_HOME/$(user_code) folder and type:
 
 make mpi
 
-This will enable the MPI features in the user code and will create an executable 
-called $(user_code)_mpi (i.e. the normal user code executable name with the 
-'_mpi' suffix attached to it). Then, use mpirun or similar to execute it with 
+This will enable the MPI features in the user code and will create an executable
+called $(user_code)_mpi (i.e. the normal user code executable name with the
+'_mpi' suffix attached to it). Then, use mpirun or similar to execute it with
 MPI support:
 
 mpirun -np #NUM_PROCS $(user_code)_mpi -i input_file -p pegs_file
@@ -61,72 +61,72 @@ mpirun -np #NUM_PROCS $(user_code)_mpi -i input_file -p pegs_file
 
 Two small issues remains in the following contribution:
 
-1. When the DOSXYZnrc user code is used with a BEAM shared library as a source, 
-an error appears regarding the inability of locking the *.lock file used 
-to distribute the workload in the parallel simulation. This is triggered by the 
-shared library, not the dosxyznrc jobs or MPI processes involved. 
+1. When the DOSXYZnrc user code is used with a BEAM shared library as a source,
+an error appears regarding the inability of locking the *.lock file used
+to distribute the workload in the parallel simulation. This is triggered by the
+shared library, not the dosxyznrc jobs or MPI processes involved.
 
-This issue is inherited from the develop branch on EGSnrc, and causes all the 
-MPI processes to halt. As a temporal solution, the use of the file locking 
-mechanism is disabled in the BEAM shared library at compile time through a 
+This issue is inherited from the develop branch on EGSnrc, and causes all the
+MPI processes to halt. As a temporal solution, the use of the file locking
+mechanism is disabled in the BEAM shared library at compile time through a
 proper compilation flag.
 
-2. When the BEAMnrc user code is compiled with MPI support or DOSXYZnrc is 
-used with a BEAM shared library as a source, a console message 
+2. When the BEAMnrc user code is compiled with MPI support or DOSXYZnrc is
+used with a BEAM shared library as a source, a console message
 appears at the end of the simulation:
 
 ls: ~/$EGS_HOME/BEAM_myaccel/myaccel_w*.egsdat: No such file or directory
 
-Of course, it is expected to not have egsdat files if data arrays are not 
-stored during simulation. The presence of such files is tested in the 
-egs_combine_runs subroutine at the end of the simulation. When MPI support is 
-enabled, and in contrast with the standard compilation, the result of the 
-system command is echoed to the terminal. This does not affect the results 
+Of course, it is expected to not have egsdat files if data arrays are not
+stored during simulation. The presence of such files is tested in the
+egs_combine_runs subroutine at the end of the simulation. When MPI support is
+enabled, and in contrast with the standard compilation, the result of the
+system command is echoed to the terminal. This does not affect the results
 and it means only a minor annoyance during execution.
 
 ## Disabling Parallel Jobs functionality
 
-Some systems (such as the National Laboratory of High Performance Computing 
-(NLHPC) in Chile) does not allow the use of a lock-file mechanism needed by the 
+Some systems (such as the National Laboratory of High Performance Computing
+(NLHPC) in Chile) does not allow the use of a lock-file mechanism needed by the
 EGSnrc parallel implementation and this MPI contribution to control access to
-the job control file. 
+the job control file.
 
-In such a case, the user can define the _NOPJOB macro during compilation to 
-disable the use of the control file. For example, in the following Makefiles add 
+In such a case, the user can define the _NOPJOB macro during compilation to
+disable the use of the control file. For example, in the following Makefiles add
 the _NOPJOB macro definition as:
 
 standard_makefile (line 169): FCFLAGS="$(FCFLAGS) -D_MPI -D_NOPJOB"
 beam_makefile (line 165): FCFLAGS="$(FCFLAGS) -D_MPI -D_NOPJOB"
 
-The result is that the simulation workload is now evenly distributed among 
+The result is that the simulation workload is now evenly distributed among
 computing units, and therefore no job control file is needed.
 
 ## OpenMP features
 
-The introduction of OpenMP features has been tested in the DOSXYZnrc user 
-code, with interesting results (see references below). However, some important 
-issues remains unsolved and definitely will need a more extended modification 
+The introduction of OpenMP features has been tested in the DOSXYZnrc user
+code, with interesting results (see references below). However, some important
+issues remains unsolved and definitely will need a more extended modification
 of the user codes, namely:
 
 1. The support of shared library sources in DOSXYZnrc when OpenMP is enabled.
-2. The OpenMP implementation in BEAMnrc, considering the output to phase space 
+2. The OpenMP implementation in BEAMnrc, considering the output to phase space
 files.
 
-An hybrid implementation, combining MPI and OpenMP features can be seen in the 
-pull request #341 (https://github.com/nrc-cnrc/EGSnrc/pull/341). For this 
-reason, it was decided to offer first a polished MPI implementation to the 
+An hybrid implementation, combining MPI and OpenMP features can be seen in the
+pull request #341 (https://github.com/nrc-cnrc/EGSnrc/pull/341). For this
+reason, it was decided to offer first a polished MPI implementation to the
 EGSnrc community.
 
 ## References
 
 This MPI implementation is contained in the following work:
 
-Doerner E, Caprile P. An hybrid parallel implementation for EGSnrc Monte Carlo 
+Doerner E, Caprile P. An hybrid parallel implementation for EGSnrc Monte Carlo
 user codes. Med. Phys. 45 (8), August 2018.
 
-The aforementioned publication was based on an OpenMP-only solution which can be 
+The aforementioned publication was based on an OpenMP-only solution which can be
 reviewed in:
 
-Doerner E, Caprile P. Parallel implementation of the EGSnrc Monte Carlo 
-simulation of ionizing radiation transport using OpenMP. Med. Phys. 44 (12), 
+Doerner E, Caprile P. Parallel implementation of the EGSnrc Monte Carlo
+simulation of ionizing radiation transport using OpenMP. Med. Phys. 44 (12),
 December 2017


### PR DESCRIPTION
The purpose of this contribution is to present a parallel solution for the EGSnrc Monte Carlo code system using the MPI programming model as an alternative to the provided implementation, based on the use of a batch-queueing system.

For details of this implementation please check the README_MPI.md file available in the EGSnrc main folder.

Currently, the BEAMnrc and DOSXYZnrc user codes support this parallel solution based on MPI. In the case of DOSXYZnrc, both the use of a phase space file and BEAM shared library as sources has been tested. Both codes can be used as models to introduce MPI features to other EGSnrc user codes.

By default, it is expected that OpenMPI is installed in the system. If another MPI implementation is desired, change the F77 macro inside the 'mpi' target to the desired MPI compiler in the following Makefiles:

$HEN_HOUSE/makefiles/standard_makefile (line 169)
$HEN_HOUSE/makefiles/beam_makefile (line 165)

by default F77=mpif90 in both files.

In order to compile an user code $(user_code) with MPI support go to the $EGS_HOME/$(user_code) folder and type:

make mpi

This will enable the MPI features in the user code and will create an executable called $(user_code)_mpi (i.e. the normal user code executable name with the '_mpi' suffix attached to it). Then, use mpirun or similar to execute it with MPI support:

mpirun -np #NUM_PROCS $(user_code)_mpi -i input_file -p pegs_file