### PR TITLE
Fix phsp output with photon splitting

### DIFF
--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -853,9 +853,11 @@ IF( n_split > 1 ) [  "we use photon splitting"
               ]
               IF( medium ~= 0 ) dpmfp = dpmfp - ustep/gmfp;
               IF( irnew ~= irold ) [
-                  ir(np) = irnew; irl = irnew; irold = irnew;
+                  ir(np) = irnew; irl = irnew;
                   medium = med(irl);
               ]
+              $AUSCALL($TRANAUSA);
+              irold = ir(np);
               IF (IWATCH>0) CALL WATCH($TRANAUSA,IWATCH);
           ] UNTIL (medium ~= 0 & dpmfp < $EPSGMFP);
           x_save = x(np); y_save = y(np); z_save = z(np);


### PR DESCRIPTION
Photons were not included in the phase space data.  This is because $AUSCALL($TRANAUSA) (call to ausgab after particle step) was not included in the $SELECT-PHOTON-MFP macro that handles splitting in dosxyznrc.