### PR TITLE
Fix #533: check on synchronized modules

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -3702,8 +3702,7 @@ IF(IO_OPT = 0  | IO_OPT >= 3) ["requested phase space files be output"
   I_MU_PHSP=0; "default to not store fractional MU index"
   "loop through CMs and determine if there are any synchronized ones"
   DO I=1,MAX_CMs[
-    IF(CMTYPE(I)='SYNCJAWS' | CMTYPE(I)='SYNCVMLC' |
-       CMTYPE(I)='SYNCMLCE' | CMTYPE(I)='SYNCHDMLC')[
+    IF(CMTYPE(I)(1:4)='SYNC')[
       "store fractional MU index in IAEA phsp files"
       I_MU_PHSP=1;
       EXIT;


### PR DESCRIPTION
Base setting if I_MU_PHSP (scoring of MU index
in IAEA format phase space files) on whether
characters 1-4 of CMNAME for any module in the
accelerator are 'SYNC'.  Replaces check on full
value of CMNAME.  The latter check failed if the only
synchronized CM was SYNCHDMLC, in which case
CMNAME can never be equal to 'SYNCHDMLC' because
CMNAME is character*8!

Resolves Issue #533