### PR TITLE
Check that ir is not -1 for region dose scoring

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.h
@@ -214,7 +214,7 @@ public:
         }
 
         /*** Check if scoring in current region ***/
-        if (dose) {
+        if (ir >= 0 && dose) {
             if (d_reg_index[ir]<0) {
                 return 0;
             }
@@ -247,7 +247,7 @@ public:
         }
 
         /*** Check if scoring in current region ***/
-        if (dose) {
+        if (ir >= 0 && dose) {
             if (d_reg_index[ir]<0) {
                 return 0;
             }


### PR DESCRIPTION
Before this change, there was an out-of-bounds read in d_reg_index when `ir` was -1. Fixes #828.