### PR TITLE
Fix geometry errors for prism and XYZ in a CD

### DIFF
--- a/HEN_HOUSE/egs++/egs_polygon.h
+++ b/HEN_HOUSE/egs++/egs_polygon.h
@@ -251,7 +251,12 @@ public:
                         if (tt <= t+epsilon) {
                             EGS_Float lam = uj[j]*(x-p[j]+u*tt);
                             if (lam >= 0 && lam < uj[j].length2()) {
-                                t = tt;
+                                if (tt < 0) {
+                                    t = 0;
+                                }
+                                else {
+                                    t = tt;
+                                }
                                 res = true;
                                 jhit = j;
                                 //if( normal ) *normal = a[j]*(-1);
@@ -437,7 +442,7 @@ public:
     /*! \brief Will the line defined by position \a x and direction \a u
       intersect the polygon plane at a position inside the polygon ?
 
-      The interprtation of the return value and the value of \a in and
+      The interpretation of the return value and the value of \a in and
       \a t is the same as in EGS_2DPolygon::howfar()
       */
     inline bool howfar(bool in, const EGS_Vector &x, const EGS_Vector &u,

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -904,7 +904,7 @@ public:
                     if(d <= boundaryTolerance) {
                         // t=0 works on most cases but can result in
                         // getting stuck on an edge, so use boundaryTolerance
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }
@@ -923,7 +923,7 @@ public:
                 EGS_Float d = (xpos[ix]-x.x)/u.x;
                 if (d <= t) {
                     if(d <= boundaryTolerance) {
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }
@@ -942,7 +942,7 @@ public:
                 EGS_Float d = (ypos[iy+1]-x.y)/u.y;
                 if (d <= t) {
                     if(d <= boundaryTolerance) {
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }
@@ -961,7 +961,7 @@ public:
                 EGS_Float d = (ypos[iy]-x.y)/u.y;
                 if (d <= t) {
                     if(d <= boundaryTolerance) {
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }
@@ -980,7 +980,7 @@ public:
                 EGS_Float d = (zpos[iz+1]-x.z)/u.z;
                 if (d <= t) {
                     if(d <= boundaryTolerance) {
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }
@@ -999,7 +999,7 @@ public:
                 EGS_Float d = (zpos[iz]-x.z)/u.z;
                 if (d <= t) {
                     if(d <= boundaryTolerance) {
-                        t = boundaryTolerance;
+                        t = halfBoundaryTolerance;
                     } else {
                         t = d;
                     }

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.h
@@ -221,7 +221,11 @@ public:
                 tt = 0;
             }
             if (tt <= t) {
-                t = tt;
+                if (tt > 0) {
+                    t = tt+boundaryTolerance;
+                } else {
+                    t = tt;
+                }
                 inew = -1;
                 if (normal) {
                     *normal = up>0 ? a*(-1) : a;


### PR DESCRIPTION
**Fix 3 different geometry errors that all arose when both an XYZ geometry and a prism were used in a CD geometry.** 

1. In the `howfar` routine in `egs_prism.h`, a step inside the geometry commonly returns exactly the distance to the boundary. However, due to floating point error the code still saw the particle as inside the geometry despite expecting to be outside. The error is avoided by adding a push to ensure we are now outside the surface. I feel like a more refined solution is possible, can anyone do better?
```
                if (tt > 0) {
                    t = tt+boundaryTolerance;
                } else {
                    t = tt;
                }
```

2. In `egs_nd_geometry.h`, steps of `t = boundaryTolerance` could fail against checks including the boundary tolerance in a CD geometry. Changing the steps to `halfBoundaryTolerance` fixed this. This solution still works for the original reason of using `boundaryTolerance` for issue #383.

3. The third error is found only in egs_view during the initial rendering, where rays were discarded after too many steps near the prism surface. In `egs_polygon.h`, the check of `(xp = x*a[j]) < d[j]+epsilon` where epsilon was included to fix a previous geometry error, lead to the possibility that `tt<0`. When this happened, the particle would get stuck stepping back and forth over a boundary. The fix was to change:
```
                                t = tt;
```
to
```
                                if(tt < 0) {
                                    t = 0;
                                } else {
                                    t = tt;
                                }
```

### The offending input file:
```
:start run control:
    ncase = 1e5
:stop run control:

:start geometry definition:
    :start geometry:
        name = base_prism
        library = egs_prism
        type = EGS_PrismY
        points = -2 4.5 -0.8 3.4 0.8 3.4 2 4.5
        closed = 0.2 -1.4
        :start media input:
            media = prism
        :stop media input:
    :stop geometry:

    ### Upper part of the holder
    :start geometry:
        name = upper_part
        library = egs_ndgeometry
        type = EGS_XYZGeometry
        x-planes = -0.5 0.5
        y-planes = -1 0
        z-planes = -0.7 4 # it should be -0.7 3.4
        :start media input:
            media = xyz
        :stop media input:
    :stop geometry:

    ### Planes to join the two parts together
    :start geometry:
        name = cd_planes_det_holder
        library = egs_planes
        type = EGS_Zplanes
        positions = -10 3.4 10
    :stop geometry:

    ### Join the two parts
    :start geometry:
        name = det_holder
        library = egs_cdgeometry
        base geometry = cd_planes_det_holder
        set geometry = 0 upper_part
        set geometry = 1 base_prism
        set label = det_holder 0 1
    :stop geometry:

    ### Sphere to embed the holder
    :start geometry:
        library = egs_spheres
        name = sphere_phantom
        midpoint= 0 -0.5 3
        radii = 4
        :start media input:
        media = water
        set medium = 0 0
        :stop media input:
    :stop geometry:

    ### Inscribe the holder in the sphere
    :start geometry:
        name = holder_in_sphere
        library = egs_genvelope
        base geometry = sphere_phantom
        inscribed geometries = det_holder
    :stop geometry:
    simulation geometry = holder_in_sphere
:stop geometry definition:

:start media definition:
    ae = 0.521                                  # MeV
    ap = 0.010                                  # MeV
    ue = 50.511                                 # MeV
    up = 50                                     # MeV

    :start air:
        density correction file = air_dry_nearsealevel
    :stop air:
    :start water:
        density correction file = water_liquid
    :stop water:
    :start xyz:
        density correction file = water_liquid
    :stop xyz:
    :start prism:
        density correction file = water_liquid
    :stop prism:
:stop media definition:

:start source definition:
    :start source:
        name      = pencil_beam
        library   = egs_parallel_beam
        charge    = -1
        direction = 0 0 1
        :start spectrum:
            type = monoenergetic
            energy = 20                         # MeV
        :stop spectrum:
        :start shape:
            type     = point
            position = 0 0 -8                   # cm
        :stop shape:
    :stop source:
    simulation source = pencil_beam
:stop source definition:
```