### PR TITLE
Change egsphant format to allow up to 95 materials

### DIFF
--- a/HEN_HOUSE/omega/progs/ctcreate/ctcreate.mortran
+++ b/HEN_HOUSE/omega/progs/ctcreate/ctcreate.mortran
@@ -2074,11 +2074,11 @@ WRITE(15,*) (ybnd(jj),jj=1,jjmax+1);
 WRITE(15,*) (zbnd(kk),kk=1,kkmax+1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
-        WRITE(15,1399) (med($IR(ii,jj,kk)),ii=1,iimax);
+        WRITE(15,1399) (achar(MOD((med($IR(ii,jj,kk))+16),95) + 32),ii=1,iimax);
     ]
     WRITE(15,*);
 ]
-1399 FORMAT($IMAXi1);
+1399 FORMAT($IMAXa1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
         WRITE(15,*) (rho($IR(ii,jj,kk)),ii=1,iimax);

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -1349,6 +1349,8 @@ REAL z_score_tmp; "dummy variable passed to IAEA phsp file opening macro"
 
 external combine_results;
 
+character medChar($IMAX);
+
 #ifdef HAVE_C_COMPILER;
 $REAL   part_dose, part2_dose, current_result, current_uncertainty;
 $LONG_INT n_run,n_tot,n_last,n_left,other_num_1,other_num_2,p_per_phsp_chunk;
@@ -1511,14 +1513,21 @@ IF(NMED = 0)[ "Input data from CT data file as processed by the code ctcreate"
     (/' x range : ',F12.5,' - ',F12.5,' cm'/
       ' y range : ',F12.5,' - ',F12.5,' cm'/
       ' z range : ',F12.5,' - ',F12.5,' cm');
+
     "input the media numbers"
     DO k=1,KMAX[
        DO j=1,JMAX[
-          read($CTUnitNumber,:medformat:) (med($IR(i,j,k)),i=1,IMAX);
+          "Read in the characters that correspond to medium numbers"
+          read($CTUnitNumber,:medformat:) (medChar(i),i=1,IMAX);
+          "Convert from ASCII to a number"
+          DO i=1,IMAX[
+            med($IR(i,j,k)) = mod((iachar(medChar(i)) + 47), 95);
+          ]
        ]
        read($CTUnitNumber,*);
     ]
-    :medformat: FORMAT($IMAXi1);
+    :medformat: FORMAT($IMAXa1);
+
     "input the densities"
     maxrhor=0.;
     minrhor=999.;
@@ -4532,11 +4541,12 @@ WRITE(iunit,*) (ybnd(jj),jj=1,jjmax+1);
 WRITE(iunit,*) (zbnd(kk),kk=1,kkmax+1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
-        WRITE(iunit,1399) (med($IRWP(ii,jj,kk)),ii=1,iimax);
+        WRITE(iunit,1399) (achar(MOD((med($IRWP(ii,jj,kk))+16),95) + 32),
+            ii=1,iimax);
     ]
     WRITE(iunit,*);
 ]
-1399 FORMAT($IMAXi1);
+1399 FORMAT($IMAXa1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
         WRITE(iunit,*) (rho($IRWP(ii,jj,kk)),ii=1,iimax);


### PR DESCRIPTION
Change the egsphant reading/writing algorithms in ctcreate and DOSXYZnrc so that up to 95 materials are allowed. Previously, for media indices greater than 9 they were replaced with `*` and the resulting egsphant file would not be valid, resulting in a crash in DOSXYZnrc.

As per Fred's suggestion below, the full range of 95 ASCII printable characters are used for the material indices in the egsphant file. This makes the file slightly less human-readable, but is backwards compatible (expanding to 2 digits per index is not). I made a change from his indexing scheme so that it starts from 0.

```
>>> nums  = [ i for i in range(0,95) ]
>>> chars = [ chr((i+16) % 95 + 32) for i in nums ]
>>> index = [ (ord(c)+47) % 95 for c in chars ]

>>> nums
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94]
>>> chars
['0', '1', '2', '3', '4', '5', '6', '7', '8', '9', ':', ';', '<', '=', '>', '?', '@', 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', '[', '\\', ']', '^', '_', '`', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z', '{', '|', '}', '~', ' ', '!', '"', '#', '$', '%', '&', "'", '(', ')', '*', '+', ',', '-', '.', '/']
>>> index
[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94]
```

This didn't require any changes to egs++ or egs_view, because the XYZ geometry uses the ramp file to assign materials. Other custom codes will need to be updated in order to read new phantoms with >9 materials, but phantoms generated with <=9 materials will still be backward compatible because the indexing starts at 0.

**3rd party codes** that I know of that might want to update: `3ddose_tools`, `egs_brachy`, `CERR` (I'm not sure if it reads egsphant, but it does read 3ddose).