### PR TITLE
Fix source collection and simple alias table

### DIFF
--- a/HEN_HOUSE/egs++/egs_alias_table.cpp
+++ b/HEN_HOUSE/egs++/egs_alias_table.cpp
@@ -305,7 +305,7 @@ EGS_SimpleAliasTable::EGS_SimpleAliasTable(int N, const EGS_Float *f) : n(0) {
     int jh_old = 0, jl_old = 0;
     for (i=0; i<n-1; ++i) {
         for (jh=jh_old; jh<n-1; jh++) {
-            if (bins[jh] > n && fcum[jh] > sum) {
+            if (bins[jh] > n && fcum[jh] >= sum) {
                 break;
             }
         }

--- a/HEN_HOUSE/egs++/egs_alias_table.h
+++ b/HEN_HOUSE/egs++/egs_alias_table.h
@@ -39,6 +39,7 @@
 
 #include "egs_libconfig.h"
 #include "egs_rndm.h"
+#include <vector>
 
 typedef EGS_Float(*EGS_AtFunction)(EGS_Float,void *);
 

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
@@ -250,6 +250,12 @@ public:
         return (nsource > 0);
     };
 
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
+        for (int j=0; j<nsource; j++) {
+            sources[j]->setSimulationChunk(nstart, nrun);
+        }
+    };
+
 protected:
 
     int nsource;


### PR DESCRIPTION
1. Fixed phsp support in the `egs_source_collection`, that was due to not defining `setSimulationChunk`. It has been added to match what already exists in `egs_transformed_source`. The bug meant that parallel runs using phase-spaces in a source collection would not have the parallel "chunks" starting at different locations in the phsp. Instead, all chunks would start at the beginning of the phsp, effectively resulting in extra recycling of those particles. In highly parallel or low number of particle simulations, this would affect the statistics and potentially introduce latent phase-space variance artifacts.

2. Fixed a bug in `EGS_SimpleAliasTable` where certain series of weights did not result in correct sampling. For example, using weight = 10 10 1 1 in a source collection resulted in sampling of 10:5.5:1:5.5 instead of 10:10:1:1. The incorrect weighting was triggered only in a relatively rare combination dependent on the order of weights, their values and their sum. Fred describes the solution in the comments below.

`EGS_SimpleAliasTable` is used in `egs_source_collection`, `egs_voxelized_shape`, `egs_shape_collection` and `egs_atomic_relaxations`.

Thanks to Patty Oliver for reporting these issues.