### PR TITLE
Update compiler flags to require c++14 standard

### DIFF
--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -93,7 +93,7 @@ unix {
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"
 
-QMAKE_CXXFLAGS+=-std=c++11
+QMAKE_CXXFLAGS+=-std=c++14
 UI_DIR = .ui/$$my_machine
 MOC_DIR = .moc/$$my_machine
 OBJECTS_DIR = .obj/$$my_machine

--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -940,14 +940,14 @@ void MCompiler::setUpCPPCompiler(const QString& link_to_name){
     vopt = QString();
   }
   else if ( the_name.contains("g++") ){
-    optimiz  = "-O2 -mtune=native -DWIN32";
+    optimiz  = "-O2 -mtune=native -std=c++14 -DWIN32";
   }
   else if (the_name.toLower()== "icpc"){
     optimiz  = "-O2 -no-prec-div -fp-model fast=2 -DWIN32";
   }
 #else
   if ( the_name.contains("g++") ){
-    optimiz  = "-O2 -mtune=native";
+    optimiz  = "-O2 -mtune=native -std=c++14";
   }
   else if (the_name.toLower()== "icpc"){
     optimiz  = "-O2 -no-prec-div -fp-model fast=2";

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -165,7 +165,7 @@ if test $create_config=yes; then
 
 case $CXX in
 
-    *g++*) opt="-O2 -mtune=native";;# mingw32-g++ and g++4 also taken into account
+    *g++*) opt="-O2 -mtune=native -std=c++14";;# mingw32-g++ and g++4 also taken into account
     icpc)  opt="-O2 -no-prec-div -fp-model fast=2";;
     icc)   opt="-O2 -no-prec-div -fp-model fast=2";;
     cl)    opt="-Ox -Ob2 -MD -GX -GR -nologo";;


### PR DESCRIPTION
The `egs_view` gui already specifies c++11, and the new mesh geometry also requires c++11. These changes are extracted from #637 to create a distinct commit, and updated to c++14 while we are at it.