### PR TITLE
Set $EGS_HOME & $HEN_HOUSE for egs++ beam sources

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -84,15 +84,35 @@ EGS_BeamSource::EGS_BeamSource(EGS_Input *input, EGS_ObjectFactory *f) :
     if (err1 || err2 || err3) {
         return;
     }
-    char *egs_home = getenv("EGS_HOME");
-    if (!egs_home) {
-        egsWarning("EGS_BeamSource: EGS_HOME is not defined\n");
-        return;
+    string egs_home;
+    int err_eh = input->getInput("egs_home",egs_home);
+    if (err_eh) {
+        char *eh = getenv("EGS_HOME");
+        if (!eh) {
+            egsWarning("EGS_BeamSource: EGS_HOME is not defined\n");
+            return;
+        }
+        else {
+            egs_home = eh;
+        }
     }
-    char *hen_house = getenv("HEN_HOUSE");
-    if (!hen_house) {
-        egsWarning("EGS_BeamSource: HEN_HOUSE is not defined\n");
-        return;
+    else {
+        egs_home = egsExpandPath(egs_home);
+    }
+    string hen_house;
+    int err_hh = input->getInput("hen_house",hen_house);
+    if (err_hh) {
+        char *hh = getenv("HEN_HOUSE");
+        if (!hh) {
+            egsWarning("EGS_BeamSource: HEN_HOUSE is not defined\n");
+            return;
+        }
+        else {
+            hen_house = hh;
+        }
+    }
+    else {
+        hen_house = egsExpandPath(hen_house);
     }
     string path = egs_home;
     path += "bin/";
@@ -136,9 +156,9 @@ EGS_BeamSource::EGS_BeamSource(EGS_Input *input, EGS_ObjectFactory *f) :
         npar = app->getNparallel();
     }
 
-    init(&ipar,&npar,&ilog,hen_house,egs_home,beam_code.c_str(),
-         pegs_file.c_str(),input_file.c_str(),
-         strlen(hen_house), strlen(egs_home),
+    init(&ipar,&npar,&ilog,hen_house.c_str(),egs_home.c_str(),
+         beam_code.c_str(),pegs_file.c_str(),input_file.c_str(),
+         hen_house.size(), egs_home.size(),
          beam_code.size(),pegs_file.size(),input_file.size());
     maxenergy(&Emax);
 


### PR DESCRIPTION
EGSnrc's work area can be changed to an arbitrary folder by redefining
`$EGS_HOME` on the command line (-e new_eh_path for interactive runs or
eh=new_eh_path for parallel runs). However, if an egs++ app uses a BEAM
source library, there was no way to reset `$EGS_HOME` for it.

Added the ability to redefine `$EGS_HOME` and `$HEN_HOUSE` for egs++
beam sources via the input block for an **EGS_BeamSource** object. Besides
entering the input file and pegs4 file names, one can now also use

```
:start source:
    library = egs_beam_source
    ...
    egs_home = new_eh_path/
    hen_house = new_hh_path/
    ...
:stop source:
```

This is useful for working on arbitrary folders for different projects. In
this case a symbolic link to the `$EGS_HOME/bin` and `$EGS_HOME/pegs4` folders
will be required on the project location.