### PR TITLE
Add code owners file to automate review requests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+### EGSnrc code owners
+
+### default code owners
+*   @nrc-cnrc/egsnrc


### PR DESCRIPTION
Add the team @nrc-cnrc/egsnrc as the code owner for all files in the repository, so reviews by members of that team will automatically be requested. In time, code owners can be added, expecially for external contributions, so that the original authors can be notified and review changes to their code. The file is added inside the `EGSnrc/.github` directory.