### PR TITLE
Fix #616: Space in group name crashes configure script

### DIFF
--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -1195,7 +1195,7 @@ _ACEOF
   if { (eval $test_compile) 2>&5; test_status=$?; (exit $test_status); }; then
     test_run=$(./conftest$test_exeext)
     if test "x$test_run" = xyes; then
-      junk_size=$(ls -al junk_file | awk '{print $5}')
+      junk_size=$(stat -c '%s' junk_file)
       if test "x$junk_size" = x4; then
         know_recl=yes
         recl_size=$recl


### PR DESCRIPTION
Fix a bug in the configure script where it would crash if there was a space in the linux group name while checking for the record length. Now the `stat` command is used instead of `ls` to find the size of a file.

Thanks to @FredericBrochu for the debugging and solution.