### PR TITLE
Change radionuclide source to use position/direction sampling from any other source

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Reid Townson, 2016
 #
-#  Contributors:
+#  Contributors:	Martin Martinov, 2021
 #
 ###############################################################################
 */
@@ -41,11 +41,7 @@
 
 EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSource(input,f),
-    sourceType(""), shape(0),
-    geom(0), regions(0), nrs(0), min_theta(0), max_theta(M_PI),
-    min_phi(0), max_phi(2*M_PI), gc(IncludeAll),
-    source_shape(0), target_shape(0), ctry(0), dist(1),
-    q_allowed(0), decays(0), activity(1) {
+    baseSource(0), q_allowed(0), decays(0), activity(1), sCount (0) {
 
     int err;
     vector<int> tmp_q;
@@ -152,155 +148,17 @@ EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
     // Get the active application
     app = EGS_Application::activeApplication();
 
-    // ==========================
-    // Source type = isotropic
-    // ==========================
-
-    err = input->getInput("source type",sourceType);
-    if (err || input->compare(sourceType,"isotropic")) {
-        sourceType = "isotropic";
-
-        egsInformation("EGS_RadionuclideSource: Source type: %s\n",sourceType.c_str());
-
-        // Create the shape for source emissions
-        vector<EGS_Float> pos;
-        EGS_Input *ishape = input->takeInputItem("shape");
-        if (ishape) {
-            shape = EGS_BaseShape::createShape(ishape);
-            delete ishape;
-        }
-        if (!shape) {
-            string sname;
-            err = input->getInput("shape name",sname);
-            if (err)
-                egsWarning("EGS_RadionuclideSource: missing/wrong inline shape "
-                           "definition and missing wrong 'shape name' input\n");
-            else {
-                shape = EGS_BaseShape::getShape(sname);
-                if (!shape) egsWarning("EGS_RadionuclideSource: a shape named %s"
-                                           " does not exist\n");
-            }
-        }
-        string geom_name;
-        err = input->getInput("geometry",geom_name);
-        if (!err) {
-            geom = EGS_BaseGeometry::getGeometry(geom_name);
-            if (!geom) egsWarning("EGS_RadionuclideSource: no geometry named %s\n",
-                                      geom_name.c_str());
-            else {
-                vector<string> reg_options;
-                reg_options.push_back("IncludeAll");
-                reg_options.push_back("ExcludeAll");
-                reg_options.push_back("IncludeSelected");
-                reg_options.push_back("ExcludeSelected");
-                gc = (GeometryConfinement) input->getInput("region "
-                        "selection",reg_options,0);
-                if (gc == IncludeSelected || gc == ExcludeSelected) {
-                    vector<int> regs;
-                    err = input->getInput("selected regions",regs);
-                    if (err || regs.size() < 1) {
-                        egsWarning("EGS_RadionuclideSource: region selection %d "
-                                   "used  but no 'selected regions' input "
-                                   "found\n",gc);
-                        gc = gc == IncludeSelected ? IncludeAll : ExcludeAll;
-                        egsWarning(" using %d\n",gc);
-                    }
-                    nrs = regs.size();
-                    regions = new int [nrs];
-                    for (int j=0; j<nrs; j++) {
-                        regions[j] = regs[j];
-                    }
-                }
-            }
-        }
-        EGS_Float tmp_theta;
-        err = input->getInput("min theta", tmp_theta);
-        if (!err) {
-            min_theta = tmp_theta/180.0*M_PI;
-        }
-
-        err = input->getInput("max theta", tmp_theta);
-        if (!err) {
-            max_theta = tmp_theta/180.0*M_PI;
-        }
-
-        err = input->getInput("min phi", tmp_theta);
-        if (!err) {
-            min_phi = tmp_theta/180.0*M_PI;
-        }
-
-        err = input->getInput("max phi", tmp_theta);
-        if (!err) {
-            max_phi = tmp_theta/180.0*M_PI;
-        }
-
-        buf_1 = cos(min_theta);
-        buf_2 = cos(max_theta);
-    }
-
-    // ==========================
-    // Source type = collimated
-    // ==========================
-
-    else if (input->compare(sourceType,"collimated")) {
-        sourceType = "collimated";
-
-        egsInformation("EGS_RadionuclideSource: Source type: %s\n",sourceType.c_str());
-
-        EGS_Input *ishape = input->takeInputItem("source shape");
-        if (ishape) {
-            source_shape = EGS_BaseShape::createShape(ishape);
-            delete ishape;
-        }
-        if (!source_shape) {
-            string sname;
-            int err = input->getInput("source shape name",sname);
-            if (err)
-                egsWarning("EGS_RadionuclideSource: missing/wrong inline source "
-                           "shape definition and missing/wrong 'source shape name' input\n");
-            else {
-                source_shape = EGS_BaseShape::getShape(sname);
-                if (!source_shape)
-                    egsWarning("EGS_RadionuclideSource: a shape named %s"
-                               " does not exist\n",sname.c_str());
-            }
-        }
-        ishape = input->takeInputItem("target shape");
-        if (ishape) {
-            target_shape = EGS_BaseShape::createShape(ishape);
-            delete ishape;
-        }
-        if (!target_shape) {
-            string sname;
-            int err = input->getInput("target shape name",sname);
-            if (err)
-                egsWarning("EGS_RadionuclideSource: missing/wrong inline target"
-                           "shape definition and missing/wrong 'target shape name' input\n");
-            else {
-                target_shape = EGS_BaseShape::getShape(sname);
-                if (!target_shape)
-                    egsWarning("EGS_RadionuclideSource: a shape named %s"
-                               " does not exist\n",sname.c_str());
-            }
-        }
-        if (target_shape) {
-            if (!target_shape->supportsDirectionMethod())
-                egsWarning("EGS_RadionuclideSource: the target shape %s, which is"
-                           " of type %s, does not support the getPointSourceDirection()"
-                           " method\n",target_shape->getObjectName().c_str(),
-                           target_shape->getObjectType().c_str());
-        }
-        EGS_Float auxd;
-        int errd = input->getInput("distance",auxd);
-        if (!errd) {
-            dist = auxd;
-        }
-
-    }
-    else {
-        egsFatal("EGS_RadionuclideSource: a source type named %s"
-                 " does not exist\n",sourceType.c_str());
-    }
+    // Import base source
+    err = input->getInput("base source",sName);
+	if (err) {
+		egsWarning("EGS_RadionuclideSource: base source must be defined\n"
+				   "using 'base source = some_name'\n");
+	}
+	baseSource = EGS_BaseSource::getSource(sName);
+	if (!baseSource) {
+		egsWarning("EGS_RadionuclideSource: no source named %s"
+				   " is defined\n",sName.c_str());
+	}
 
     // Initialize emission type to signify nothing has happened yet
     emissionType = 99;
@@ -361,8 +219,11 @@ EGS_I64 EGS_RadionuclideSource::getNextParticle(EGS_RandomGenerator *rndm, int
 
     q = decays[i]->getCharge();
 
-    getPositionDirection(rndm,x,u,wt);
-    latch = 0;
+	int qTemp (q), latchTemp (latch);
+	EGS_Float ETemp (E);
+	baseSource->getNextParticle(rndm, qTemp, latchTemp, ETemp, wt, x, u);
+	sCount++;
+	latch = 0;
 
     if (disintegrationOccurred) {
         xOfDisintegration = x;
@@ -400,103 +261,14 @@ EGS_I64 EGS_RadionuclideSource::getNextParticle(EGS_RandomGenerator *rndm, int
     return ++count;
 }
 
-void EGS_RadionuclideSource::getPositionDirection(EGS_RandomGenerator *rndm,
-        EGS_Vector &x, EGS_Vector &u, EGS_Float &wt) {
-
-    if (sourceType == "isotropic") {
-        bool ok = true;
-        do {
-            x = shape->getRandomPoint(rndm);
-            if (geom) {
-                if (gc == IncludeAll) {
-                    ok = geom->isInside(x);
-                }
-                else if (gc == ExcludeAll) {
-                    ok = !geom->isInside(x);
-                }
-                else if (gc == IncludeSelected) {
-                    ok = false;
-                    int ireg = geom->isWhere(x);
-                    for (int j=0; j<nrs; ++j) {
-                        if (ireg == regions[j]) {
-                            ok = true;
-                            break;
-                        }
-                    }
-                }
-                else {
-                    ok = true;
-                    int ireg = geom->isWhere(x);
-                    for (int j=0; j<nrs; ++j) {
-                        if (ireg == regions[j]) {
-                            ok = false;
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-        while (!ok);
-        u.z = buf_1 - rndm->getUniform()*(buf_1 - buf_2);
-        EGS_Float sinz = 1-u.z*u.z;
-        if (sinz > epsilon) {
-            sinz = sqrt(sinz);
-            EGS_Float cphi, sphi;
-            EGS_Float phi = min_phi +(max_phi - min_phi)*rndm->getUniform();
-            cphi = cos(phi);
-            sphi = sin(phi);
-            u.x = sinz*cphi;
-            u.y = sinz*sphi;
-        }
-        else {
-            u.x = 0;
-            u.y = 0;
-        }
-        wt = 1;
-    }
-    else if (sourceType == "collimated") {
-        x = source_shape->getRandomPoint(rndm);
-        int ntry = 0;
-        do {
-            target_shape->getPointSourceDirection(x,rndm,u,wt);
-            ntry++;
-            if (ntry > 10000) {
-                egsFatal("EGS_RadionuclideSource::getPositionDirection:\n"
-                         "  my target shape %s, which is of type %s, failed to\n"
-                         "  return a positive weight after 10000 attempts\n",
-                         target_shape->getObjectName().c_str(),
-                         target_shape->getObjectType().c_str());
-            }
-        }
-        while (wt <= 0);
-
-        if (disintegrationOccurred) {
-            ctry += ntry-1;
-        }
-    }
-}
-
 void EGS_RadionuclideSource::setUp() {
     otype = "EGS_RadionuclideSource";
     if (!isValid()) {
         description = "Invalid radionuclide source";
     }
     else {
-        description = "Radionuclide source of type ";
-
-        if (sourceType == "isotropic") {
-            description += sourceType;
-            description += " and a shape of type ";
-            description += shape->getObjectType();
-
-        }
-        else if (sourceType == "collimated") {
-            description += sourceType;
-            description += " from a shape of type ";
-            description += source_shape->getObjectType();
-            description += " onto a shape of type ";
-            description += target_shape->getObjectType();
-        }
+        description = "Radionuclide production in base source ";
+        description += sName;
 
         description += " with:";
         if (std::find(q_allowed.begin(), q_allowed.end(), -1) !=
@@ -512,12 +284,9 @@ void EGS_RadionuclideSource::setUp() {
         if (std::find(q_allowed.begin(), q_allowed.end(), 1) != q_allowed.end()) {
             description += " alphas";
         }
-
-        if (sourceType == "isotropic") {
-            if (geom) {
-                geom->ref();
-            }
-        }
+		
+		description += "\nBase source description:\n";
+		description += baseSource->getSourceDescription();
     }
 }
 
@@ -528,7 +297,7 @@ bool EGS_RadionuclideSource::storeState(ostream &data_out) const {
         }
     }
     egsStoreI64(data_out,count);
-    egsStoreI64(data_out,ctry);
+	baseSource->storeState(data_out);
 
     return true;
 }
@@ -543,8 +312,7 @@ bool EGS_RadionuclideSource::addState(istream &data) {
     EGS_I64 tmp_val;
     egsGetI64(data,tmp_val);
     count = tmp_val;
-    egsGetI64(data,tmp_val);
-    ctry = tmp_val;
+	baseSource->addState(data);
 
     return true;
 }
@@ -555,7 +323,7 @@ void EGS_RadionuclideSource::resetCounter() {
     }
     ishower = 0;
     count = 0;
-    ctry = 0;
+	sCount = 0;
 }
 
 bool EGS_RadionuclideSource::setState(istream &data) {
@@ -565,7 +333,7 @@ bool EGS_RadionuclideSource::setState(istream &data) {
         }
     }
     egsGetI64(data,count);
-    egsGetI64(data,ctry);
+	baseSource->setState(data);
 
     return true;
 }

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Reid Townson, 2016
 #
-#  Contributors:	Martin Martinov, 2021
+#  Contributors:
 #
 ###############################################################################
 */
@@ -41,16 +41,16 @@
 
 EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSource(input,f),
-    baseSource(0), q_allowed(0), decays(0), activity(1), sCount (0) {
+    baseSource(0), q_allowed(0), decays(0), activity(1) {
 
     int err;
     vector<int> tmp_q;
     err = input->getInput("charge", tmp_q);
     if (!err) {
         if (std::find(q_allowed.begin(), q_allowed.end(), -1) != q_allowed.end()
-                && std::find(q_allowed.begin(), q_allowed.end(), 0) != q_allowed.end()
-                && std::find(q_allowed.begin(), q_allowed.end(), 1) != q_allowed.end()
-                && std::find(q_allowed.begin(), q_allowed.end(), 2) != q_allowed.end()
+			&& std::find(q_allowed.begin(), q_allowed.end(), 0) != q_allowed.end()
+			&& std::find(q_allowed.begin(), q_allowed.end(), 1) != q_allowed.end()
+			&& std::find(q_allowed.begin(), q_allowed.end(), 2) != q_allowed.end()
            ) {
             q_allowAll = true;
         }
@@ -69,6 +69,7 @@ EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
 
     // Create the decay spectra
     count = 0;
+	sCount = 0;
     Emax = 0;
     unsigned int i = 0;
     EGS_Float spectrumWeightTotal = 0;
@@ -159,7 +160,7 @@ EGS_RadionuclideSource::EGS_RadionuclideSource(EGS_Input *input,
 		egsWarning("EGS_RadionuclideSource: no source named %s"
 				   " is defined\n",sName.c_str());
 	}
-
+	
     // Initialize emission type to signify nothing has happened yet
     emissionType = 99;
 
@@ -218,7 +219,6 @@ EGS_I64 EGS_RadionuclideSource::getNextParticle(EGS_RandomGenerator *rndm, int
     }
 
     q = decays[i]->getCharge();
-
 	int qTemp (q), latchTemp (latch);
 	EGS_Float ETemp (E);
 	baseSource->getNextParticle(rndm, qTemp, latchTemp, ETemp, wt, x, u);
@@ -297,6 +297,7 @@ bool EGS_RadionuclideSource::storeState(ostream &data_out) const {
         }
     }
     egsStoreI64(data_out,count);
+    egsStoreI64(data_out,sCount);
 	baseSource->storeState(data_out);
 
     return true;
@@ -311,7 +312,9 @@ bool EGS_RadionuclideSource::addState(istream &data) {
     }
     EGS_I64 tmp_val;
     egsGetI64(data,tmp_val);
-    count = tmp_val;
+    count += tmp_val;
+    egsGetI64(data,tmp_val);
+    sCount += tmp_val;
 	baseSource->addState(data);
 
     return true;
@@ -324,6 +327,7 @@ void EGS_RadionuclideSource::resetCounter() {
     ishower = 0;
     count = 0;
 	sCount = 0;
+	baseSource->resetCounter();
 }
 
 bool EGS_RadionuclideSource::setState(istream &data) {
@@ -333,6 +337,7 @@ bool EGS_RadionuclideSource::setState(istream &data) {
         }
     }
     egsGetI64(data,count);
+    egsGetI64(data,sCount);
 	baseSource->setState(data);
 
     return true;

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Reid Townson, 2016
 #
-#  Contributors:
+#  Contributors:	Martin Martinov, 2021
 #
 ###############################################################################
 */
@@ -137,20 +137,19 @@ on the number of disintegration events (tracked by <b> \c ishower </b>). This
 is distinct from the <b> \c ncase </b> input parameter, which is the
 number of particles returned by the source (includes relaxations etc.).
 
-A radionuclide source is defined using the following input. Notice that the
-format is similar to \ref EGS_IsotropicSource or \ref EGS_CollimatedSource.
-Be <b>careful using a collimated source</b> - it may neglect effects from the physical
-source on the spectrum, and neglect potential contributions from surrounding
-structures. Restricting the emission angles by collimation generally constitutes
-a physical approximation of your geometry and is an approximate efficiency
-enhancement technique. It is also important to note that the collimated source
-determines the fluence with \f$N/d^2\f$, where \c N is the number of
-disintegrations sampled and \c d is the user-defined minimum distance between the
-source and target shapes.
+A radionuclide source is defined using the following input. It imports a base
+source and uses the base source getNextParticle() invocation to determine decay
+location. This implementation leads to increased random number sampling than
+that strictly required in the simulation, due to the information generated in
+the base source beyond particle position that is not used in
+egs_radionuclide_source.  Thus, its probably best, though not required, that
+the base source use a monoenergetic spectrum to avoid oversampling.
+
 \verbatim
 :start source:
     name                = my_mixture
     library             = egs_radionuclide_source
+	base source 		= name of the source used to generate decay locations
     activity            = [optional, default=1] total activity of mixture,
                           assumed constant. The activity only affects the
                           emission times assigned to particles.
@@ -164,26 +163,6 @@ source and target shapes.
     experiment time     = [optional, default=0] time length of the experiment,
                           set to 0 for no time limit. Source particles generated
                           after the experiment time are not transported.
-
-    # If source type = isotropic
-    geometry            = [optional] my_geometry # see egs_isotropic_source
-    region selection    = [optional] geometry confinement option
-                          one of IncludeAll, ExcludeAll,
-                          IncludeSelected, ExcludeSelected
-    selected regions    = [required for IncludeSelected, ExcludeSelected]
-                          regions to apply geometry confinement
-    :start shape:
-        definition of the isotropic source shape
-    :stop shape:
-
-    # If source type = collimated (beware of its limitations)
-    :start source shape:
-        definition of the source shape
-    :stop source shape:
-    :start target shape:
-        definition of the target shape
-    :stop target shape:
-    distance = source-target shape min. distance
 
     :start spectrum:
         definition of an EGS_RadionuclideSpectrum (see link below)
@@ -255,9 +234,8 @@ results for non-disintegration emissions.
 :stop geometry definition:
 :start source definition:
     :start source:
-        name                = my_source
-        library             = egs_radionuclide_source
-        activity            = 28e6
+        name                = source_location
+        library             = egs_isotropic_source
         geometry            = my_envelope
         region selection    = IncludeSelected
         selected regions    = 1 2
@@ -268,6 +246,17 @@ results for non-disintegration emissions.
                 media   = H2O521ICRU
             :stop media input:
         :stop shape:
+		:start spectrum:
+			type   = monoenergetic # Input is ignored
+			energy = 1.0 # Input is ignored
+		:stop spectrum:
+    :stop source:
+	
+    :start source:
+        name                = my_source
+        library             = egs_radionuclide_source
+		base source 		= source_location
+        activity            = 28e6
         :start spectrum:
             type        = radionuclide
             nuclide     = Ir-192
@@ -284,36 +273,15 @@ class EGS_RADIONUCLIDE_SOURCE_EXPORT EGS_RadionuclideSource :
 
 public:
 
-    /*! \brief Geometry confinement options */
-    enum GeometryConfinement {
-        IncludeAll      = 0,
-        ExcludeAll      = 1,
-        IncludeSelected = 2,
-        ExcludeSelected = 3
-    };
-
     /*! \brief Constructor from input file */
     EGS_RadionuclideSource(EGS_Input *, EGS_ObjectFactory *f=0);
 
     /*! \brief Destructor */
-    ~EGS_RadionuclideSource() {
-        if (shape) {
-            EGS_Object::deleteObject(shape);
-        }
-        if (geom) {
-            if (!geom->deref()) {
-                delete geom;
-            }
-        }
-        if (nrs > 0 && regions) {
-            delete [] regions;
-        }
-        if (source_shape) {
-            EGS_Object::deleteObject(source_shape);
-        }
-        if (target_shape) {
-            EGS_Object::deleteObject(target_shape);
-        }
+    ~EGS_RadionuclideSource() {		
+        if (baseSource)
+			if (!baseSource->deref()) {
+				delete baseSource;
+			}
 
         for (vector<EGS_RadionuclideSpectrum * >::iterator it =
                     decays.begin();
@@ -336,15 +304,7 @@ public:
 
     /*! \brief Returns the current fluence (number of disintegrations) */
     EGS_Float getFluence() const {
-        if (sourceType == "isotropic") {
-            return ishower+1;
-        }
-        else if (sourceType == "collimated") {
-            double res = ctry + ishower+1;
-            return res/(dist*dist);
-        }
-
-        return ishower+1;
+        return (ishower+1)*(baseSource->getFluence()/sCount); //!< Scale ishower+1 return by fluence ratio returned by file
     };
 
     /*! \brief Returns the emission time of the most recent particle */
@@ -382,22 +342,9 @@ public:
         egsInformation("======================================================\n\n");
     };
 
-    /*! \brief Calculates the position and direction of a new source particle */
-    void getPositionDirection(EGS_RandomGenerator *rndm,
-                              EGS_Vector &x, EGS_Vector &u, EGS_Float &wt);
-
     /*! \brief Checks the validity of the source */
     bool isValid() const {
-        if (sourceType == "isotropic") {
-            return (decays.size() != 0 && shape != 0);
-        }
-        else if (sourceType == "collimated") {
-            return (decays.size() != 0 && source_shape != 0 &&
-                    target_shape != 0 &&
-                    target_shape->supportsDirectionMethod());
-        }
-
-        return false;
+        return baseSource;
     };
 
     /*! \brief Store the source state to the data stream \a data_out.
@@ -439,23 +386,9 @@ private:
 
     void setUp();
 
-    string sourceType;
-
-    // Isotropic source inputs
-    EGS_BaseShape *shape;  //!< The shape from which particles are emitted.
-    EGS_BaseGeometry    *geom; //!< A reference geometry for the source shape
-    int                 *regions; //!< Regions to include/exclude from the reference geometry
-    int       nrs; //!< Number of reference regions
-    EGS_Float min_theta, max_theta; //!< Minimum and maximum theta angle of emission
-    EGS_Float min_phi, max_phi; //!< Minimum and maximum phi angle of emission
-    EGS_Float buf_1, buf_2;
-    GeometryConfinement gc; //!< The geometry confinement mode
-
-    // Collimated source inputs
-    EGS_BaseShape *source_shape,  //!< The source shape
-                  *target_shape;  //!< The target shape
-    EGS_I64       ctry;           //!< Number of attempts to sample a particle
-    EGS_Float     dist;           //!< Source-target shape min. distance
+    string sName; //!< Name of the base source
+    EGS_I64 sCount; //!< Name of the base source
+    EGS_BaseSource *baseSource; //!< Pointer to the base source
 
     vector<int>         q_allowed; //!< A list of allowed charges
     vector<EGS_RadionuclideSpectrum *> decays; //!< The radionuclide decay structure


### PR DESCRIPTION
The implementation of egs_radionuclude_source is changed so
that it takes an input 'base source' instead of defining a
collimated or isotropic source.  This way you can use any
of the egs sources or a custom egs source to define the
location of the radionuclide in the simulation.  The change
in particular was made towards fast simulations targeted
radionuclide therapy across a whole patient phantom.