### PR TITLE
Fix an egs_configure compilation error on Windows

### DIFF
--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -236,7 +236,7 @@ if( lRes == ERROR_SUCCESS ){
 
     RegCloseKey( hKey );
 
-    unsigned long lpdwResult;
+    unsigned long long lpdwResult;
     if ( ! SendMessageTimeoutA(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
                                (LPARAM) "Environment", SMTO_ABORTIFHUNG,
                                9000, &lpdwResult) )
@@ -338,7 +338,7 @@ if( lRes == ERROR_SUCCESS ){
 
     RegCloseKey( hKey );
 
-    ulong lpdwResult;
+    unsigned long long lpdwResult;
     if ( ! SendMessageTimeoutA(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
                                (LPARAM) "Environment", SMTO_ABORTIFHUNG,
                                9000, &lpdwResult) )


### PR DESCRIPTION
Fix a type mismatch of a variable that resulted in compilation errors. Newer compilers are strict about the type matching correctly, though only the windows compiler mingw seemed to throw an error.