### PR TITLE
Fix #803 a quiksyncdef error from DYNJAWS in BEAMnrc GUI

### DIFF
--- a/HEN_HOUSE/omega/progs/gui/beamnrc/syncjaws.tcl
+++ b/HEN_HOUSE/omega/progs/gui/beamnrc/syncjaws.tcl
@@ -326,12 +326,12 @@ proc define_syncjaws { id } {
 	}
     }
 
-    button $w.quikdyndef -text \
+    button $w.quiksyncdef -text \
 "Define x/y
 using field
-size and SSD" -command "quikdyndef $id" -relief groove -bd 8
+size and SSD" -command "quiksyncdef $id" -relief groove -bd 8
     if {"$cmval($id,2,1)" != "1" && "$cmval($id,2,1)" != "2"} {
-        grid configure $w.quikdyndef -row 3 -column 0 -rowspan 4 -sticky w
+        grid configure $w.quiksyncdef -row 3 -column 0 -rowspan 4 -sticky w
     }
 
     grid configure $w.lo -row 0 -column 1 -sticky w
@@ -719,7 +719,7 @@ proc add_SYNCJAWS_yz {id xscale zscale xmin zmin l m parent_w} {
     }
 }
 
-proc quikdyndef { id } {
+proc quiksyncdef { id } {
 
     global cmval ssd fmin fmax fieldfocus
 


### PR DESCRIPTION
Fix #803 a GUI error that occurred in DYNJAWS jaw definitions when clicking
the button to calculate the jaw settings from the field size and SSD.
The button triggered a function that was duplicated with the same name
in SYNCJAWS, leading to the error. As the fix, the syncjaws version of
the function has been renamed. This bug has existed since SYNCJAWS was
added to the GUI.