### PR TITLE
Fix #607: Bug in sprrznrc output of D/Dmax

### DIFF
--- a/HEN_HOUSE/user_codes/sprrznrc/sprrznrc.mortran
+++ b/HEN_HOUSE/user_codes/sprrznrc/sprrznrc.mortran
@@ -4668,8 +4668,8 @@ IF(ISPRREG=1)["create the .plotdat file"
     AXISTYPE=0;             "0 for no logs"
     DO IX=1, NR [
        XCOORD(IX) = RCYL(IX);
-       YCOORD(IZ) = SCDOSE(IZ,IX,3)/Dmax;
-       UNCERT(IZ) = SCDOSE(IZ,IX,3)*SCDOSE2(IZ,IX,3)/(Dmax*100.);
+       YCOORD(IX) = SCDOSE(IZ,IX,3)/Dmax;
+       UNCERT(IX) = SCDOSE(IZ,IX,3)*SCDOSE2(IZ,IX,3)/(Dmax*100.);
     ]
     "Convert slab number(IZ) to a character string"
     $CONVERT_INT(IZ)_TO_CHAR(CH_IZ);


### PR DESCRIPTION
Fix a bug in the sprrznrc output of D/Dmax vs radius. The indices of the y coordinate and uncertainty were using the z index instead of looping over the x index.