### PR TITLE
Fix getMass and dose scoring density scaling

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -350,7 +350,7 @@ void EGS_DoseScoring::reportResults() {
                     dr=1;
                 }
                 EGS_Float finalDose = 0;
-                if(mass > 0) {
+                if (mass > 0) {
                     finalDose = r*normD/mass;
                 }
                 egsInformation("%*d %-*s %7.3f   %8.4f %10.4e +/- %-7.3f%% %10.4e +/- %-7.3f%%\n",
@@ -390,7 +390,7 @@ void EGS_DoseScoring::reportResults() {
             if (r > 0) {
                 dr = dr/r;
                 EGS_Float finalDose = 0;
-                if(massM[im] > 0) {
+                if (massM[im] > 0) {
                     finalDose = r*normD/massM[im];
                 }
                 egsInformation(
@@ -452,9 +452,10 @@ void EGS_DoseScoring::outputDoseFile(const EGS_Float &normD) {
         for (int i=0; i<nx*ny*nz; i++) {
             doseF->currentResult(i,r,dr);
             EGS_Float mass = dose_geom->getMass(i); //local reg.
-            if(mass > 0) {
+            if (mass > 0) {
                 dose = r*normD/mass;
-            } else {
+            }
+            else {
                 dose = 0;
             }
 

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -686,6 +686,10 @@ int EGS_AdvancedApplication::helpInit(EGS_Input *transportp, bool do_hatch) {
         }
     }
 
+    // Set the mass in geometries (only a few have defined this function)
+    // This happens after hatch so that the media densities can be used
+    geometry->setMass();
+
     egsInformation("\n\nThe following media are defined:\n"
                    "================================\n\n");
     EGS_Float Emax = source ? source->getEmax() : 0;

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -615,6 +615,11 @@ public:
         return first_parallel;
     };
 
+    /*! \brief Returns the active simulation geometry for the application. */
+    inline EGS_BaseGeometry *getGeometry() const {
+        return geometry;
+    }
+
     /*! \brief Calculates distance to a boundary along the current direction.
 
      This function implements the EGSnrc howfar geometry specification
@@ -922,7 +927,7 @@ protected:
 
      This function is re-implemented in the EGS_AdvancedApplication
      class, from which EGSnrc applications using the mortran EGSnrc
-     physics subroutines should be derived. The defualt implementation
+     physics subroutines should be derived. The default implementation
      is to set transport parameter and cross section options
      from input between :start MC Transport parameter: and
      :stop MC Transport parameter: in the input file,

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -243,15 +243,15 @@ public:
     };
 
     EGS_Float getMediumRho(int ind) const {
-        if (ind==-1) {
-            return -1;
+        if (ind < 0) {
+            return 0;
         }
         else {
             if (app) {
                 return app->getMediumRho(ind);
             }
             else {
-                return -1;
+                return 0;
             }
         }
     };

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -231,10 +231,12 @@ public:
      */
     virtual EGS_Float hownear(int ireg, const EGS_Vector &x) = 0;
 
-    /*! \brief Calculates the volume*relative rho (rhor) of region ireg.
+    /*! \brief Calculates the regular mass of all regions for the geometry */
+    virtual void setMass() {
+        return;
+    }
 
-      Currently only implemented in EGS_XYZGeometry
-    */
+    /*! \brief Returns the regular mass of region ireg */
     virtual EGS_Float getMass(int ireg) {
         return 1.0;
     }

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.h
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.h
@@ -402,6 +402,8 @@ public:
 
     int getMaxStep() const;
 
+    void setMass();
+
     virtual EGS_Float getMass(int ireg);
 
     virtual EGS_Float getMassCorrectionRatio(int ireg);
@@ -444,6 +446,7 @@ public:
 protected:
 
     EGS_BaseGeometry *base_geom;           //!< The envelope geometry
+    const vector<AEnvelopeAux> inscribedAux;
     vector<EGS_BaseGeometry *> inscribed_geoms; //!< The inscribed geometries
     vector<EGS_AffineTransform *> transforms; //!< The inscribed geometries
     vector<volcor::VCOptions *> opts; //!< The inscribed geometries

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/volcor.h
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/volcor.h
@@ -542,7 +542,7 @@ vector<EGS_Float> applyFileVolumeCorrections(VCOptions *opts, vector<RegVolume> 
 vector<EGS_Float> getUncorrectedVolumes(EGS_BaseGeometry *base) {
     vector<EGS_Float> uncorrected;
     for (int ir=0; ir < base->regions(); ir++) {
-        EGS_Float vol = base->getMass(ir)/base->getRelativeRho(ir);
+        EGS_Float vol = base->getMass(ir) / (base->getRelativeRho(ir) * base->getMediumRho(base->medium(ir)));
         uncorrected.push_back(vol);
     }
     return uncorrected;

--- a/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.h
+++ b/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.h
@@ -152,9 +152,15 @@ public:
      * This is useful for e.g. outputing bounds for a 3ddose file */
     int getNRegDir(int dir);
 
+    /*! \brief set the mass for the geometry */
+    void setMass();
+
     /*! \brief get mass of a given region  */
     EGS_Float getMass(int ireg);
 
+    void setApplication(EGS_Application *App) {
+        app = App;
+    };
 };
 
 

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.h
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.h
@@ -183,8 +183,15 @@ public:
     /*! \brief Implement geNRegDir for spherical regions */
     int getNRegDir(int dir);
 
+    /*! \brief Implement setMass for spherical regions */
+    void setMass();
+
     /*! \brief Implement getMass for spherical regions */
     EGS_Float getMass(int ireg);
+
+    void setApplication(EGS_Application *App) {
+        app = App;
+    };
 
 private:
 
@@ -247,8 +254,14 @@ public:
     EGS_Float getBound(int idir, int ind);
 
     int getNRegDir(int dir);
+    
+    void setMass();
 
     EGS_Float getMass(int ireg);
+
+    void setApplication(EGS_Application *App) {
+        app = App;
+    };
 
 private:
 

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.h
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.h
@@ -254,7 +254,7 @@ public:
     EGS_Float getBound(int idir, int ind);
 
     int getNRegDir(int dir);
-    
+
     void setMass();
 
     EGS_Float getMass(int ireg);


### PR DESCRIPTION
Fix the `getMass` definitions in `egs_spheres` and `egs_rz` to return the regular mass. Also fix divide-by-zero situations in `egs_dose_scoring` for vacuum, and add proper accounting for density scaling. This is an important change for users who use the input `set relative density =` along with `egs_dose_scoring` - the reported dose from the ausgab object was not scaled by the density scaling factor.

The changes to `getMass` do not affect any standard EGSnrc output, but may have impact in other applications such as `egs_brachy` (@randlet @mchamberland) or power-users of `egs_autoenvelope`. These functions were added somewhat recently and are not used anywhere but in `egs_autoenvelope`. Similar, more critical fixes to `egs_nd_geometry` are handled in PR #719.

Fixes #720. Thanks to @mpayrits for outlining these changes.