### PR TITLE
Fix g bug: SEGFAULT when using spectrum

### DIFF
--- a/HEN_HOUSE/user_codes/g/g.mortran
+++ b/HEN_HOUSE/user_codes/g/g.mortran
@@ -1671,7 +1671,6 @@ ELSE IF( mono = 2 | mono = 3 ) [
   ]
 ]
 ELSE [
-    emax = ensrcd(nensrc);
   IF ( ensrcd(0) - abs(iqi)*rm <= $E_THRESHOLD)[
        ensrcd(0) = $E_THRESHOLD + $E_EPS + abs(iqi)*rm;
   ]


### PR DESCRIPTION
g app crashes when used for a spectrum due to a superfluous command left
in entry point `source_check_emin` copied from entry `point source_get_emax` 
during implementation of the former.

Thanks to @dworogers for reporting this bug.