### PR TITLE
Fix egs_inputs line length

### DIFF
--- a/HEN_HOUSE/src/get_inputs.mortran
+++ b/HEN_HOUSE/src/get_inputs.mortran
@@ -219,7 +219,7 @@ COMIN/GetInput,EGS-IO/;
 CHARACTER*$STRING256 TEXT;      "Used to read in each line of the input file   "
 CHARACTER*$STRING256 KEEPTEXT;  "Used to keep an old line of TEXT              "
 CHARACTER*$STRING256 ORIGTEXT;  "The text without conversion to upper case     "
-CHARACTER*$STRING256  TEXTPIECE; "Used to read a piece of TEXT                  "
+CHARACTER*$STRING256  TEXTPIECE; "Used to read a piece of TEXT                 "
 CHARACTER*$STRING40  DELIM_START;"Start of the delimeter                       "
 CHARACTER*$STRING40  DELIM_END;  "End of the delimeter                         "
 CHARACTER*$STRING32  VNAME;      "The name of the variable being extracted.    "


### PR DESCRIPTION
Fix the line length that was longer than 80 characters in get_inputs.mortran. This mistake was added in PR #510 just now, so likely no one will experience any issues from this.