### PR TITLE
Fix a typo that made EEMF fail to compile

### DIFF
--- a/HEN_HOUSE/src/EEMF_macros.mortran
+++ b/HEN_HOUSE/src/EEMF_macros.mortran
@@ -26,12 +26,12 @@
 "  Contributors:    Dave Rogers                                               "
 "                                                                             "
 "#############################################################################"
-#                                                                             "
-#  When using EEMF macros for publications, please cite our paper:            "
-#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in    "
-#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                          "
-#                                                                             "
-##############################################################################"
+"#                                                                            "
+"#  When using EEMF macros for publications, please cite our paper:           "
+"#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in   "
+"#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                         "
+"#                                                                            "
+"#############################################################################"
 
 
 "******************************************************************************"

--- a/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
+++ b/HEN_HOUSE/src/EEMF_macros_beamnrc.mortran
@@ -26,12 +26,12 @@
 "  Contributors:    Dave Rogers                                               "
 "                                                                             "
 "#############################################################################"
-#                                                                             "
-#  When using EEMF macros for publications, please cite our paper:            "
-#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in    "
-#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                          "
-#                                                                             "
-##############################################################################"
+"#                                                                            "
+"#  When using EEMF macros for publications, please cite our paper:           "
+"#  VN Malkov, DWO Rogers. Charged particle transport in magnetic fields in   "
+"#  EGSnrc. Medical Physics 43, pp. 4447-4458 (2016).                         "
+"#                                                                            "
+"#############################################################################"
 
 
 "******************************************************************************"


### PR DESCRIPTION
Fix a typo in the comments for EEMF, that made compilation fail. This must have a been a last-minute change that didn't get tested.