### PR TITLE
Fix #528: Windows PowerShell bug with .exe in app_name

### DIFF
--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -245,6 +245,12 @@ EGS_Application::EGS_Application(int argc, char **argv) : input(0), geometry(0),
     //
     if (!getArgument(argc,argv,"-a","--application",app_name)) {
         app_name = egsStripPath(argv[0]);
+
+        // In Windows PowerShell, we need to remove a .exe extension
+        size_t exePos = app_name.find_last_of(".exe");
+        if (exePos != string::npos) {
+            app_name = app_name.substr(0, exePos-3);
+        }
     }
     if (!app_name.size()) egsFatal("%s\n   failed to determine application "
                                        "name from %s or command line arguments\n",__egs_app_msg1,argv[0]);


### PR DESCRIPTION
Fix a `Windows PowerShell` and `git bash` bug where the .exe extension on applications was included in the app_name variable. This resulted in a runtime error where the input file failed to be found. Now we check to see if there is a .exe at the end of the app_name, and remove it.