### PR TITLE
Fix bug in precision goal in g and 1 keV round-off

### DIFF
--- a/HEN_HOUSE/src/egsnrc.macros
+++ b/HEN_HOUSE/src/egsnrc.macros
@@ -771,7 +771,7 @@ X-OPTIONS/;
 " use the a lower threshold.
 "***************************************************************************"
 "============================================================"
-REPLACE {$RELAX-CUTOFF} WITH {0.001"threshold energy for outer shells"}
+REPLACE {$RELAX-CUTOFF} WITH {0.001D0"threshold energy for outer shells"}
 REPLACE {$MXPESHELL} WITH {16} "K,L1..L3,M1..M5,N1..N7 + outer shell"
 REPLACE {$MXNE} WITH {500}     "number of energy points per shell "
 "============================================================"

--- a/HEN_HOUSE/user_codes/g/g.mortran
+++ b/HEN_HOUSE/user_codes/g/g.mortran
@@ -230,6 +230,14 @@ REPLACE {$DEBUGIT} WITH {.false.} "that can be used for debugging purposes"
 REPLACE {$MXGE} WITH {2000}
 REPLACE {$MXCHUNK} WITH {10000}
 
+"Round-off errors produce wrong results for a 1 keV energy value."
+"The quick fix is to add an epsilon equal to or larger than 1.0D-12 eV."
+"Using here a slightly larger epsilon of 1.0D-4 eV to account for "
+"machine precision differences. This should still be negligible in "
+"the keV energy range."
+REPLACE {$E_THRESHOLD} WITH {1.0D-3}; "Minimum energy in EGSnrc"
+REPLACE {$E_EPS}       WITH {1.0D-10};"Shifted by small epsilon"
+
 "Replace the $CALL-HOWNEAR macro for an infinite homogeneous geometry"
 REPLACE {$CALL-HOWNEAR(#);} WITH {;
   {P1} = 1e10;
@@ -400,6 +408,9 @@ IF((iqin~=0 & ekmax+rm > ue(1)) | (iqin=0 & ekmax > up(1)))[
    STOP;
 ]
 
+"Increase minimum energy by small epsilon to prevent round-off errors"
+"at 1 keV and below"
+call source_check_emin();
 
 "---------------------------------------------------------------------"
 "STEP 7   SHOWER-CALL                                                 "
@@ -475,7 +486,12 @@ IF( calc_type = 1 ) [  "will seek a given precision -- default does not do this"
        is used for energies under 100 keV where the original
        implementation is more efficient. An exception would be Ir-192.
     **********************************************************************/
-    accu0 = accu; m = m_balance;
+    IF (itimes = 1) ["Only do this on 1st energy"
+       accu0 = accu; m = m_balance;
+    ]"end itimes = 1 block"
+
+    "Update for each energy since accu "
+    "changes in the 1-g calculation block"
     IF (m > 1)[
        accu = accu0/sqrt(m);
     ]
@@ -1399,7 +1415,7 @@ $INTEGER mono;
 $INTEGER nensrc,mode,iqi;
 $REAL    ensrcd(0:$NENSRC),srcpdf($NENSRC),srcpdf_at($NENSRC);
 $INTEGER srcbin_at($NENSRC);
-$INTEGER i;
+$INTEGER i,j;
 $REAL    ei,eave,sum,ui,vi,wi;
 real*8   esum,esum2,ecount,aux,aux2;
 
@@ -1631,6 +1647,34 @@ ELSE IF( mono = 2 | mono = 3 ) [
 ]
 ELSE [
     emax = ensrcd(nensrc);
+]
+return;
+
+entry source_check_emin();
+"=========================="
+"Set to 1 keV plus a small epsilon"
+"if minimum energy is 1 keV or less"
+IF( mono = 0 ) [
+  j = 1;
+  DO i=2,neis[
+     IF( eis(i) < eis(j) ) [
+       j = i;
+     ]
+  ]
+  IF ( eis(j) - abs(iqi)*rm <= $E_THRESHOLD)[
+       eis(j) = $E_THRESHOLD + $E_EPS + abs(iqi)*rm;
+  ]
+]
+ELSE IF( mono = 2 | mono = 3 ) [
+  IF ( eis(1) - abs(iqi)*rm <= $E_THRESHOLD)[
+       eis(1) = $E_THRESHOLD + $E_EPS + abs(iqi)*rm;
+  ]
+]
+ELSE [
+    emax = ensrcd(nensrc);
+  IF ( ensrcd(0) - abs(iqi)*rm <= $E_THRESHOLD)[
+       ensrcd(0) = $E_THRESHOLD + $E_EPS + abs(iqi)*rm;
+  ]
 ]
 return;
 


### PR DESCRIPTION
This pull request addresses a bug in `g.mortran` in a type 1 calculation for multiple energies whereby the precision goal is reduced at every energy step potentially making the calculation last very long. Bug reported by @dworogers. 

Two other fixes are included in this pull request. See the list below for more information:

- For `calculation type 1` set desired uncertainty `accu0` at the first step of the energy loop. The value of `accu`
  must be updated for each energy since it is different for the `mutr` and `1-g` calculation blocks. Fixes issue #665.

- Round-off errors produce wrong results for a 1 keV energy value. The quick fix is to add an epsilon equal to or larger than 1.0D-18 MeV. Using here a slightly larger epsilon of 1.0D-10 MeV to account for machine precision differences. This should still be negligible in the keV energy range:

```
  REPLACE {$E_THRESHOLD} WITH {1.0D-3}; "Minimum energy in EGSnrc"
  REPLACE {$E_EPS}       WITH {1.0D-10};"Shifted by small epsilon"
```

- Finally set `$RELAX-CUTOFF` in `egsnrc.macros` to 0.001D0 to make it a double precision constant fixing the annoying warning messages from `subroutine egs_shellwise_photo`. Fixes issue #495.