### PR TITLE
Add eemf copyright

### DIFF
--- a/HEN_HOUSE/src/EEMF_macros.mortran
+++ b/HEN_HOUSE/src/EEMF_macros.mortran
@@ -83,7 +83,6 @@ REPLACE{$EMInternalOutput}WITH{.false.};
 REPLACE{$EM_MACROS_ACTIVE}WITH{.true.};
 REPLACE{$SL}WITH{299792458.0}; "speed of light"
 REPLACE{$ERM}WITH{0.510998910}; "electron rest energy in MeV"
-REPLACE{$PI_em}WITH{3.14159265}; "Pi"
 REPLACE{$ERM_kg}WITH{9.10938356E-31}; "electron mass in kg"
 REPLACE{$EC_em}WITH{1.60217662E-19}; "electron charge"
 "parameter for rounding errors"

--- a/HEN_HOUSE/src/EEMF_macros.mortran
+++ b/HEN_HOUSE/src/EEMF_macros.mortran
@@ -1,31 +1,33 @@
 %C80
-"#############################################################################"
-"                                                                             "
-"  EGSnrc enhanced electromagnetic field transport macros                     "
-"  Copyright (C) 2016 National Research Council Canada                        "
-"                                                                             "
-"  This file is part of EGSnrc.                                               "
-"                                                                             "
-"  EGSnrc is free software: you can redistribute it and/or modify it under    "
-"  the terms of the GNU Affero General Public License as published by the     "
-"  Free Software Foundation, either version 3 of the License, or (at your     "
-"  option) any later version.                                                 "
-"                                                                             "
-"  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY  "
-"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  "
-"  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for   "
-"  more details.                                                              "
-"                                                                             "
-"  You should have received a copy of the GNU Affero General Public License   "
-"  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.             "
-"                                                                             "
-"#############################################################################"
-"                                                                             "
-"  Author:          Victor Malkov, 2016                                       "
-"                                                                             "
-"  Contributors:                                                              "
-"                                                                             "
-"#############################################################################"
+################################################################################         
+#                                                                            
+#  EEMF_macros EEMF_macros_beamnrc                                                
+#  Copyright (C) 2016 Victor N. Malkov, David W.O. Rogers                            
+#                                                                                         
+#  This file is part of the EEMF macros                                                       
+#                                                                                         
+#  The EEMF macros are a free software: you can redistribute it and/or modify it  
+#  under the terms of the GNU Affero General Public License as published     
+#  by the Free Software Foundation, either version 3 of the License, or      
+#  (at your option) any later version.                                                   
+#                                                                             
+#  The EEMF macros are distributed in the hope that they will be useful, but           
+#  WITHOUT ANY WARRANTY; without even the implied warranty of                             
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU                     
+#  Affero General Public License for more details:                                       
+#  <http://www.gnu.org/licenses/>.                                                       
+#                                                                                         
+################################################################################  
+#                                                                                         
+#  When the EEMF macros are used for publications, please cite our paper:             
+#  Malkov, V.N. and Rogers, D.W.O., 2016. Charged particle transport
+#  in magnetic fields in EGSnrc. Medical Physics, 43(7), pp.4447-4458.  
+#                                                                                     
+################################################################################     
+#                                                                                         
+#  Author:        Victor N. Malkov, 2016                                         
+#                                                                                  
+#  Contributors:  David W.O. Rogers      
 
 
 "******************************************************************************"

--- a/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
+++ b/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
@@ -82,10 +82,8 @@ REPLACE{$EMInternalOutput}WITH{.false.};
 "******************************** CONSTANTS ***********************************"
 REPLACE{$EM_MACROS_ACTIVE}WITH{.true.};
 REPLACE{$SL}WITH{299792458.0}; "speed of light"
-REPLACE{$SL2}WITH{89875517873681764.};
 REPLACE{$ERM}WITH{0.510998910}; "electron rest energy in MeV"
 REPLACE{$ERMJ}WITH{8.18710506E-14}
-REPLACE{$PI_em}WITH{3.14159265}; "Pi"
 REPLACE{$ERM_kg}WITH{9.10938356D-31}; "electron mass in kg"
 REPLACE{$EC_em}WITH{1.60217662E-19}; "electron charge"
 REPLACE{$ERM_kg2}WITH{8.298085698e-61}
@@ -2403,7 +2401,7 @@ REPLACE{$EF_timeRootFinder(#,#);}WITH{;
    OUTPUT x(np), y(np), z(np);(3(1PE13.4));
    OUTPUT u(np), v(np), w(np);(3(1PE13.4));
    OUTPUT E(np), distanceTravelled, EF_pPrll, EF_pPerp;(4(1PE13.4));
-   OUTPUT 1000000.*EIN/(ofr_cas); (1(1PE13.4));
+   OUTPUT 1000000.*EIN; (1(1PE13.4));
    CALL SLEEP(10);
  ];
  EF_currentTime=EF_futureTime;

--- a/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
+++ b/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
@@ -1,31 +1,33 @@
 %C80
-"#############################################################################"
-"                                                                             "
-"  EGSnrc enhanced electromagnetic field transport macros (for BEAMnrc)       "
-"  Copyright (C) 2016 National Research Council Canada                        "
-"                                                                             "
-"  This file is part of EGSnrc.                                               "
-"                                                                             "
-"  EGSnrc is free software: you can redistribute it and/or modify it under    "
-"  the terms of the GNU Affero General Public License as published by the     "
-"  Free Software Foundation, either version 3 of the License, or (at your     "
-"  option) any later version.                                                 "
-"                                                                             "
-"  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY  "
-"  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS  "
-"  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for   "
-"  more details.                                                              "
-"                                                                             "
-"  You should have received a copy of the GNU Affero General Public License   "
-"  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.             "
-"                                                                             "
-"#############################################################################"
-"                                                                             "
-"  Author:          Victor Malkov, 2016                                       "
-"                                                                             "
-"  Contributors:                                                              "
-"                                                                             "
-"#############################################################################"
+################################################################################         
+#                                                                            
+#  EEMF_macros EEMF_macros_beamnrc                                                
+#  Copyright (C) 2016 Victor N. Malkov, David W.O. Rogers                            
+#                                                                                         
+#  This file is part of the EEMF macros                                                       
+#                                                                                         
+#  The EEMF macros are a free software: you can redistribute it and/or modify it  
+#  under the terms of the GNU Affero General Public License as published     
+#  by the Free Software Foundation, either version 3 of the License, or      
+#  (at your option) any later version.                                                   
+#                                                                             
+#  The EEMF macros are distributed in the hope that they will be useful, but           
+#  WITHOUT ANY WARRANTY; without even the implied warranty of                             
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU                     
+#  Affero General Public License for more details:                                       
+#  <http://www.gnu.org/licenses/>.                                                       
+#                                                                                         
+################################################################################  
+#                                                                                         
+#  When the EEMF macros are used for publications, please cite our paper:             
+#  Malkov, V.N. and Rogers, D.W.O., 2016. Charged particle transport
+#  in magnetic fields in EGSnrc. Medical Physics, 43(7), pp.4447-4458.  
+#                                                                                     
+################################################################################     
+#                                                                                         
+#  Author:        Victor N. Malkov, 2016                                         
+#                                                                                  
+#  Contributors:  David W.O. Rogers      
 
 
 "******************************************************************************"


### PR DESCRIPTION
This is an update of the copyright to the EEMF macros. The changes are based on the fix that @rtownson introduced in the fix-eemf-compilation as that changed led to a change in file names. Please let me know if there is a better way of adding these changes.