### PR TITLE
Fix #554: Compile error when BEAMnrc EEMF macros are used

### DIFF
--- a/HEN_HOUSE/src/EEMF_macros.mortran
+++ b/HEN_HOUSE/src/EEMF_macros.mortran
@@ -2,7 +2,7 @@
 "#############################################################################"
 "                                                                             "
 "  EGSnrc enhanced electromagnetic field transport macros                     "
-"  Copyright (C) 2016 National Research Council Canada                        "
+"  Copyright (C) 2016 Victor N. Malkov, D. W. O. Rogers                       "
 "                                                                             "
 "  This file is part of EGSnrc.                                               "
 "                                                                             "
@@ -23,9 +23,15 @@
 "                                                                             "
 "  Author:          Victor Malkov, 2016                                       "
 "                                                                             "
-"  Contributors:                                                              "
+"  Contributors:    Dave Rogers                                               "
 "                                                                             "
 "#############################################################################"
+#                                                                             "
+#  When using EEMF macros for publications, please cite our paper:            "
+#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in    "
+#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                          "
+#                                                                             "
+##############################################################################"
 
 
 "******************************************************************************"
@@ -83,7 +89,6 @@ REPLACE{$EMInternalOutput}WITH{.false.};
 REPLACE{$EM_MACROS_ACTIVE}WITH{.true.};
 REPLACE{$SL}WITH{299792458.0}; "speed of light"
 REPLACE{$ERM}WITH{0.510998910}; "electron rest energy in MeV"
-REPLACE{$PI_em}WITH{3.14159265}; "Pi"
 REPLACE{$ERM_kg}WITH{9.10938356E-31}; "electron mass in kg"
 REPLACE{$EC_em}WITH{1.60217662E-19}; "electron charge"
 "parameter for rounding errors"

--- a/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
+++ b/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
@@ -1,8 +1,8 @@
 %C80
 "#############################################################################"
 "                                                                             "
-"  EGSnrc enhanced electromagnetic field transport macros (for BEAMnrc)       "
-"  Copyright (C) 2016 National Research Council Canada                        "
+"  EGSnrc enhanced electromagnetic field transport macros for BEAMnrc         "
+"  Copyright (C) 2016 Victor N. Malkov, D. W. O. Rogers                       "
 "                                                                             "
 "  This file is part of EGSnrc.                                               "
 "                                                                             "
@@ -23,9 +23,15 @@
 "                                                                             "
 "  Author:          Victor Malkov, 2016                                       "
 "                                                                             "
-"  Contributors:                                                              "
+"  Contributors:    Dave Rogers                                               "
 "                                                                             "
 "#############################################################################"
+#                                                                             "
+#  When using EEMF macros for publications, please cite our paper:            "
+#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in    "
+#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                          "
+#                                                                             "
+##############################################################################"
 
 
 "******************************************************************************"
@@ -82,10 +88,8 @@ REPLACE{$EMInternalOutput}WITH{.false.};
 "******************************** CONSTANTS ***********************************"
 REPLACE{$EM_MACROS_ACTIVE}WITH{.true.};
 REPLACE{$SL}WITH{299792458.0}; "speed of light"
-REPLACE{$SL2}WITH{89875517873681764.};
 REPLACE{$ERM}WITH{0.510998910}; "electron rest energy in MeV"
 REPLACE{$ERMJ}WITH{8.18710506E-14}
-REPLACE{$PI_em}WITH{3.14159265}; "Pi"
 REPLACE{$ERM_kg}WITH{9.10938356D-31}; "electron mass in kg"
 REPLACE{$EC_em}WITH{1.60217662E-19}; "electron charge"
 REPLACE{$ERM_kg2}WITH{8.298085698e-61}
@@ -2403,7 +2407,7 @@ REPLACE{$EF_timeRootFinder(#,#);}WITH{;
    OUTPUT x(np), y(np), z(np);(3(1PE13.4));
    OUTPUT u(np), v(np), w(np);(3(1PE13.4));
    OUTPUT E(np), distanceTravelled, EF_pPrll, EF_pPerp;(4(1PE13.4));
-   OUTPUT 1000000.*EIN/(ofr_cas); (1(1PE13.4));
+   OUTPUT 1000000.*EIN; (1(1PE13.4));
    CALL SLEEP(10);
  ];
  EF_currentTime=EF_futureTime;


### PR DESCRIPTION
Fixes a compile error for EEMF beamnrc macros, due to an undeclared variable being used in an error message. Renames the BEAMnrc macros file to fix a typo in the filename. Removes a couple unused constants.