### PR TITLE
Print mcdf label in Mortran apps

### DIFF
--- a/HEN_HOUSE/src/get_inputs.mortran
+++ b/HEN_HOUSE/src/get_inputs.mortran
@@ -1795,8 +1795,14 @@ write(ounit,'(a,/)')
 write(ounit,'(a,/)') line;
 
 /* initialized in egs_set_defaults */
-write(ounit,'(a,38x,a)') ' Photon cross sections',
+IF (mcdf_pe_xsections)[
+    write(ounit,'(a,38x,a,a)') ' Photon cross sections',
+      'mcdf-',$cstring(photon_xsections);
+]
+ELSE[
+    write(ounit,'(a,38x,a)') ' Photon cross sections',
       $cstring(photon_xsections);
+]
 write(ounit,'(a,37x,a)') ' Compton cross sections', $cstring(comp_xsections);
 
 write(ounit,'(a,$)') ' Photon transport cutoff(MeV)';


### PR DESCRIPTION
Mortan apps were not properly reporting whether `mcdf-xcom`, `mcdf-epdl`, `epdl` or `xcom`
photoelectric cross sections were used. This fix was part of a larger PR (PR #598) that awaits review. 
It has been separated for speedier merge to develop. This PR fixes the recently posted issue #602.

Given how small the fix is, it should incorporated quickly into develop!