### PR TITLE
Fix egs++ 3ddose output

### DIFF
--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1171,7 +1171,7 @@ void EGS_AdvancedApplication::resetRNGState() {
 //************************************************************
 // Returns density for medium ind
 EGS_Float EGS_AdvancedApplication::getMediumRho(int ind) {
-    return the_media->rho[ind];
+    return ind < 0 ? 0.0 : the_media->rho[ind];
 }
 // Returns edep
 EGS_Float EGS_AdvancedApplication::getEdep() {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -231,7 +231,7 @@ public:
      */
     virtual EGS_Float hownear(int ireg, const EGS_Vector &x) = 0;
 
-    /*! \brief Calculates the volume*relative rho (rhor) of region ireg.
+    /*! \brief Calculates the mass of region ireg.
 
       Currently only implemented in EGS_XYZGeometry
     */

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -646,7 +646,11 @@ medium2  min_density2 max_density2 default_density2
 and defines that <code>medium1</code> is to be used for all voxels
 with a mass density between <code>min_density1</code> and
 <code>max_density1</code>, etc., assuming <code>default_density1</code>, etc.,
-id the default mass density for this medium.
+is the default mass density for this medium. These default densities must 
+exactly match the densitites, in g/cm3, in their media's respective PEGS4 data
+or density correction files. Stating them is necessary and is a workaround for
+the fact that the PEGS system is not yet hatched at egs++ geometry
+initialization time and cannot yet be used to retrieve the default densities.
 There can be an arbitrary number of
 lines in the ct ramp file. The <code>density_file</code> is a binary
 file that contains: 1 byte set to 0 or 1 for data written on a big- or


### PR DESCRIPTION
This pull request addresses the problems outlined in issue #720. `EGS_XYZGeometry::getMass()` now returns the actual mass of the voxel. The description of the default density in the Doxygen has been extended. I have changed the Doxygen of `EGS_BaseGeometry::getMass()` to state that it returns actual mass. But I did not fix the description saying that it is only implemented in `EGS_XYZGeometry`. It seems to also be implemented in at least `EGS_cSpheres` and `EGS_cSphericalShell`, but I'm not familiar enough with those and whether they're considered stable.
There's also the issue of vacuum voxels. In the previous implementation, encountering a vacuum voxel, with a medium index of -1, resulted in at least two kinds of undefined behaviour. The first is accessing `the_media->rho[-1]` in `EGS_AdvancedApplication::getMediumRho()`. In practice this probably mostly points into zeroed out memory and hence returns 0.0. This then causes float division by zero in several places in `EGS_DoseScoring`. I have addressed the first UB instance by adding a check to `EGS_AdvancedApplication::getMediumRho()` and I'll let someone else tackle the instances in `EGS_DoseScoring`.
I would have moved `EGS_XYZGeometry::getMass()` and most other functions' implementations from the header into the source file, but I've left it as it is for now for some sort of consistency.
I have also overridden `getMass()` in `EGS_DeformedXYZ` to return 1 since the volume calculation there should be different, which is outside the scope of this pull request. I see `EGS_DeformedXYZ`, which can't be constructed from an input file, is either a geometry in the making or, and I find this more likely since it hasn't been touched in 5 years, has been abandoned. As such I think you should remove it as it's dead code. And if you ever pick it up again, I don't think deriving from an `EGS_XYZGeometry` is a good idea since it's composed of tetrahedra. Presently it also doesn't override `getType()` so would be accepted for 3ddose output by `EGS_DoseScoring`, possibly leading to strange results.
Fixes #720.
