### PR TITLE
Fix the egs_chamber region-specific ECUT check

### DIFF
--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
@@ -1884,7 +1884,7 @@ int EGS_ChamberApplication::ausgab(int iarg) {
     // jwu: check if we are above ECUT
     if( do_rECUT[ig] && (the_stack->iq[np] == -1 || the_stack->iq[np] == 1) )
         if( is_rECUT[ig][ir] ){
-            if( the_stack->E[np]-the_useful->rm < rECUT[ig] ){
+            if( the_stack->E[np] < rECUT[ig] ){
             // before discarding the particle
             // deposit all of its energy locally
             if( ir >= 0 && is_cavity[ig][ir] ) {


### PR DESCRIPTION
Fix the ECUT check in `egs_chamber` that is used when a user selects the `ECUT regions` specifically in their calculation geometry. The bug was that the rest mass was subtracted from the particle energy during the ECUT comparison, effectively resulting in the ECUT being 0.511 MeV higher than it should have been. **This is a significant bug!** It looks like this line has been there for as long as we have a git history of egs_chamber. Please double check to be sure I'm not mistaken on how the ECUT should be handled here.

Thanks to /u/LuisDFQ on the Reddit community for pointing out that `ECUT regions` gave a different result than just using a global ECUT of the same value.