### PR TITLE
Guard against more than one track_scoring object in egsinp

### DIFF
--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -1001,6 +1001,16 @@ void EGS_Application::addAusgabObject(EGS_AusgabObject *o) {
     if (!o) {
         return;
     }
+    // only one track scoring object is allowed, otherwise there can be bugs
+    // if both objects try and write to the same file.
+    if (o->getObjectType() == "EGS_TrackScoring") {
+        for (int j=0; j<a_objects_list.size(); ++j) {
+            if (a_objects_list[j]->getObjectType() == "EGS_TrackScoring") {
+                egsFatal("error: only one ausgab object of type "
+                    "'EGS_TrackScoring' is allowed\n");
+            }
+        }
+    }
     o->setApplication(this);
     a_objects_list.add(o);
     //int ncall = 1 + (int)AugerEvent;


### PR DESCRIPTION
As discussed in https://github.com/nrc-cnrc/EGSnrc/issues/745, ensure that multiple `EGS_TrackScoring` objects are not defined as this can lead to bugs at write time when the objects try to write to the same file (i.e. if the `file name addition` is blank). More than one track scoring object is not seen as a required feature, since photons, electrons and positrons can all be toggled in `egs_view`.

```
:start ausgab object:
    library = egs_track_scoring
    name    = some_name
    score photons   = yes or no # optional, yes assumed if missing
    score electrons = yes or no # optional, yes assumed if missing
    score positrons = yes or no # optional, yes assumed if missing
    start scoring   = event_number # optional, 0 assumed if missing
    stop  scoring   = event_number # optional, 1024 assumed if missing
    buffer size     = size         # optional, 1024 assumed if missing
    file name addition = some_string # optional, empty string assumed if missing
:stop ausgab object:
```