### PR TITLE
Fix glib and egs_rz windows compilation

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/Makefile
@@ -76,9 +76,9 @@ $(ABS_DSO)$(libpre)egs_autoenvelope$(libext): volcor.h $(GZSTREAM_H) \
 						..$(DSEP)egs_gtransformed$(DSEP)egs_gtransformed.h
 
 clean:
-	rm -f $(ABS_DSO)$(libpre)egs_autoenvelope$(libext) $(ABS_DSO)$(libpre)egs_sobol$(libext) $(ABS_DSO)$(libpre)sobol$(libext) \
+	$(REMOVE) $(ABS_DSO)$(libpre)egs_autoenvelope$(libext) $(ABS_DSO)$(libpre)egs_sobol$(libext) $(ABS_DSO)$(libpre)sobol$(libext) \
 		$(ABS_DSO)$(libpre)gzstream$(libext) $(ABS_DSO)$(libpre)gzstream$(libext)
-	rm -f $(DSO2)autoenvelope.$(obje) $(DSO2)sobol.$(obje) $(DSO2)egs_sobol.$(obje) \
+	$(REMOVE) $(DSO2)autoenvelope.$(obje) $(DSO2)sobol.$(obje) $(DSO2)egs_sobol.$(obje) \
 		$(DSO2)gzstream.$(obje) $(DSO2)gzstream.$(obje) \
 
 touchup:

--- a/HEN_HOUSE/egs++/geometry/egs_glib/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_glib/Makefile
@@ -52,8 +52,8 @@ $(DSO2)$(library).$(obje): ndgeom
 $(ABS_DSO)$(libpre)$(library)$(libext): ndgeom
 
 ndgeom:
-	cd ..$(DSEP)egs_nd_geometry && make
+	cd ..$(DSEP)egs_nd_geometry && $(MAKE)
 
 clean:
-	rm -f $(ABS_DSO)$(libpre)$(library)$(libext)
-	rm -f $(DSO2)$(library).$(obje)
+	$(REMOVE) $(ABS_DSO)$(libpre)$(library)$(libext) $(DSO2)$(library).$(obje)
+

--- a/HEN_HOUSE/egs++/geometry/egs_rz/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_rz/Makefile
@@ -52,14 +52,13 @@ $(DSO2)$(library).$(obje): ndgeom cyls planes
 $(ABS_DSO)$(libpre)$(library)$(libext): ndgeom cyls planes
 
 ndgeom:
-	cd ..$(DSEP)egs_nd_geometry && make
+	cd ..$(DSEP)egs_nd_geometry && $(MAKE)
 
 cyls:
-	cd ..$(DSEP)egs_cylinders && make
+	cd ..$(DSEP)egs_cylinders && $(MAKE)
 
 planes:
-	cd ..$(DSEP)egs_planes && make
+	cd ..$(DSEP)egs_planes && $(MAKE)
 
 clean:
-	rm -f $(ABS_DSO)$(libpre)$(library)$(libext)
-	rm -f $(DSO2)$(library).$(obje)
+	$(REMOVE) $(ABS_DSO)$(libpre)$(library)$(libext) $(DSO2)$(library).$(obje)


### PR DESCRIPTION
Fix compilation of egs_glib and egs_rz geometries on windows. This bug was introduced in PR #103 that added the geometries.