### PR TITLE
Fix DOSXYZnrc parallel runs

### DIFF
--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -3002,7 +3002,7 @@ IF(IPARALLEL>1 | n_parallel>0)[
    "this file is written directly into the user code directory"
    parname=$cstring(egs_home) // $cstring(user_code) // $file_sep //
              $cstring(work_dir) // $cstring(output_file);
-   IF(n_parallel>0)[
+   IF(i_parallel>0)[
       "have to add _w[iparallel] if not controlled by script"
       parname=$cstring(parname)//'_w';
       call egs_itostring(parname,i_parallel,.false.);


### PR DESCRIPTION
Fix a bug in `DOSXYZnrc` parallel runs when they were initiated using the `Run job in parallel` option in the GUI. The `_w` tag was not added to the pardose files, resulting in a crash when the code tried to combine them. This bug did not affect parallel runs using the `-j` command line argument.