### PR TITLE
Fix egs_chamber usage of latch for splitting

### DIFF
--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.macros
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.macros
@@ -52,6 +52,38 @@ REPLACE {$RANGE-DISCARD;} WITH {;
     ]
 };
 
+/*
+   We want to have an additional array of ints for
+   the particle stack, which will have the splitting numbers
+ */
+REPLACE {;COMIN/STACK-EXTRA/;} WITH {
+  common/extra_stack/ nbr_splitting($MXSTACK), nbr_splittingI;
+  $INTEGER            nbr_splitting, nbr_splittingI;
+};
+APPEND {;COMIN/STACK-EXTRA/;} TO {;COMIN/STACK/;};
+REPLACE {$TRANSFERPROPERTIESTO#FROM#;} WITH {
+    X{P1}=X{P2};Y{P1}=Y{P2};Z{P1}=Z{P2};IR{P1}=IR{P2};
+    WT{P1}=WT{P2};DNEAR{P1}=DNEAR{P2};LATCH{P1}=LATCH{P2};
+    nbr_splitting{P1}=nbr_splitting{P2};
+};
+
+REPLACE {$EXCHANGE-STACK(#,#);} WITH {
+;
+FDUMMY = U({P2});     U({P2})     = U({P1});     U({P1})     = FDUMMY;
+FDUMMY = V({P2});     V({P2})     = V({P1});     V({P1})     = FDUMMY;
+FDUMMY = W({P2});     W({P2})     = W({P1});     W({P1})     = FDUMMY;
+FDUMMY = E({P2});     E({P2})     = E({P1});     E({P1})     = FDUMMY;
+FDUMMY = WT({P2});    WT({P2})    = WT({P1});    WT({P1})    = FDUMMY;
+IDUMMY = IQ({P2});    IQ({P2})    = IQ({P1});    IQ({P1})    = IDUMMY;
+"LATCH IS NOW STANDARD"
+IDUMMY = LATCH({P2}); LATCH({P2}) = LATCH({P1}); LATCH({P1}) = IDUMMY;
+"add this for the extra stack
+IDUMMY = nbr_splitting{P2};
+nbr_splitting{P2}=nbr_splitting{P1};
+nbr_splitting{P1}=IDUMMY;
+}
+;
+
 subroutine do_rayleigh;
 implicit none;
 $declare_max_medium;


### PR DESCRIPTION
Fix the egs_chamber russian roulette splitting algorithm so that the latch variable is no longer used. Instead, an extra stack is created with a splitting variable in it. This avoids allowing egs_chamber to overwrite the latch, in case other objects such as `egs_phsp_scoring` need to use it.

Previously, if you used russian roulette in egs_chamber and scored a phsp using egs_phsp_scoring, the multiple passer flag for scoring particles may have been incorrect. I think this would be a small effect.