### PR TITLE
Fix the dose values in egs++ 3ddose output

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -428,7 +428,7 @@ public:
 
     EGS_Float getMediumRho(int ind) const;
 
-    void setApplication(EGS_Application *app);
+    virtual void setApplication(EGS_Application *app);
 
     /*! \brief Does this geometry object have a B field scaling feature?
      */
@@ -855,6 +855,9 @@ protected:
         are also useful to track region numbers upon modyfying the geometry.
      */
     vector<label> labels;
+
+    /*! \brief The application this object belongs to */
+    EGS_Application *app;
 
 private:
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -42,6 +42,7 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 #include "egs_transformations.h"
+#include "egs_application.h"
 
 #ifdef HAS_GZSTREAM
     #include "gzstream.h"
@@ -171,6 +172,8 @@ EGS_XYZGeometry::EGS_XYZGeometry(EGS_PlanesX *Xp, EGS_PlanesY *Yp,
     xpos = xp->getPositions();
     ypos = yp->getPositions();
     zpos = zp->getPositions();
+
+    setApplication(EGS_Application::activeApplication());
 }
 
 EGS_XYZGeometry::~EGS_XYZGeometry() {

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -588,6 +588,7 @@ private:
 
 #ifdef EXPLICIT_XYZ
 #include "../egs_planes/egs_planes.h"
+#include "egs_application.h"
 
 /*! \brief An XYZ-geometry
 
@@ -1123,8 +1124,38 @@ public:
             int ix = ir - iy*nx;
             EGS_Float vol = (xpos[ix+1]-xpos[ix])*(ypos[iy+1]-ypos[iy])*
                             (zpos[iz+1]-zpos[iz]);
-            EGS_Float dens = getRelativeRho(ireg);
+
+            EGS_Float dens;
+            if (has_rho_scaling) {
+                dens = getRelativeRho(ireg);
+            }
+            else {
+                // We should only get here for the XYZ geometry
+
+                // Calculate the voxel midpoint
+                EGS_Vector tp;
+                EGS_Float minx,maxx,miny,maxy,minz,maxz;
+                minx=getBound(0,ix);
+                maxx=getBound(0,ix+1);
+                miny=getBound(1,iy);
+                maxy=getBound(1,iy+1);
+                minz=getBound(2,iz);
+                maxz=getBound(2,iz+1);
+                tp.x=(minx+maxx)/2.;
+                tp.y=(miny+maxy)/2.;
+                tp.z=(minz+maxz)/2.;
+
+                // Get the global region number from the current voxel midpoint
+                int g_reg = app->isWhere(tp);
+
+                // Get the medium index for this region
+                int imed = app->getMedium(g_reg);
+
+                // Get the density
+                dens = app->getMediumRho(imed);
+            }
             EGS_Float mass = vol*dens;
+
             return mass;
         }
         else {
@@ -1239,6 +1270,10 @@ public:
     void getZLabelRegions(const string &str, vector<int> &regs) {
         zp->getLabelRegions(str, regs);
     }
+
+    void setApplication(EGS_Application *App) {
+        app = App;
+    };
 
 protected:
 


### PR DESCRIPTION
Fix the value of dose in 3ddose files generated from egs++ apps using `egs_dose_scoring`. The dose was not being scaled by the correct mass/density of materials, because the `getMass` function in the ND geometry was not functioning properly for XYZ geometries unless they were defined using an egsphant file or density file. In other words, the dose was wrong if the XYZ geometry boundaries were defined using "slabs" or "planes". 

This is a critical bug in the value of dose reported and has been an issue since the ability to generate 3ddose files was added to `egs_dose_scoring`. Any old dose in 3ddose files generated this way should be considered unreliable, due to the undefined value of density, and those simulations should be repeated.

Note that the doses reported by `egs_dose_scoring` by material, or by region were correct. Only the dose in 3ddose files from `egs_dose_scoring` has this issue. All 3ddose files from DOSXYZnrc are not affected.

Big thanks to our reddit user u/5xum for reporting this issue, and @marenaud for determining it was a bug.