### PR TITLE
Fix egs-parallel job name with invalid leading character bug

### DIFF
--- a/HEN_HOUSE/scripts/egs-parallel-pbs
+++ b/HEN_HOUSE/scripts/egs-parallel-pbs
@@ -123,6 +123,7 @@ jobname=$(echo "${basename}[$nthread]" | sed 's/^[^[:alnum:]]*//')
 trim=$(( $(echo $jobname | wc -c) - 14 ))
 if [ $trim -gt 0 ]; then
     jobname=$(echo $jobname | cut -c $trim-)
+    jobname=$(echo $jobname | sed 's/^[^[:alnum:]]*//')
 fi
 log "job name: $jobname"
 

--- a/HEN_HOUSE/scripts/egs-parallel-pbsdsh
+++ b/HEN_HOUSE/scripts/egs-parallel-pbsdsh
@@ -113,6 +113,7 @@ jobname=$(echo "${basename}[$nthread]" | sed 's/^[^[:alnum:]]*//')
 trim=$(( $(echo $jobname | wc -c) - 14 ))
 if [ $trim -gt 0 ]; then
     jobname=$(echo $jobname | cut -c $trim-)
+    jobname=$(echo $jobname | sed 's/^[^[:alnum:]]*//')
 fi
 log "job name: $jobname"
 


### PR DESCRIPTION
Fix a mistake in the previous fix for non-alphanumeric characters in the job name in egs-parallel jobs resulting in a crash. The previous fix removed non-alphanum characters from the start of the original job name, but actually we needed to remove from the start of the trimmed 14 character job name.