### PR TITLE
Document egs++ rng definition block

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Reid Townson
+#                   Max Orok
 #
 ###############################################################################
 */
@@ -42,6 +43,7 @@
 <li> \ref common_media </li>
 <li> \ref common_source </li>
 <li> \ref common_rco </li>
+<li> \ref common_rng </li>
 <li> \ref common_mc </li>
 </ul>
 
@@ -293,6 +295,17 @@ RCO by specifying <b><code>-s</code></b> on the command line. In this case,
 all parallel jobs will execute the same number of histories as specified
 in the input file.
 
+\section common_rng Random numbers
+The random number block specifies the random generator used for the simulation. Currently, the only generator available in egs++ is the \link EGS_Ranmar <b><code>ranmar</code></b>\endlink generator. This block is optional but useful to ensure simulation reproducibility by explicitly setting initial seeds. For parallel runs, each job uses a different set of seeds based on the seeds in the input file. The <b><code>high resolution</code></b> input can be used to obtain higher quality results with the tradeoff of increased runtime (which varies depending on the simulation).
+
+\verbatim
+:start rng definition:
+    type            = ranmar      # generator type
+    initial seeds   = 33 97       # initial seeds
+    high resolution = yes         # no (default), yes
+:stop rng definition:
+\endverbatim
+
 \section  common_mc Monte Carlo transport parameters
 The Monte Carlo transport parameters have important and significant influence on both the accuracy of the simulation, and the efficiency. If you are unsure, <b>neglect this input block entirely to use the defaults</b>. If you are publishing an article using EGSnrc, make sure to disclose the transport parameters in use, as well as the release version.
 
@@ -410,6 +423,12 @@ Putting together the examples suggested above, we have a complete input file. No
         dose regions = 1 # list of individual region numbers (we just have 1)
     :stop ausgab object:
 :stop ausgab object definition:
+
+:start rng definition:
+    type = ranmar
+    initial seeds = 33 97
+    high resolution = yes
+:stop rng definition:
 
 :start run control:
     ncase = 1e5 # Number of histories to run


### PR DESCRIPTION
Add documentation for the `rng definition` block in egsinp files. Will have to be adjusted if `high resolution = yes` becomes the default (https://github.com/nrc-cnrc/EGSnrc/issues/594).

Rendered: 

![image](https://user-images.githubusercontent.com/40000585/140550687-6dab66b0-20a3-4bf4-b9e4-5b3b7fa668f2.png)
