### PR TITLE
Revert "Avoid infinite loop in conestack geometry"

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.h
@@ -1554,12 +1554,6 @@ public:
                 t = tp;                             // set t = distance to plane
             }
 
-            // If we are right on a plane, return -1
-            if(tp < boundaryTolerance) {
-                t = 0;
-                return -1;
-            }
-
             // distance to outer cone
             int ir = ireg - il*nmax;                // cone index in current layer
             bool hitc = false;                      // assume we don't hit the cone


### PR DESCRIPTION
This reverts commit 9f94ea42a1b968fa89a932f2eb6a342978e2a504. The original commit was intended to fix an infinite loop in the conetack geometry, but ended up also introducing geometry errors in long simulations of ionization chambers. 

Additionally, I was not able to reproduce the original infinite loop issue after reverting the change (though it does reappear when I switch to v2018). There have been no other changes in the conestack geometry since then, so I am unsure what else might have fixed the issue. Maybe it was a rare event and the same seeds no longer generate the same path, so I am running longer simulations to check.

This commit should get added to master and we should add a v2019a tag to update the release.