### PR TITLE
Fix command to get file size in configure script

### DIFF
--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -1195,7 +1195,7 @@ _ACEOF
   if { (eval $test_compile) 2>&5; test_status=$?; (exit $test_status); }; then
     test_run=$(./conftest$test_exeext)
     if test "x$test_run" = xyes; then
-      junk_size=$(stat -c '%s' junk_file)
+      junk_size=$(printf %d $(wc -c <junk_file))
       if test "x$junk_size" = x4; then
         know_recl=yes
         recl_size=$recl


### PR DESCRIPTION
Use `wc -c` to obtain the number of bytes in the temporary file when determining the Fortran record length during EGSnrc configuration. The problem with `stat -c` is that it is not standard; for example, there is no `-c` option in BSD variants (macOS). Using the `stat` command is a regression introduced in issue #616 to remove a dependency on the format of the `ls` output.