### PR TITLE
Fix dosxyz_gui help text for phsp output

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_main_inputs_egsnrc.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/set_main_inputs_egsnrc.tcl
@@ -338,7 +338,7 @@ proc edit_parameters {} {
 
     # option to score IAEA phase space data if isource=2,4,8,9,10,20,21
     frame $w2.dflag.phsp
-    button $w2.dflag.phsp.help -text "?" -command "help dflag"
+    button $w2.dflag.phsp.help -text "?" -command "help iphspout"
     label $w2.dflag.phsp.lab -text "Phase space output on exiting phantom"
     menubutton $w2.dflag.phsp.inp -text $phspoutopt($iphspout) -width 20\
                 -menu $w2.dflag.phsp.inp.m -bd 1 -relief raised -indicatoron 1

--- a/HEN_HOUSE/omega/progs/gui/dosxyznrc/xyznrc_parameters.tcl
+++ b/HEN_HOUSE/omega/progs/gui/dosxyznrc/xyznrc_parameters.tcl
@@ -682,6 +682,19 @@ set dflagopt(0) "uniform"
 set dflagopt(1) "non-uniform"
 set dflag $dflagopt(0)
 
+set help_text(iphspout) {
+For outputting IAEA format phase space data on exit\
+from the phantom geometry (i_phsp_out). If i_phsp_out=1, then data\
+is output in DOSXYZnrc coordinates. If i_phsp_out=2\
+data is output in BEAMnrc coordinates. This option is\
+only available for phase space or BEAMnrc simulation\
+sources (which have a region surrounding the phantom).\
+The default is i_phsp_out=0: no phase space\
+output. If you are using source 20 or source 21\
+(synchronized sources) then you also have the option of\
+storing the MU index (frMU_indx) in the phase space file (see source inputs).
+}
+
 set phspoutopt(0) "none"
 set phspoutopt(1) "in DOSXYZnrc coordinates"
 set phspoutopt(2) "in BEAMnrc coordinates"


### PR DESCRIPTION
Fix the dosxyz_gui help text for phase-space output on exiting the phantom. I based the text on what is in the manual for the parameter. Previously, the help text for the `dsurround` parameter would show instead.