### PR TITLE
Fix egs_view compilation

### DIFF
--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -1787,7 +1787,6 @@ p, li { white-space: pre-wrap; }
  <includes>
   <include location="local">egs_vector.h</include>
   <include location="local">egs_user_color.h</include>
-  <include location="global">vector</include>
  </includes>
  <resources/>
  <connections>


### PR DESCRIPTION
Fix a bug that caused `egs_view` to not compile, giving an error about including `vector.h`. This include statement has been removed since it is not necessary. This has been tested both on qt4 and qt5.