### PR TITLE
Fix #489: Allow odd no. of TARGET/ISOCENTER leaves in SYNCHDMLC

### DIFF
--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCHDMLC.inp
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/inputformats/SYNCHDMLC.inp
@@ -14,9 +14,8 @@
              NGROUP_$SYNCHDMLC = number of groups of adjacent leaves where
                                all leaves in a group are:
                                1. FULL leaves
-                               2. HALF TARGET/ISOCENTER pairs with TARGET leaf
-                                  on the -X (ORIENT=0) or -Y (ORIENT=1) side
-                               3. QUARTER TARGET/ISOCENTER pairs
+                               2. HALF TARGET/ISOCENTER leaves
+                               3. QUARTER TARGET/ISOCENTER leaves
                                NGROUP_$SYNCHDMLC defaults to 3 if set <=0
              MODE_$SYNCHCMLC = 0 for single setting of leaf openings (static
                              field)
@@ -135,7 +134,7 @@
                   leaf on +X [ORIENT=0] or +Y [ORIENT=1] side of ISOCENTER
                   leaf only) ZTONGUE_$SYNCHDMLC(1)<=ZGROOVE_$SYNCHDMLC(3)
 
-        Note: If there are no HALF leaf pairs in your model, you can input
+        Note: If there are no HALF leaves in your model, you can input
               blanks, zeroes, or arbitrary floating-point numbers for these
               cross section dimensions.
 
@@ -206,15 +205,22 @@
          NUM_LEAF_$SYNCHDMLC(I): Number of adjacent leaves in group I
               LEAFTYPE: Type of leaf in group I.
                         Set to: 1 for FULL leaves
-                                2 for HALF TARGET/ISOCENTER pair with
-                                  TARGET leaf on the -X (ORIENT=0)
-                                  or -Y (ORIENT=1) side
-                                3 for QUARTER TARGET/ISOCENTER pair with
-                                  TARGET leaf on the -X (ORIENT=0)
-                                  or -Y (ORIENT=1) side
+                                2 for HALF TARGET/ISOCENTER leaves.
+                                  Starting leaf on -X (ORIENT=0) or -Y
+                                  (ORIENT=1) side depends on adjacent leaf:
+                                  If adjacecent leaf is a HALF or QUARTER
+                                  TARGET, then it will be HALF ISOCENTER.
+                                  Otherwise, it will be HALF TARGET.
+                                3 for QUARTER TARGET/ISOCENTER leaves.
+                                  Starting leaf on -X (ORIENT=0) or -Y
+                                  (ORIENT=1) side will depend on the
+                                  adjacent leaf: If it is a HALF or
+                                  QUARTER TARGET leaf, then the starting
+                                  leaf will be QUARTER ISOCENTER.
+                                  Otherwise, it will be QUARTER TARGET.
 
-          Note: If LEAFTYPE is 2 or 3, then you must have an even number
-                of leaves in the group.
+    Restrictions: 1. Cannot have a HALF or QUARTER TARGET leaf on the -ve
+                     side of a FULL leaf.
 
     9  START_$SYNCHDMLC (F15.0) : the start position (cm) wrt the CAX of
                         leaf 1 as projected to ZMIN_$SYNCHDMLC.
@@ -379,7 +385,7 @@
     The collimator starts at Z=47.0 cm, is 7 cm thick and has 80 tungsten
     leaves opening in the X direction. Leaves 1-10 and 71-80 are FULL
     (type 1), leaves 11-24 and 57-70 are HALF TARGET/HALF ISOCENTER
-    pairs, and leaves 25-56 are QUARTER TARGET/QUARTER ISOCENTER pairs.
+    leaves, and leaves 25-56 are QUARTER TARGET/QUARTER ISOCENTER leaves.
     The Z focus of the leaf sides is at Z=0 cm which is the position of the
     source. The leaf ends are straight and also focused at Z=0 cm.
     In this example, the mlc is being run in step-and-shoot mode
@@ -402,9 +408,9 @@
   0.11, 0.04, 0.04, 0.035, 0.08, 0.065, 47.2, 47.3, 50.53, 50.52, 52.9, 53.1,
     1.7, 53.6, 53.9,  QUARTER ISOCENTER cross-section
   10, 1, FULL leaves
-  14, 2, HALF TARGET/ISOCENTER pairs
-  32, 3, QUARTER TARGET/ISOCENTER pairs
-  14, 2, HALF TARGET/ISOCENTER pairs
+  14, 2, HALF TARGET/ISOCENTER leaves
+  32, 3, QUARTER TARGET/ISOCENTER leaves
+  14, 2, HALF TARGET/ISOCENTER leaves
   10, 1, FULL leaves
   -10.5, START
   0.005, LEAFGAP

--- a/HEN_HOUSE/doc/src/pirs509a-beamnrc/pirs509a-beamnrc.tex
+++ b/HEN_HOUSE/doc/src/pirs509a-beamnrc/pirs509a-beamnrc.tex
@@ -6842,8 +6842,8 @@ DOSXYZnrc\cite{Wa05}.
 \subsubsubsection{SYNCHDMLC}
 SYNCHDMLC is a version of SYNCVMLC optimized for modeling the High-definition Multileaf
 Collimator (HDMLC 120) available on TrueBeam and Novalis linacs.  SYNCHDMLC features five
-possible leaf cross sections: FULL, HALF TARGET/HALF ISOCENTER pairs, and QUARTER TARGET/QUARTER ISOCENTER
-pairs.  FULL leaves are similar to FULL leaves in DYNVMLC/SYNCVMLC.  HALF TARGET/HALF ISOCENTER leaves are
+possible leaf cross sections: FULL, HALF TARGET/HALF ISOCENTER leaves, and QUARTER TARGET/QUARTER ISOCENTER
+leaves.  FULL leaves are similar to FULL leaves in DYNVMLC/SYNCVMLC.  HALF TARGET/HALF ISOCENTER leaves are
 equivalent to the TARGET/ISOCENTER leaves in DYNVMLC/SYNCVMLC. QUARTER TARGET/QUARTER ISOCENTER have the
 same shaped cross sections as the HALF TARGET/HALF ISOCENTER leaves, but the cross section perpendicular to
 the opening direction is generally thinner.  Similar to other synchronized CMs, leaf opening
@@ -8463,8 +8463,9 @@ is included with the distribution.  This file is {\tt \$OMEGA\_HOME/beamnrc/CMs/
 
 SYNCHDMLC is a CM coded by Lobo \& Popescu and based on an earlier code by Borges et al\cite{Bo12} for
 modeling the high-definition micro mlc (HD120) available on TrueBeam and Novalis linacs.  In overall
-design it is similar to DYNVMLC/SYNCVMLC but features two different types of TARGET/ISOCENTER leaf pairs:
-HALF TARGET/HALF ISOCENTER and QUARTER TARGET/QUARTER ISOCENTER.  In terms of leaf cross-section
+design it is similar to DYNVMLC/SYNCVMLC but features two different types of TARGET/ISOCENTER leaves:
+HALF TARGET/HALF ISOCENTER and QUARTER TARGET/QUARTER ISOCENTER.  In addition, the last TARGET or ISOCENTER
+leaf in a group need not have a matching ISOCENTER or TARGET counterpart.  In terms of leaf cross-section
 (perpendicular to the opening direction), these are
 similar to the TARGET/ISOCENTER leaves in DYNVMLC, with HALF TARGET/HALF ISOCENTER leaves being
 wider than the QUARTER TARGET/QUARTER ISOCENTER leaves.
@@ -8490,10 +8491,9 @@ leaf types show the dimensions that the
 user must input (see Table~\ref{dynvmlc_tab} for label key).
 QUARTER leaf cross-sections have similar Z-dimensions
 to HALF leaf cross-sections but are thinner in X.
-TARGET/ISOCENTER leaves must always occur in pairs.
 In this illustration leaves 1, 2, 11, 12 are FULL; leaves 3, 4, 9, 10
-are HALF TARGET/HALF ISOCENTER pairs; leaves 5--8 are QUARTER TARGET/QUARTER ISOCENTER
-pairs.}
+are HALF TARGET/HALF ISOCENTER leaves; leaves 5--8 are QUARTER TARGET/QUARTER ISOCENTER
+leaves.  Unlike DYNVMLC and SYNCVMLC, an odd number of TARGET/ISOCENTER leaves may be specified in a group.}
 \label{synchdmlc_fig}
 \end{figure}
 
@@ -8505,7 +8505,7 @@ have the same meanings as those used for DYNVMLC (See Section~\ref{dynvmlcsect} 
 Table~\ref{dynvmlc_tab}).  In general, QUARTER leaves
 are used closer to middle of the mlc, and, while their Z-dimensions are similar to those for their HALF counterparts, they
 are significantly thinner in the X- ({\tt ORIENT}=0) or Y- ({\tt ORIENT}=1)
-dimension.  HALF TARGET/HALF ISOCENTER leaves must occur in pairs, as must QUARTER TARGET/QUARTER ISOCENTER leaves.
+dimension.
 
 \index{SYNCHDMLC!restrictions on leaf dimensions}
 Similar to DYNVMLC, leaf cross-section dimensions must be defined so that the Z and X ({\tt ORIENT}=0) or Y ({\tt ORIENT}=1) grid lines
@@ -8523,14 +8523,20 @@ QUARTER ISOCENTER/QUARTER TARGET ({\tt zg}$_{QUARTER~ISOCENTER}$ $\geq$ {\tt zt}
 QUARTER ISOCENTER/HALF TARGET ({\tt zg}$_{QUARTER~ISOCENTER}$ $\geq$ {\tt zt}$_{HALF~TARGET}$)\\
 and HALF ISOCENTER/FULL (ie {\tt zg}$_{HALF~ISOCENTER}$ $\geq$ {\tt zt}$_{FULL}$).
 
-As in DYNVMLC, rather than specifying the type of each leaf, the user is able to specify groups
-of adjacent leaves all having the same type.  Since HALF TARGET/HALF ISOCENTER leaves and
-QUARTER TARGET/QUARTER ISOCENTER leaves must always occur in pairs, there are really
-only three types to choose from.  This also means there must be an even number of
-HALF or QUARTER TARGET/ISOCENTER leaves.  Also note that, even though the user
-must specify cross-sections for all leaf types, they need not use all types in a
-given MLC simulation.  Thus, there may be no FULL leaves, HALF TARGET/ISOCENTER
-pairs, or QUARTER TARGET/ISOCENTER pairs in the simulation.
+As in DYNVMLC and SYNCVMLC, rather than specifying the type of each leaf in the MLC, the user is able to specify groups
+of adjacent leaves of the same type.  Since TARGET leaves always alternate with ISOCENTER leaves within a group,
+for the purpose of defining a leaf group, HALF or QUARTER TARGET/ISOCENTER leaves are considered one type.
+Unlike DYNVMLC and SYNCVMLC, however, the number of TARGET/ISOCENTER leaves in a group does not have to be even.  Thus,
+the final TARGET or ISOCENTER leaf in a group need not be matched by its ISOCENTER or TARGET (respectively)
+counterpart.  If a group of TARGET/ISOCENTER is defined adjacent to another group of TARGET/ISOCENTER leaves, the
+first leaf in the group will automatically be chosen to match the last leaf of the previous group.  Thus, if
+the last leaf of the previous group was a QUARTER or HALF TARGET leaf, then the first leaf of the current
+group will be a QUARTER or HALF ISOCENTER leaf, and vice versa.  In terms of leaf groups, the only restriction
+is that the numbers and types of leaves cannot be specified so that a QUARTER or HALF TARGET leaf ends up
+immediately adjacent to a FULL leaf on the -X (ORIENT=0) or -Y (ORIENT=1) side.
+Finally, note that the user need not use all leaf types in a simulated MLC.  Thus, there may be no FULL leaves, HALF TARGET/ISOCENTER
+leaves, or QUARTER TARGET/ISOCENTER leaves in the simulation.  In this case, inputs for the
+cross-section parameters of the unused leaves can be left as blanks or zeros.
 
 Similar to DYNVMLC and SYNCVMLC, leaf ends can be straight, focused ({\tt ENDTYPE}=1) or cylindrical
 ({\tt ENDTYPE}=0).  For straight, focused ends, the user must specify the Z-position of the

--- a/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_cm.mortran
+++ b/HEN_HOUSE/omega/beamnrc/CMs/SYNCHDMLC_cm.mortran
@@ -241,9 +241,8 @@
 "I>            NGROUP_$SYNCHDMLC = number of groups of adjacent leaves where
 "I>                              all leaves in a group are:
 "I>                              1. FULL leaves
-"I>                              2. HALF TARGET/ISOCENTER pairs with TARGET leaf
-"I>                                 on the -X (ORIENT=0) or -Y (ORIENT=1) side
-"I>                              3. QUARTER TARGET/ISOCENTER pairs
+"I>                              2. HALF TARGET/ISOCENTER leaves
+"I>                              3. QUARTER TARGET/ISOCENTER leaves
 "I>                              NGROUP_$SYNCHDMLC defaults to 3 if set <=0
 "I>            MODE_$SYNCHCMLC = 0 for single setting of leaf openings (static
 "I>                            field)
@@ -362,7 +361,7 @@
 "I>                 leaf on +X [ORIENT=0] or +Y [ORIENT=1] side of ISOCENTER
 "I>                 leaf only) ZTONGUE_$SYNCHDMLC(1)<=ZGROOVE_$SYNCHDMLC(3)
 "I>
-"I>       Note: If there are no HALF leaf pairs in your model, you can input
+"I>       Note: If there are no HALF leaves in your model, you can input
 "I>             blanks, zeroes, or arbitrary floating-point numbers for these
 "I>             cross section dimensions.
 "I>
@@ -434,15 +433,22 @@
 "I>        NUM_LEAF_$SYNCHDMLC(I): Number of adjacent leaves in group I
 "I>             LEAFTYPE: Type of leaf in group I.
 "I>                       Set to: 1 for FULL leaves
-"I>                               2 for HALF TARGET/ISOCENTER pair with
-"I>                                 TARGET leaf on the -X (ORIENT=0)
-"I>                                 or -Y (ORIENT=1) side
-"I>                               3 for QUARTER TARGET/ISOCENTER pair with
-"I>                                 TARGET leaf on the -X (ORIENT=0)
-"I>                                 or -Y (ORIENT=1) side
+"I>                               2 for HALF TARGET/ISOCENTER leaves.
+"I>                                 Starting leaf on -X (ORIENT=0) or -Y
+"I>                                 (ORIENT=1) side depends on adjacent leaf:
+"I>                                 If adjacecent leaf is a HALF or QUARTER
+"I>                                 TARGET, then it will be HALF ISOCENTER.
+"I>                                 Otherwise, it will be HALF TARGET.
+"I>                               3 for QUARTER TARGET/ISOCENTER leaves.
+"I>                                 Starting leaf on -X (ORIENT=0) or -Y
+"I>                                 (ORIENT=1) side will depend on the
+"I>                                 adjacent leaf: If it is a HALF or
+"I>                                 QUARTER TARGET leaf, then the starting
+"I>                                 leaf will be QUARTER ISOCENTER.
+"I>                                 Otherwise, it will be QUARTER TARGET.
 "I>
-"I>         Note: If LEAFTYPE is 2 or 3, then you must have an even number
-"I>               of leaves in the group.
+"I>   Restrictions: 1. Cannot have a HALF or QUARTER TARGET leaf on the -ve
+"I>                    side of a FULL leaf.
 "I>
 "I>   9  START_$SYNCHDMLC (F15.0) : the start position (cm) wrt the CAX of
 "I>                       leaf 1 as projected to ZMIN_$SYNCHDMLC.
@@ -607,7 +613,7 @@
 "I>   The collimator starts at Z=47.0 cm, is 7 cm thick and has 80 tungsten
 "I>   leaves opening in the X direction. Leaves 1-10 and 71-80 are FULL
 "I>   (type 1), leaves 11-24 and 57-70 are HALF TARGET/HALF ISOCENTER
-"I>   pairs, and leaves 25-56 are QUARTER TARGET/QUARTER ISOCENTER pairs.
+"I>   leaves, and leaves 25-56 are QUARTER TARGET/QUARTER ISOCENTER leaves.
 "I>   The Z focus of the leaf sides is at Z=0 cm which is the position of the
 "I>   source. The leaf ends are straight and also focused at Z=0 cm.
 "I>   In this example, the mlc is being run in step-and-shoot mode
@@ -630,9 +636,9 @@
 "I> 0.11, 0.04, 0.04, 0.035, 0.08, 0.065, 47.2, 47.3, 50.53, 50.52, 52.9, 53.1,
 "I>   1.7, 53.6, 53.9,  QUARTER ISOCENTER cross-section
 "I> 10, 1, FULL leaves
-"I> 14, 2, HALF TARGET/ISOCENTER pairs
-"I> 32, 3, QUARTER TARGET/ISOCENTER pairs
-"I> 14, 2, HALF TARGET/ISOCENTER pairs
+"I> 14, 2, HALF TARGET/ISOCENTER leaves
+"I> 32, 3, QUARTER TARGET/ISOCENTER leaves
+"I> 14, 2, HALF TARGET/ISOCENTER leaves
 "I> 10, 1, FULL leaves
 "I> -10.5, START
 "I> 0.005, LEAFGAP
@@ -1136,6 +1142,7 @@ character*256 mlc_file;
 CHARACTER*80 MLC_TITLE; "T> title line in mlc_file
 $REAL INDEXTMP; "T>temporary input variable for field indices in dynamic and
                 "  step-and-shoot simulations
+$LOGICAL check_full_qtr;
 " **************************************************************** "
 
 "                 STEP I : INITIALIZE PARAMETERS
@@ -1147,7 +1154,7 @@ $REAL INDEXTMP; "T>temporary input variable for field indices in dynamic and
 "I. GET THE TITLE "
 "================ "
 ;
-OUTPUT;(/' Next component is a VARIAN type MLC'/' Title: ',$);
+OUTPUT;(/' Next component is a VARIAN HD 120 MLC'/' Title: ',$);
 MINPUT ($SYNCHDMLC) TITLE_$SYNCHDMLC;(60A1);
           "MINPUT is a replacement macro with EOF and
           "ERR branching to :EOF_{P1}: and :ERR_{P1}:
@@ -1360,12 +1367,15 @@ OUTPUT;(' ');
 NUM_FULL=0;
 NUM_HLF=0;
 NUM_QTR=0;
+check_full_qtr = .FALSE.;
 DO I=1,NGROUP_$SYNCHDMLC [
    OUTPUT I;
    (' Group ',I3,':'/
     '   No. of leaves, leaf type (1. FULL leaves--the default, '/
-    '   2. HALF TARGET/ISOCENTER pairs with TARGET leaf on -X or -Y side'/
-    '   3. QUARTER TARGET/ISOCENTER pairs with TARGET leaf on -X or -Y side)'/
+    '   2. HALF TARGET/ISOCENTER leaves with TARGET or ISOCENTER leaf on -X',
+    ' or -Y side'/
+    '   3. QUARTER TARGET/ISOCENTER leaves with TARGET or ISOCENTER leaf on -X',
+    ' or -Y side)'/
     '   :',$);
    MINPUT ($SYNCHDMLC) NUM_LEAF_$SYNCHDMLC(I), LEAFTYPE; (2I5);
    OUTPUT NUM_LEAF_$SYNCHDMLC(I), LEAFTYPE; (2I5);
@@ -1380,39 +1390,46 @@ DO I=1,NGROUP_$SYNCHDMLC [
             ' Leaf type for group ',I3,' not recognized.'/
             ' Will default to 1.'//);
    ]
-   IF(MOD(NUM_LEAF_$SYNCHDMLC(I),2)~=0 & (LEAFTYPE=2 |
-     LEAFTYPE=3) )[
-      OUTPUT ICM_$SYNCHDMLC,I;
-         (//' ***ERROR IN CM ',I3,' ($SYNCHDMLC)'/
-            ' Leaf group ',I3,' consists of TARGET/ISOCENTER pairs but'/
-            ' does not have an even number of leaves.'//);
-     IERR_GEOM(ICM_$SYNCHDMLC)=IERR_GEOM(ICM_$SYNCHDMLC)+1;
-   ]
    "now set LEAFTYPE for each leaf"
    DO J=1,NUM_LEAF_$SYNCHDMLC(I)[
       K=K+1;
       IF(LEAFTYPE=1)[
          LEAFTYPE_$SYNCHDMLC(K)=1;
          NUM_FULL=NUM_FULL+1;
+         IF(K>1)[
+            IF(LEAFTYPE_$SYNCHDMLC(K-1) = 2 | LEAFTYPE_$SYNCHDMLC(K-1) = 4)[
+                OUTPUT ICM_$SYNCHDMLC;
+            (//' ***ERROR IN CM ',I3,' ($SYNCHDMLC)'/
+             ' Cannot have TARGET leaf on -ve side of FULL leaf.'//);
+                IERR_GEOM(ICM_$SYNCHDMLC)=IERR_GEOM(ICM_$SYNCHDMLC)+1;
+
+           ]
+           ELSEIF(LEAFTYPE_$SYNCHDMLC(K-1) = 5)[
+               check_full_qtr=.TRUE.;
+           ]
+        ]
       ]
-      ELSEIF(LEAFTYPE=2)["half target/isocenter pair"
-        IF(MOD(J,2)~=0)["target leaf"
-           LEAFTYPE_$SYNCHDMLC(K)=2;
+      ELSEIF(LEAFTYPE=2)["half target/isocenter leaf"
+        IF(K>1 & (LEAFTYPE_$SYNCHDMLC(K-1)=4 | LEAFTYPE_$SYNCHDMLC(K-1)=2))[
+           LEAFTYPE_$SYNCHDMLC(K)=3; "isocenter leaf"
         ]
         ELSE[
-           LEAFTYPE_$SYNCHDMLC(K)=3;
+           LEAFTYPE_$SYNCHDMLC(K)=2; "target leaf"
         ]
         NUM_HLF=NUM_HLF+1;
       ]
-     ELSE ["quarter target/isocenter pair"
-        IF(MOD(J,2)~=0)["target leaf"
-           LEAFTYPE_$SYNCHDMLC(K)=4;
+      ELSE ["quarter target/isocenter leaf"
+        IF(K>1 & (LEAFTYPE_$SYNCHDMLC(K-1)=4 | LEAFTYPE_$SYNCHDMLC(K-1)=2))[
+             LEAFTYPE_$SYNCHDMLC(K)=5; "isocenter leaf"
         ]
         ELSE[
-           LEAFTYPE_$SYNCHDMLC(K)=5;
+           LEAFTYPE_$SYNCHDMLC(K)=4;
+           IF(K>1 & LEAFTYPE_$SYNCHDMLC(K-1)=1)[
+             check_full_qtr=.TRUE.;
+           ]
         ]
         NUM_QTR=NUM_QTR+1;
-     ]
+      ]
   ]
 ]
 ;
@@ -1996,6 +2013,25 @@ IF(NUM_HLF>0 & NUM_QTR>0) [
       ' ZTONGUE_$SYNCHDMLC(4)>=ZGROOVE_$SYNCHDMLC(3).'/
       ' QUARTER TARGET leaf will not fit with'/
       ' HALF ISO leaf if FULL leaf is on -X or -Y side.'//);
+       IERR_GEOM(ICM_$SYNCHDMLC)=IERR_GEOM(ICM_$SYNCHDMLC)+1;
+  ]
+]
+
+IF(check_full_qtr) [ "Ya never know"
+  IF(ZGROOVE_$SYNCHDMLC(5)<=ZTONGUE_$SYNCHDMLC(1))[
+   OUTPUT ICM_$SYNCHDMLC;
+   (//' ***ERROR IN CM ',I3,' ($SYNCHDMLC) in leaf definition:'/
+      ' ZGROOVE_$SYNCHDMLC(5)<=ZTONGUE_$SYNCHDMLC(1).'/
+      ' QUARTER ISOCENTER leaf will not fit with'/
+      ' FULL leaf if ISOCENTER leaf is on -X or -Y side.'//);
+       IERR_GEOM(ICM_$SYNCHDMLC)=IERR_GEOM(ICM_$SYNCHDMLC)+1;
+  ]
+  IF(ZTONGUE_$SYNCHDMLC(4)>=ZGROOVE_$SYNCHDMLC(1))[
+   OUTPUT ICM_$SYNCHDMLC;
+   (//' ***ERROR IN CM ',I3,' ($SYNCHDMLC) in leaf definition:'/
+      ' ZTONGUE_$SYNCHDMLC(4)>=ZGROOVE_$SYNCHDMLC(1).'/
+      ' QUARTER TARGET leaf will not fit with'/
+      ' FULL leaf if FULL leaf is on -X or -Y side.'//);
        IERR_GEOM(ICM_$SYNCHDMLC)=IERR_GEOM(ICM_$SYNCHDMLC)+1;
   ]
 ]

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/beamnrc_params.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/beamnrc_params.tcl
@@ -2465,19 +2465,27 @@ the high-definition micro MLC (HD120) as well as the Millenium MLC (120 MLC) ava
 linacs.  The original code was contributed by Borges et al, while the current\
 version is from Lobo & Popescu.  SYNCHDMLC is based on SYNCVMLC.
 
-The user has the option to specify cross-sections for five leaf types:\
+The user has the option to specify five leaf types:\
 FULL, HALF TARGET, HALF ISOCENTER, QUARTER TARGET, QUARTER ISOCENTER.  The geometry of each type\
 has been defined so that the HD120 MLC can be simulated using QUARTER TARGET\ISOCENTER\
 and HALF TARGET/ISOCENTER leaves and the 120 MLC can be simulated with\
-HALF TARGET/ISOCENTER and FULL leaves.  The cross-sections dimensions of unused leaf\
+HALF TARGET/ISOCENTER and FULL leaves.  The cross-section dimensions of unused leaf\
 types can be left as blanks, zeroes or nonsense real numbers (although the input line\
-must exist in the .egsinp file).  Note that HALF TARGET/ISOCENTER leaves \
-and QUARTER TARGET/ISOCENTER leaves must be specified in pairs.
+must exist in the .egsinp file).  Unlike DYNVMLC and SYNCVMLC, the number of leaves\
+in a TARGET/ISOCENTER group need not be even.  Thus, although these leaves are automatically placed so that\
+TARGET and ISOCENTER leaves alternate, the last TARGET or ISOCENTER leaf in the\
+group need not have a matching ISOCENTER or TARGET (respectively) counterpart.\
+If the next group of leaves is also TARGET/ISOCENTER, then the first leaf in the group\
+will be chosen to match the last leaf of the previous group: HALF or QUARTER TARGET to match\
+a HALF or QUARTER ISOCENTER in the previous group, or vice versa.\
+Note that the overall leaf bank cannot be defined so that\
+a TARGET leaf is immediately adjacent on the -X (ORIENT=0) or -Y (ORIENT=1) side of a FULL\
+leaf.
 
 The figure at left shows a SYNCHDMLC with 12 leaves opening in the Y-direction (ORIENT=0) using\
 all leaf types.\
-Leaves 1,2,11,12 are FULL; leaves 3,4,9,10 are HALF TARGET/ISOCENTER pairs; leaves 5-9 are\
-QUARTER TARGET/ISOCENTER pairs.
+Leaves 1,2,11,12 are FULL; leaves 3,4,9,10 are HALF TARGET/ISOCENTER leaves; leaves 5-9 are\
+QUARTER TARGET/ISOCENTER leaves.
 
 SYNCHDMLC has the option to specify cylindrical (ENDTYPE=0) or straight, focused (ENDTYPE=1)\
 leaf ends.  The origins of the cylinders defining leaf ends are at Z=ZMIN+ZTHICK/2\

--- a/HEN_HOUSE/omega/progs/gui/beamnrc/synchdmlc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/synchdmlc.tcl
@@ -60,7 +60,7 @@
 
 
 proc init_SYNCHDMLC { id } {
-    global cmval ngroups nleaf sync_file nfull nhlf nqtr
+    global cmval ngroups nleaf sync_file nfull nhlf nqtr check_full_qtr
 
     set cmval($id,0) {}
     set cmval($id,1) {}
@@ -113,11 +113,13 @@ proc init_SYNCHDMLC { id } {
     set nhlf 0
     # no. of groups of QUARTER leaf pairs
     set nqtr 0
+    # set below 1 to do a dim. check between QUARTER and FULL leaves
+    set check_full_qtr 0
     set sync_file($id) {}
 }
 
 proc read_SYNCHDMLC { fileid id } {
-    global cmval GUI_DIR ngroups cm_ident nleaf sync_file nfull nhlf nqtr
+    global cmval GUI_DIR ngroups cm_ident nleaf sync_file nfull nhlf nqtr check_full_qtr
 
     # read a trash line
     gets $fileid data
@@ -210,12 +212,17 @@ proc read_SYNCHDMLC { fileid id } {
       } elseif {$cmval($id,8,1,$i)==3} {
          incr nqtr
       }
+      if {$i > 1} {
+          if { ($cmval($id,8,1,$i)==1 && $cmval($id,8,1,[expr $i-1])==3) ||
+              ($cmval($id,8,1,$i)==3 && $cmval($id,8,1,[expr $i-1])==1) } {
+             set check_full_qtr 1
+          }
+      }
     }
 
     # read start 9
     gets $fileid data
     set data [get_val $data cmval $id,9]
-
     # read leafgap 10
     gets $fileid data
     set data [get_val $data cmval $id,10]
@@ -659,9 +666,8 @@ proc define_synchdmlc_types { id } {
     set w $top.f
 
     message $w.message -text "Specify leaf types: FULL or HALF TARGET/ISOCENTER or \
-            QUARTER TARGET/ISOCENTER pairs.\
-            Note that for TARGET/ISOCENTER pairs, the number of\
-            leaves must be even.  Add a row to start a \
+            QUARTER TARGET/ISOCENTER leaves.\
+            Add a row to start a\
             new group.  When a new row is added the next leaf in the order will\
             automatically appear in the 'from leaf' box."\
             -width 400 -font $helvfont
@@ -671,8 +677,8 @@ proc define_synchdmlc_types { id } {
     label $w.grid.l0 -text "from leaf"
     label $w.grid.l1 -text "to leaf"
     label $w.grid.l2 -text "FULL"
-    label $w.grid.l3 -text "HALF TARGET/ISOCENTER pairs"
-    label $w.grid.l4 -text "QUARTER TARGET/ISOCENTER pairs"
+    label $w.grid.l3 -text "HALF TARGET/ISOCENTER"
+    label $w.grid.l4 -text "QUARTER TARGET/ISOCENTER"
 
     grid configure $w.grid.l0 -row 0 -column 0
     grid configure $w.grid.l1 -row 0 -column 1 -padx 5
@@ -713,6 +719,7 @@ proc define_synchdmlc_types { id } {
     pack $top.b.addb $top.b.delb $top.b.okb $top.b.helpb -side left -padx 10
     pack $top.b -pady 10
 }
+
 proc define_synchdmlc_leaves { id } {
 # defines the cross-section dimensions for FULL, ISOCENTER and TARGET HALF, ISOCENTER and TARGET QUARTER
 # leaf types
@@ -1064,7 +1071,7 @@ proc define_synchdmlc_leaves { id } {
 }
 
 proc check_dimensions_synchdmlc { id } {
-    global cmval helvfont dimtext totprob
+    global cmval helvfont dimtext totprob check_full_qtr
 
 #checks dimensions of all leaf types, within the leaf and against leaves
 #that it must fit together with
@@ -1540,6 +1547,23 @@ of bottom of groove of HALF ISOCENTER ($cmval($id,7,9) cm)"
           incr totprob
         }
     }
+#AND BETWEEN QUARTER AND FULL LEAVES--could happen
+    if {check_full_qtr == 1 && "$cmval($id,31,9)"!="" && "$cmval($id,5,8)"!=""} {
+        if {$cmval($id,31,9)<=$cmval($id,5,8)} {
+          set dimtext "$dimtext
+- Z of bottom of groove of QUARTER ISOCENTER ($cmval($id,31,9) cm) must be > Z \
+of bottom of tongue of FULL ($cmval($id,5,8) cm)"
+          incr totprob
+        }
+    }
+    if {check_full_qtr == 1 && "$cmval($id,30,11)"!="" && "$cmval($id,5,9)"!=""} {
+        if {$cmval($id,30,11)>=$cmval($id,5,9)} {
+          set dimtext "$dimtext
+- Z of bottom of tongue of QUARTER TARGET ($cmval($id,30,11) cm) must be < Z \
+of bottom of groove of FULL ($cmval($id,5,9) cm)"
+          incr totprob
+        }
+    }
 
     if {$totprob==0} {
         set dimtext "$dimtext
@@ -2007,7 +2031,7 @@ proc save_synchdmlc { id } {
 }
 
 proc save_synchdmlc_type { id } {
-    global cmval fromw tow nleaf nhlf nfull nqtr
+    global cmval fromw tow nleaf nhlf nfull nqtr check_full_qtr
 
     if {$tow($cmval($id,2,1))>$nleaf($id)} {
        tk_dialog .toomanytypegroups "Too many leaves" "You have specified too many\
@@ -2022,27 +2046,13 @@ proc save_synchdmlc_type { id } {
     set nhlf 0
     set nqtr 0
     set nfull 0
+    set check_full_qtr 0
     for {set j 1} {$j<=$cmval($id,2,1)} {incr j} {
         if {[catch {set cmval($id,8,0,$j) [expr $tow($j)-$fromw($j)+1]}]==1} {
            tk_dialog .nope "No no no" "The leaf types for group $j\
                     have been improperly set or not set at all.\
                     Go back and fix them." warning 0 OK
-        } elseif {[expr fmod($cmval($id,8,0,$j),2)]!=0 && \
-		      $cmval($id,8,1,$j)==2 } {
-            tk_dialog .oddpairnum "Odd no. of pairs" "Leaf group $j\
-          (leaves $fromw($j)-$tow($j)) has an odd number of leaves yet is\
-          specified as HALF TARGET/ISOCENTER pairs.  Groups of this type must\
-          have an even number of leaves." warning 0 OK
-	return
-
-	} elseif {[expr fmod($cmval($id,8,0,$j),2)]!=0 && \
-		      $cmval($id,8,1,$j)==3 } {
-            tk_dialog .oddpairnum "Odd no. of pairs" "Leaf group $j\
-          (leaves $fromw($j)-$tow($j)) has an odd number of leaves yet is\
-         specified as QUARTER TARGET/ISOCENTER pairs.  Groups of this type must\
-          have an even number of leaves." warning 0 OK
-        return
-	}
+        }
 
         if {$cmval($id,8,1,$j)==1} {
             incr nfull
@@ -2050,6 +2060,12 @@ proc save_synchdmlc_type { id } {
             incr nhlf
         } elseif {$cmval($id,8,1,$j)==3} {
             incr nqtr
+        }
+        if {$j > 1} {
+          if {($cmval($id,8,1,$j)==1 && $cmval($id,8,1,[expr $j-1])==3) ||
+              ($cmval($id,8,1,$j)==3 && $cmval($id,8,1,[expr $j-1])==1)} {
+             set check_full_qtr 1
+          }
         }
     }
 
@@ -2299,7 +2315,7 @@ proc draw_SYNCHDMLC { id } {
 
     # put the canvas up
     set ncan 3
-    set width 300.0
+    set width 200.0
     set canwidth [expr $width+150.0]
     set scrlheight [expr 2*$canwidth]
     set scrlwidth [expr 2*$canwidth]
@@ -2516,16 +2532,16 @@ proc add_SYNCHDMLC_xy {id xscale yscale xmin ymin l m parent_w} {
           if {$cmval($id,8,1,$i)==1} {
              set type($k) 1
           } elseif {$cmval($id,8,1,$i)==2} {
-             if {[expr fmod($j,2)] != 0} {
-               set type($k) 2
-             } else {
+             if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 3
+             } else {
+               set type($k) 2
              }
           } elseif {$cmval($id,8,1,$i)==3} {
-	     if {[expr fmod($j,2)] != 0} {
-               set type($k) 4
-	     } else {
+             if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 5
+             } else {
+               set type($k) 4
              }
           }
         }
@@ -2731,16 +2747,16 @@ proc add_SYNCHDMLC_ends {id xscale zscale xmin zmin zmax l m parent_w} {
           if {$cmval($id,8,1,$i)==1} {
              set type($k) 1
           } elseif {$cmval($id,8,1,$i)==2} {
-             if {[expr fmod($j,2)] != 0} {
-               set type($k) 2
-             } else {
+             if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 3
+             } else {
+               set type($k) 2
              }
           } elseif {$cmval($id,8,1,$i)==3} {
-	     if {[expr fmod($j,2)] != 0} {
-               set type($k) 4
-	     } else {
+	     if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 5
+	     } else {
+               set type($k) 4
              }
           }
         }
@@ -3163,16 +3179,16 @@ proc add_SYNCHDMLC_sides {id yscale zscale ymin zmin zmax l m parent_w} {
           if {$cmval($id,8,1,$i)==1} {
              set type($k) 1
           } elseif {$cmval($id,8,1,$i)==2} {
-             if {[expr fmod($j,2)] != 0} {
-               set type($k) 2
-             } else {
+             if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 3
+             } else {
+               set type($k) 2
              }
           } elseif {$cmval($id,8,1,$i)==3} {
-             if {[expr fmod($j,2)] != 0} {
-               set type($k) 4
-             } else {
+             if {$k > 1 && ($type([expr $k-1])==4 || $type([expr $k-1])==2)} {
                set type($k) 5
+             } else {
+               set type($k) 4
              }
           }
         }


### PR DESCRIPTION
Allows more accurate modeling of Varian HD 120 MLC.  Accompanying
changes to GUI and documentation included.