### PR TITLE
Add egs_circle_perpendicular shape

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -62,7 +62,8 @@ source_libs = egs_collimated_source egs_isotropic_source egs_parallel_beam \
 
 shape_libs = egs_circle egs_ellipse egs_extended_shape egs_gaussian_shape \
              egs_line_shape egs_polygon_shape egs_rectangle egs_shape_collection \
-             egs_voxelized_shape egs_spherical_shell egs_conical_shell
+             egs_voxelized_shape egs_spherical_shell egs_conical_shell \
+             egs_circle_perpendicular
 
 aobject_libs = egs_track_scoring egs_dose_scoring egs_radiative_splitting egs_phsp_scoring
 

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/Makefile
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/Makefile
@@ -1,0 +1,48 @@
+
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build circle shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Iwan Kawrakow, 2005
+#
+#  Contributors:
+#
+###############################################################################
+
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_CIRCLE_PERPENDICULAR_DLL
+
+library = egs_circle_perpendicular
+lib_files = egs_circle_perpendicular
+my_deps = $(common_shape_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)
+
+test:
+	@echo "common_h2: $(common_h2)"
+	@echo "extra_dep: $(extra_dep)"

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.cpp
@@ -1,0 +1,83 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ circle perpendicular shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2020
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+
+/*! \file egs_circle_perpendicular.cpp
+ *  \brief A circular shape perpendicular to source particles
+ *  \RT
+ */
+
+#include "egs_circle_perpendicular.h"
+#include "egs_input.h"
+#include "egs_functions.h"
+
+extern "C" {
+
+    EGS_CIRCLE_PERPENDICULAR_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        if (!input) {
+            egsWarning("createShape(circle): null input?\n");
+            return 0;
+        }
+        EGS_Float radius;
+        int err = input->getInput("radius",radius);
+        if (err) {
+            egsWarning("createShape(circle): no 'radius' input\n");
+            return 0;
+        }
+        EGS_Float Ro;
+        err = input->getInput("inner radius",Ro);
+        if (err) {
+            Ro = 0;
+        }
+        vector<EGS_Float> pos;
+        err = input->getInput("midpoint",pos);
+        if (err) {
+            pos.clear();
+            pos.push_back(0);
+            pos.push_back(0);
+        }
+        else {
+            if (pos.size() != 2) {
+                egsWarning("createShape(circle): 2 instead of %d inputs expected"
+                           " for keyword 'midpoint'. Reseting midpoint to (0,0)\n",
+                           pos.size());
+                pos.clear();
+                pos.push_back(0);
+                pos.push_back(0);
+            }
+        }
+        EGS_CirclePerpendicularShape *shape = new EGS_CirclePerpendicularShape(pos[0],pos[1],radius,Ro,"",f);
+        shape->setName(input);
+        shape->setTransformation(input);
+        return shape;
+    }
+
+}

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
@@ -113,7 +113,7 @@ public:
     /*! \brief Conctruct a circle with midpoint given by \a Xo and \a Yo,
     radius \a R and innder radius \a R_i */
     EGS_CirclePerpendicularShape(EGS_Float Xo, EGS_Float Yo, EGS_Float R, EGS_Float R_i = 0,
-                    const string &Name="",EGS_ObjectFactory *f=0) :
+                                 const string &Name="",EGS_ObjectFactory *f=0) :
         EGS_SurfaceShape(Name,f), xo(Xo), yo(Yo), ro(R_i), dr(R-R_i) {
         otype = "circle";
         if (dr < 0) {
@@ -149,10 +149,17 @@ public:
         EGS_Float angleBetween = std::acos(u * perpToCircle / (perpToCircle.length() * u.length()));
 
         // We will rotate about a vector perpendicular to u and the target surface normal
-        EGS_Vector rotateAbout = u.times(perpToCircle);
+        // Check against fabs(u.z) to account for both parallel and anti-parallel cases
+        EGS_Vector rotateAbout;
+        if ((fabs(u.z) - perpToCircle.z) < epsilon) {
+            rotateAbout = perpToCircle;
+        }
+        else {
+            rotateAbout = u.times(perpToCircle);
+        }
         EGS_RotationMatrix rotation = EGS_RotationMatrix::rotV(-angleBetween, rotateAbout);
         EGS_AffineTransform *transform = new EGS_AffineTransform(rotation);
-        if(transform) {
+        if (transform) {
             // Transform the point on the target surface by this rotation
             transform->rotate(x);
 

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
@@ -1,0 +1,176 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ circle perpendicular shape headers
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2020
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+
+/*! \file egs_circle_perpendicular.h
+ *  \brief A circular shape perpendicular to source particles
+ *  \RT
+ */
+
+#ifndef EGS_CIRCLE_PERPENDICULAR_
+#define EGS_CIRCLE_PERPENDICULAR_
+
+#include "egs_shapes.h"
+#include "egs_rndm.h"
+#include "egs_math.h"
+
+#ifdef WIN32
+
+    #ifdef BUILD_CIRCLE_PERPENDICULAR_DLL
+        #define EGS_CIRCLE_PERPENDICULAR_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_CIRCLE_PERPENDICULAR_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_CIRCLE_PERPENDICULAR_LOCAL
+
+#else
+
+    #ifdef HAVE_VISIBILITY
+        #define EGS_CIRCLE_PERPENDICULAR_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_CIRCLE_PERPENDICULAR_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_CIRCLE_PERPENDICULAR_EXPORT
+        #define EGS_CIRCLE_PERPENDICULAR_LOCAL
+    #endif
+
+#endif
+
+/*! \brief A circle shape perpendicular to source particles.
+
+\ingroup Shapes
+\ingroup SurfaceS
+
+This shape is specified via
+\verbatim
+:start shape:
+    library = egs_circle_perpendicular
+    radius = the circle radius
+    midpoint = Ox, Oy (optional)
+    inner radius = the inner radius (optional)
+:stop shape:
+\endverbatim
+and delivers points uniformly distributed within a circle.
+The surface of this circle is always perpendicular to source particles,
+when this shape is used as the target in a source that calls the
+getPointSourceDirection() function. For example, in a 
+\link EGS_CollimatedSource collimated source \endlink
+when a source shape and target shape are defined, the special properties
+of this circle only apply when it is used as the target shape. Otherwise,
+it behaves like an \link EGS_CircleShape egs_circle \endlink.
+
+For each source particle, when getPointSourceDirection() is called, the 
+circle shape is rotated so that the circle surface is perpendicular to the 
+vector between the source location, and the origin of the circle. In 
+effect this means that the source particles see a sphere instead of a 
+circle, except that for a given particle, the possible target locations
+are on the surface of a circle rather than within a sphere.
+
+If you place a transformation block inside this shape, to perform
+an \link EGS_AffineTransform affine transformation \endlink, only
+the translation part of the transformation will be applied. Rotations
+will be un-done when the surface is rotated to be perpendicular
+to the source particle.
+
+If an inner radius is specified,
+the points will be within the ring between the <code>inner radius</code>
+and the \c radius. Points within a circle in planes other
+than the xy-plane at z=0 can be obtained by attaching an
+\link EGS_AffineTransform affine transformation \endlink
+to the circle shape.
+*/
+class EGS_CIRCLE_PERPENDICULAR_EXPORT EGS_CirclePerpendicularShape : public EGS_SurfaceShape {
+
+public:
+
+    /*! \brief Conctruct a circle with midpoint given by \a Xo and \a Yo,
+    radius \a R and innder radius \a R_i */
+    EGS_CirclePerpendicularShape(EGS_Float Xo, EGS_Float Yo, EGS_Float R, EGS_Float R_i = 0,
+                    const string &Name="",EGS_ObjectFactory *f=0) :
+        EGS_SurfaceShape(Name,f), xo(Xo), yo(Yo), ro(R_i), dr(R-R_i) {
+        otype = "circle";
+        if (dr < 0) {
+            ro = R;
+            dr = R_i - R;
+        }
+        A = M_PI*dr*(dr + 2*ro);
+    };
+    ~EGS_CirclePerpendicularShape() {};
+    EGS_Vector getPoint(EGS_RandomGenerator *rndm) {
+        EGS_Float r = ro + dr*sqrt(rndm->getUniform());
+        EGS_Float cphi, sphi;
+        rndm->getAzimuth(cphi,sphi);
+        return EGS_Vector(xo + r*cphi, yo + r*sphi, 0);
+    };
+
+    void getPointSourceDirection(const EGS_Vector &Xo,
+                                 EGS_RandomGenerator *rndm, EGS_Vector &u, EGS_Float &wt) {
+                                     
+        // Perform user requested transformations to a point on the source surface
+        // This is effectively the same as transforming the target position
+        // because we're just calculating the direction between the two
+        EGS_Vector xo = T ? Xo*(*T) : Xo;
+
+        // Get a point on the circle target surface
+        EGS_Vector x = getPoint(rndm);
+        u = x - xo;
+        EGS_Float d2i = 1/u.length2(), di = sqrt(d2i);
+        u *= di;
+
+        // Calculate the angle between the normal to the circle surface and the u vector between points
+        EGS_Vector perpToCircle = EGS_Vector(0, 0, 1);
+        EGS_Float angleBetween = std::acos(u * perpToCircle / (perpToCircle.length() * u.length()));
+
+        // We will rotate about a vector perpendicular to u and the target surface normal
+        EGS_Vector rotateAbout = u.times(perpToCircle);
+        EGS_RotationMatrix rotation = EGS_RotationMatrix::rotV(-angleBetween, rotateAbout);
+        EGS_AffineTransform *transform = new EGS_AffineTransform(rotation);
+        if(transform) {
+            // Transform the point on the target surface by this rotation
+            transform->rotate(x);
+
+            // Calculate the new u vector
+            u = x - xo;
+        }
+        delete transform;
+
+        d2i = 1/u.length2(), di = sqrt(d2i);
+        u *= di;
+        wt = A*fabs(u.z)*d2i;
+        if (T) {
+            T->rotate(u);
+        }
+    };
+
+protected:
+
+    EGS_Float xo, yo, ro, dr;
+};
+
+#endif

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
@@ -77,18 +77,19 @@ This shape is specified via
 :stop shape:
 \endverbatim
 and delivers points uniformly distributed within a circle.
-The surface of this circle is always perpendicular to source particles,
+The surface of this circle is always perpendicular to a ray based on the
+source particle position,
 when this shape is used as the target in a source that calls the
-getPointSourceDirection() function. For example, in a 
+getPointSourceDirection() function. For example, in a
 \link EGS_CollimatedSource collimated source \endlink
 when a source shape and target shape are defined, the special properties
 of this circle only apply when it is used as the target shape. Otherwise,
 it behaves like an \link EGS_CircleShape egs_circle \endlink.
 
-For each source particle, when getPointSourceDirection() is called, the 
-circle shape is rotated so that the circle surface is perpendicular to the 
-vector between the source location, and the origin of the circle. In 
-effect this means that the source particles see a sphere instead of a 
+For each source particle, when getPointSourceDirection() is called, the
+circle shape is rotated so that the circle surface is perpendicular to the
+vector between the source particle location and the origin of the circle. In
+effect this means that the source particles see a sphere instead of a
 circle, except that for a given particle, the possible target locations
 are on the surface of a circle rather than within a sphere.
 
@@ -131,7 +132,7 @@ public:
 
     void getPointSourceDirection(const EGS_Vector &Xo,
                                  EGS_RandomGenerator *rndm, EGS_Vector &u, EGS_Float &wt) {
-                                     
+
         // Perform user requested transformations to a point on the source surface
         // This is effectively the same as transforming the target position
         // because we're just calculating the direction between the two
@@ -162,7 +163,7 @@ public:
 
         d2i = 1/u.length2(), di = sqrt(d2i);
         u *= di;
-        wt = A*fabs(u.z)*d2i;
+        wt = A*u.length()*d2i;
         if (T) {
             T->rotate(u);
         }


### PR DESCRIPTION
Adds a new circle shape where the angle of the surface of the circle depends on the position of the source particle directed toward it.

This shape is specified via
```
:start shape:
    library = egs_circle_perpendicular
    radius = the circle radius
    midpoint = Ox, Oy (optional)
    inner radius = the inner radius (optional)
:stop shape:
```
and delivers points uniformly distributed within a circle. The surface of this circle is always perpendicular to a ray based on the source particle position, when this shape is used as the target in a source that calls the `getPointSourceDirection()` function. For example, in a collimated source when a source shape and target shape are defined, the special properties of this circle only apply when it is used as the target shape. Otherwise, it behaves like an egs_circle.

For each source particle, when `getPointSourceDirection()` is called, the circle shape is rotated so that the circle surface is perpendicular to the vector between the source location, and the origin of the circle. In effect this means that the source particles see a sphere instead of a circle, except that for a given particle, the possible target locations are on the surface of a circle rather than within a sphere.

Thanks to Nathan Murtha for both requesting and helping to debug this feature!