### PR TITLE
Change endl to \n in egs++ scoring to improve performance

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -421,7 +421,7 @@ void EGS_DoseScoring::outputDoseFile(const EGS_Float &normD) {
         int ny=dose_geom->getNRegDir(1);
         int nz=dose_geom->getNRegDir(2);
         //output no. of voxels in x,y,z
-        df_out << nx << " " << ny << " " << nz << endl;
+        df_out << nx << " " << ny << " " << nz << "\n";
         //use single precision real for output
         float bound, dose, doseun;
         //output voxel boundaries
@@ -429,17 +429,17 @@ void EGS_DoseScoring::outputDoseFile(const EGS_Float &normD) {
             bound=dose_geom->getBound(0,i);
             df_out << bound << " ";
         }
-        df_out << endl;
+        df_out << "\n";
         for (int j=0; j<=ny; j++) {
             bound=dose_geom->getBound(1,j);
             df_out << bound << " ";
         }
-        df_out << endl;
+        df_out << "\n";
         for (int k=0; k<=nz; k++) {
             bound=dose_geom->getBound(2,k);
             df_out << bound << " ";
         }
-        df_out << endl;
+        df_out << "\n";
         //divide dose by mass and output
         for (int i=0; i<nx*ny*nz; i++) {
             doseF->currentResult(i,r,dr);
@@ -447,7 +447,7 @@ void EGS_DoseScoring::outputDoseFile(const EGS_Float &normD) {
             dose=r*normD/mass;
             df_out << dose << " ";
         }
-        df_out << endl;
+        df_out << "\n";
         //output uncertainties
         for (int i=0; i<nx*ny*nz; i++) {
             doseF->currentResult(i,r,dr);
@@ -460,7 +460,7 @@ void EGS_DoseScoring::outputDoseFile(const EGS_Float &normD) {
             doseun=dr;
             df_out << doseun << " ";
         }
-        df_out << endl;
+        df_out << "\n";
         df_out.close();
     }
     else {

--- a/HEN_HOUSE/egs++/egs_scoring.h
+++ b/HEN_HOUSE/egs++/egs_scoring.h
@@ -145,7 +145,7 @@ public:
         //sum += tmp; sum2 += tmp*tmp; tmp = 0;
         //data << current_ncase << "  " << sum << "  " << sum2 << endl;
         data << current_ncase << "  " << sum+tmp << "  " << sum2+tmp *tmp
-             << endl;
+             << "\n";
         return data.good();
     };
 
@@ -314,14 +314,14 @@ public:
       EGS_ScoringSingle::storeData function.
     */
     bool storeState(ostream &data) {
-        data << nreg << "  " << current_ncase_short << endl;
+        data << nreg << "  " << current_ncase_short << "\n";
         if (!egsStoreI64(data,current_ncase)) {
             return false;
         }
         if (!egsStoreI64(data,current_ncase_65536)) {
             return false;
         }
-        data << endl;
+        data << "\n";
         for (int j=0; j<nreg; j++) {
             if (!result[j].storeState(data)) {
                 return false;


### PR DESCRIPTION
Change a few occurances of `endl` to `\n` in egs++ mid-simulation scoring routines, to increase performance. The reason for this is that `endl` performs a buffer flush each time, which I believe is not necessary. The takeaway here is to never use `<< endl` unless you actually want the flush.

The performance hit was huge for large arrays, like a 300x300x300 3ddose file. On linux this was a 50% speedup on the total simulation time, on windows 400%. For smaller scoring arrays (i.e. most cases) the speedup will be minimal.

There is an outstanding problem that even with these changes, egs++ simulations with large 3ddose files are many times slower than dosxyznrc (2-30x slower), entirely due to the storeState function. This might be fixed if we remove ostream and use fprintf instead, but that would probably require updating the storeState functions across all of egs++. Or if we changed the egsdat file to be binary... This is under discussion here: https://github.com/nrc-cnrc/EGSnrc/discussions/688

Note that a partial work-around is to use `nbatch=1`.

Thanks to @ojalaj for reporting this!