### PR TITLE
A generic fluence scoring ausgab object (AO)

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/Doxyfile
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/Doxyfile
@@ -738,6 +738,7 @@ INPUT                  = main.doxy \
                          common.doxy \
                          geometry.doxy \
                          sources.doxy \
+                         aobjects.doxy \
                          cavity.doxy \
                          egs_cbct.doxy \
                          egs_chamber.doxy \

--- a/HEN_HOUSE/doc/src/pirs898-egs++/aobjects.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/aobjects.doxy
@@ -44,11 +44,11 @@
 
 \section ausgab_objects_general General discussion
 
-An ausgab object allows accessing the simulation at specific points in the simulation 
+An ausgab object allows accessing the simulation at specific points in the simulation
 to extract information (scoring) or modify aspects of the simulation, for instance to increase
 calculation efficiency by means of variance reduction techinques.
-The enumerated type EGS_Application#AusgabCall links certain events with an integer-valued constant, which is 
-passed to the \c ausgab scoring routine of the EGS_Application class and all defined ausgab objects 
+The enumerated type EGS_Application#AusgabCall links certain events with an integer-valued constant, which is
+passed to the \c ausgab scoring routine of the EGS_Application class and all defined ausgab objects
 if the event flag is set to \c true.
 
 */

--- a/HEN_HOUSE/doc/src/pirs898-egs++/aobjects.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/aobjects.doxy
@@ -44,4 +44,11 @@
 
 \section ausgab_objects_general General discussion
 
-An ausgab object is an object that blah blah blah.
+An ausgab object allows accessing the simulation at specific points in the simulation 
+to extract information (scoring) or modify aspects of the simulation, for instance to increase
+calculation efficiency by means of variance reduction techinques.
+The enumerated type EGS_Application#AusgabCall links certain events with an integer-valued constant, which is 
+passed to the \c ausgab scoring routine of the EGS_Application class and all defined ausgab objects 
+if the event flag is set to \c true.
+
+*/

--- a/HEN_HOUSE/doc/src/pirs898-egs++/main.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/main.doxy
@@ -83,6 +83,9 @@
         <td> \ref Sources "Particle sources"</td>
     </tr>
     <tr>
+        <td> \ref AusgabObjects "Ausgab objects"</td>
+    </tr>
+    <tr>
         <td> \ref egspp_main "Main library"</td>
     </tr>
 

--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -66,7 +66,8 @@ shape_libs = egs_circle egs_ellipse egs_extended_shape egs_gaussian_shape \
              egs_voxelized_shape egs_spherical_shell egs_conical_shell \
              egs_circle_perpendicular
 
-aobject_libs = egs_track_scoring egs_dose_scoring egs_radiative_splitting egs_phsp_scoring
+aobject_libs = egs_track_scoring egs_dose_scoring egs_radiative_splitting \
+	       egs_phsp_scoring egs_fluence_scoring
 
 all_libs = $(geometry_libs) $(source_libs) $(shape_libs) $(aobject_libs)
 lib_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(all_libs)))

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/Makefile
@@ -49,4 +49,4 @@ test:
 
 clean:
 	$(REMOVE) $(ABS_DSO)*$(library)*
-	$(REMOVE) *.o	
+	$(REMOVE) *.o

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/Makefile
@@ -46,3 +46,7 @@ $(make_depend)
 test:
 	@echo "common_h2: $(common_h2)"
 	@echo "extra_dep: $(extra_dep)"
+
+clean:
+	$(REMOVE) $(ABS_DSO)*$(library)*
+	$(REMOVE) *.o	

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/Makefile
@@ -31,8 +31,8 @@ include $(EGS_CONFIG)
 include $(SPEC_DIR)egspp.spec
 include $(SPEC_DIR)egspp_$(my_machine).conf
 
-# For debugging invoke: make DEBUG=-DDEBUG
-DEFS = $(DEF1) -DBUILD_FLUENCE_SCORING_DLL $(DEBUG)
+# For extra debugging messages invoke: make MYDEFS=-DDEBUG
+DEFS = $(DEF1) -DBUILD_FLUENCE_SCORING_DLL $(MYDEFS)
 
 library = egs_fluence_scoring
 lib_files = egs_fluence_scoring

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/Makefile
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/Makefile
@@ -1,0 +1,53 @@
+
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build fluence scoring object
+#  Copyright (C) 2022 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2022
+#
+#  Contributors:
+#
+###############################################################################
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+# For debugging invoke: make DEBUG=-DDEBUG
+DEFS = $(DEF1) -DBUILD_FLUENCE_SCORING_DLL $(DEBUG)
+
+library = egs_fluence_scoring
+lib_files = egs_fluence_scoring
+my_deps = $(common_ausgab_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)
+
+test:
+	@echo "common_h2: $(common_h2)"
+	@echo "extra: $(extra)"
+	@echo "common_ausgab_deps: $(common_ausgab_deps)"
+	@echo $(ABS_DSO)*$(library)*
+clean:
+	$(REMOVE) $(ABS_DSO)*$(library)*
+	$(REMOVE) *.o

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1,0 +1,1086 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ fluence scoring object implementation
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2022
+#
+#  Contributors:    
+#
+###############################################################################
+
+/*! \file egs_fluence_scoring.cpp
+ *  \brief A fluence scoring ausgab object: implementation
+ *  
+ */
+
+#include <string>
+#include <cstdlib>
+
+#include "egs_fluence_scoring.h"
+#include "egs_input.h"
+#include "egs_functions.h"
+
+EGS_PlanarFluence::EGS_PlanarFluence(const string &Name, EGS_ObjectFactory *f) :
+    EGS_AusgabObject(Name,f), hits_field(false), 
+    scoring_charge(photon), particle_name("photon"),
+    flu_s(0), flu_nbin(128), flu_xmin(0.001), flu_xmax(1.0), 
+    norm_u(1.0), Nx(1), Ny(1), flu(0), fluT(0), current_ncase(0), 
+    m_primary(0.0), m_tot(0.0)
+{
+    otype = "EGS_PlanarFluence";
+    m_midpoint = EGS_Vector(0,0,5);
+    m_R  =  5;
+    m_R2 = 25;
+    field_type = circle; Area = M_PI * m_R2;
+    m_normal = EGS_Vector(0,0,1);
+    m_d = m_normal*m_midpoint;
+}
+
+/*! Destructor.  */
+EGS_PlanarFluence::~EGS_PlanarFluence(){
+
+   if( flu ) {
+       for(int j=0; j<Nx*Ny; j++) {delete flu[j];}
+       if(flu)  delete [] flu;
+       if(fluT) delete fluT;
+   }
+}
+
+void EGS_PlanarFluence::setApplication(EGS_Application *App) {
+
+    EGS_AusgabObject::setApplication(App);
+
+    if( !app ) return;
+
+    /* Setup fluence scoring arrays, Nx*Ny = 1 for the circle */
+    flu  = new EGS_ScoringArray* [Nx*Ny];
+    fluT = new EGS_ScoringArray(Nx*Ny);
+    for (int j = 0; j < Nx*Ny; j++) 
+        flu[j] = new EGS_ScoringArray(flu_nbin);
+    describeMe();
+}
+
+void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
+    if( !inp ) {
+        egsWarning("AO type %s: null input?\n",otype.c_str()); return;
+    }
+
+    vector<string> name; int the_selection = 0;
+    name.push_back("photon"); name.push_back("electron"); name.push_back("positron");
+    the_selection = inp->getInput("scoring particle", name, 0);
+    switch(the_selection){
+        case 1:
+          particle_name="electron";
+          scoring_charge = electron;
+          break;
+        case 2:
+          particle_name="positron";
+          scoring_charge = positron;
+          break;
+        default:
+          particle_name="photon";
+          scoring_charge = photon;
+    }    
+
+    EGS_Float flu_Emin, flu_Emax, norma;
+    int err_n    = inp->getInput("number of bins",flu_nbin);
+    int err_i    = inp->getInput("minimum kinetic energy",flu_Emin);
+    int err_f    = inp->getInput("maximum kinetic energy",flu_Emax);
+    int err_norm = inp->getInput("normalization",norma);
+    if (!err_norm) norm_u = norma;
+
+    vector<string> scale;
+    scale.push_back("linear"); scale.push_back("logarithmic");
+    flu_s = inp->getInput("scale",scale,0);
+    if( flu_s == 0 ) {
+        flu_xmin = flu_Emin; flu_xmax = flu_Emax;
+    }
+    else {
+        flu_xmin = log(flu_Emin); flu_xmax = log(flu_Emax);
+    }
+    flu_a = flu_nbin; flu_a /= (flu_xmax - flu_xmin);
+    flu_b = -flu_xmin*flu_a;
+    /****************************************************** 
+       Algorithm assigns E in [Ei,Ei+1), one could add extra
+       bin for E = Emax cases. Alternatively, push those
+       events into last bin (bias?) during scoring.
+       Which approach is correct?
+     ******************************************************/
+    //flu_nbin++;
+
+    vector<string> output_spectra; 
+    output_spectra.push_back("no");
+    output_spectra.push_back("yes");
+    verbose = inp->getInput("verbose",output_spectra,0);
+
+    // Specific plane input
+    vector<EGS_Float> tmp_field;
+    int err2 = inp->getInput("scoring circle",tmp_field);
+    if( err2 ) {
+        int err3 =  inp->getInput("scoring rectangle",tmp_field);
+        if( err3 || tmp_field.size() != 4) {
+            egsWarning(
+            "\n\n***  Wrong/missing 'scoring rectangle' input "
+            "setting it to 10 cm X 10 cm field at origin!\n\n");
+            m_midpoint = EGS_Vector();
+            ax = 10; ay = 10;
+            field_type = rectangle; Area = ax*ay;
+        }
+        else{
+            EGS_Float xmin = tmp_field[0],xmax = tmp_field[1],
+                      ymin = tmp_field[2],ymax = tmp_field[3];
+            /* scoring plane location in space */
+            m_midpoint = EGS_Vector((xmax+xmin)/2.,(ymax+ymin)/2.,0); // plane at origin by default
+            /* scoring plane normal */
+            m_normal = EGS_Vector(0,0,1); // default normal along positive z-axis
+            /* define unit vectors on right-handed scoring plane */
+            ux = EGS_Vector(1,0,0); uy = EGS_Vector(0,1,0);
+            /* Request a scoring plane transformation for initial position and orientation */
+            EGS_AffineTransform *t = EGS_AffineTransform::getTransformation(inp);
+            if (t){
+                t->rotate(m_normal) ; t->transform(m_midpoint);
+                t->rotate(ux); t->rotate(uy);
+                delete t;
+            }
+            
+            /* get screen resolution */
+            vector<int> screen;
+            int err4 = inp->getInput("resolution",screen);
+            if( err4 ) {
+              Nx=1; Ny=1;
+              egsWarning(
+              "\n\n***  Missing/wrong 'resolution' input "
+              "     Scoring in the whole field\n\n");
+              
+            }
+            else if (screen.size()==1){ Nx = screen[0];Ny = screen[0];}
+            else if (screen.size()==2){ Nx = screen[0];Ny = screen[1];}
+            else if (screen.size()> 2){ Nx = screen[0];Ny = screen[1];
+              egsWarning(
+              "\n\n***  Too many 'resolution' inputs\n"
+              "     Using first two entries\n\n");
+
+            }
+
+            ax = xmax - xmin; ay = ymax-ymin;
+            vx = ax/Nx; vy = ay/Ny;
+            field_type = rectangle; Area = vx*vy;
+        }
+    }
+    else if( tmp_field.size() != 4 ) {
+        egsWarning(
+        "\n\n***  Wrong/missing 'scoring circle' input "
+        "setting it to 10 cm diameter field at origin!\n\n");
+        m_midpoint = EGS_Vector();
+        m_R  =  5;
+        m_R2 = 25;
+        field_type = circle; Area = M_PI * m_R2;
+    }
+    else{
+        vector<EGS_Float> tmp_normal;
+        int err1 = inp->getInput("scoring plane normal",tmp_normal);
+        if( err1 || tmp_normal.size() != 3 ) {
+          egsWarning(
+          "\n\n***  Wrong/missing 'scoring plane normal' input. "
+          "Set to null vector\n\n");
+          m_normal = EGS_Vector();// set to null vector
+        }
+        else{
+          m_normal = EGS_Vector(tmp_normal[0],tmp_normal[1],
+                                tmp_normal[2]);
+          m_normal.normalize();
+        }
+        m_midpoint = EGS_Vector(tmp_field[0],tmp_field[1],
+                                tmp_field[2]);
+        m_R = tmp_field[3]; 
+        m_R2 = tmp_field[3]*tmp_field[3];
+        field_type = circle; Area = M_PI * m_R2;
+    }
+
+    m_d = m_normal*m_midpoint;
+}
+
+void EGS_PlanarFluence::describeMe(){
+    char buf[128];
+    sprintf(buf,"\nPlanar %s fluence\n",particle_name.c_str());
+    description =  buf;
+    //description  = "\nParticle Fluence Scoring\n";
+    description += "========================\n";
+    description += " - scoring field normal      = ";
+    sprintf(buf,"(%g %g %g)\n",m_normal.x,m_normal.y,m_normal.z); 
+    description += buf;
+    description += " - scoring field center      = ";
+    sprintf(buf,"(%g %g %g)\n",m_midpoint.x,m_midpoint.y,m_midpoint.z); 
+    description += buf;
+    if (field_type == circle){
+       description += " - scoring field radius      = ";
+       sprintf(buf,"%g cm\n",m_R); 
+       description += buf;
+    }
+    else if (field_type == rectangle) {
+       description += " - scoring field             = ";
+       sprintf(buf,"%g cm X %g cm\n",ax,ay); 
+       description += buf;
+       description += " - scoring field resolution  = ";
+       sprintf(buf,"%d X %d\n",Nx,Ny); 
+       description += buf;
+    }
+    description += " - scoring field distance from origin = ";
+    sprintf(buf,"%g cm\n",m_d); 
+    description += buf;
+
+    if (flu){
+       //if (planar_fluence)
+       //   description += " - scoring planar particle fluence between ";
+       //else
+          description += " - scoring planar particle fluence in the ";
+       EGS_Float Emin = flu_s ? exp(flu_xmin):flu_xmin, 
+                 Emax = flu_s ? exp(flu_xmax):flu_xmax;
+       sprintf(buf,"%g MeV and %g MeV energy range",Emin,Emax);
+       description += buf;
+       if (flu_s)
+          description += " on a logarithmic scale \n";
+       else
+          description += " on a linear scale \n";
+    }
+    
+}
+
+void EGS_PlanarFluence::score(const EGS_Particle& p, const int& ivoxel){
+     EGS_Float up = p.u*m_normal, aup = fabs(up); 
+     /********************************************************** 
+      Prevent large weights from particles very close to plane.
+     ***********************************************************/
+     if( aup < 0.08 ) aup = 0.0871557;// Limit incident angle to 85 degrees
+     EGS_Float e = p.q ? p.E - app->getRM() : p.E;
+     if (flu){
+       //EGS_Float fup = planar_fluence ? 1.0:aup;
+       EGS_Float fup = aup;
+       if( flu_s ) {e = log(e);} // log scale
+       EGS_Float ae; int je;
+       /* Score fluence in each voxel */
+       if( e > flu_xmin && e <= flu_xmax) {
+         /* Score total fluence in each voxel */
+         fluT->score(ivoxel,p.wt/fup);
+         /* Score differential fluence in each voxel */
+         ae = flu_a*e + flu_b; 
+        /****************************************************** 
+           Algorithm assigns E in [Ei,Ei+1), hence push events
+           with E = Emax into last bin (bias?) during scoring.
+           Alternatively add extra bin for E = Emax cases.
+           Which approach is correct?
+        ******************************************************/
+         je = min((int)ae,flu_nbin-1);//je = (int) ae;
+        /******************************************************/
+         if (ivoxel < 0 || ivoxel > Nx*Ny)
+            egsFatal("\n-> Scoring out of bounds, ivoxel = %d\n",ivoxel);
+         EGS_ScoringArray *aux = flu[ivoxel];
+         if (je < 0 || je >= flu_nbin )
+            egsFatal("\n-> Scoring out of bounds, ibin = %d ae = %g E = %g MeV\n",je,ae,e);
+         aux->score(je,p.wt/fup);
+       }
+     }
+}
+
+int EGS_PlanarFluence::hitsField(const EGS_Particle& p, EGS_Float* dist){
+     if ( field_type==circle ){
+         EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
+         if( (up > 0 && m_d > xp ) || 
+             (up < 0 && m_d < xp ) ){
+             EGS_Float t = (m_d - xp)/up;
+             EGS_Vector x1(p.x + p.u*t - m_midpoint);
+             if( dist ) *dist = t;
+             return x1.length2() < m_R*m_R ? 0:-1;
+         }
+         return -1;
+     }
+     else if ( field_type == rectangle ){
+         EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
+         if( (up > 0 && m_d > xp) || (up < 0 && m_d < xp) ) {
+             EGS_Float t = (m_d - xp)/up; // distance to plane along u
+             EGS_Vector x1(p.x + p.u*t - m_midpoint);// vector on scoring plane
+             EGS_Float xcomp = x1*ux;// x-direction component
+             EGS_Float ycomp = x1*uy;// y-direction component
+                       xcomp = 2*xcomp + ax;
+                       ycomp = 2*ycomp + ay;
+             if( xcomp > 0 && xcomp < 2*ax && 
+                 ycomp > 0 && ycomp < 2*ay ){
+                 int i = int(xcomp/(2*vx)),
+                     j = int(ycomp/(2*vy)),
+                     k = i + j*Nx;
+                 if( dist ) *dist = t;
+                 return k;
+             }
+         }
+         return -1;
+     }
+     else return -1;
+}
+
+void EGS_PlanarFluence::ouputResults(){
+  if (!flu) return;  
+
+EGS_Float src_norm = 1.0,          // default to number of histories in this run
+            Fsrc = app->getFluence();// Fluence or number of primary histories
+  egsInformation("\n\n last case = %lld source particles or fluence = %g\n\n",
+                  current_ncase, Fsrc);
+
+  if (Fsrc) 
+     src_norm = Fsrc/current_ncase;// fluence or primary histories per histories run
+
+  string normLabel = src_norm == 1 ? "history" : "MeV-1 cm-2";
+  string src_type = app->sourceType();
+  if ( src_type == "EGS_BeamSource" ){ 
+      normLabel = "primary history";
+     egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
+                  src_type.c_str(), src_norm);
+  }
+  else if ( src_type == "EGS_CollimatedSource" || 
+           (src_type == "EGS_ParallelBeam" && src_norm != 1)){ 
+     egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
+                  src_type.c_str(), src_norm);
+  }
+  else{
+        egsInformation("\n\n %s normalization = %g (histories per particle)\n\n",
+                  src_type.c_str(), src_norm);
+
+  }
+
+  double norm = 1.0/src_norm;  //per fluence or particle depending on source
+         norm /= Area;         //per unit area
+         norm *= flu_a;        //per unit bin width
+         norm *= norm_u;       // times user-requested normalization
+  
+  if (verbose) 
+     egsInformation("\nNormalization = Ncase/Fsrc/A/bw = %g\n",norm);
+
+  string suffix = "_" + particle_name + ".agr";
+  string spe_name = app->constructIOFileName(suffix.c_str(),true);
+  ofstream spe_output(spe_name.c_str(),ios::out); 
+  //spe_output.open(spe_name.c_str());
+  if (!spe_output){
+      egsFatal("\n EGS_PlanarFluence: Error: Failed to open file %s\n",spe_name.c_str());
+      exit(1);
+  }
+
+  spe_output << "# " << particle_name.c_str() << " fluence \n";
+  spe_output << "# \n";
+  spe_output << "@    legend 0.2, 0.8\n";
+  spe_output << "@    legend box linestyle 0\n";
+  spe_output << "@    legend font 4\n";
+  spe_output << "@    xaxis  label \"energy / MeV\"\n";
+  spe_output << "@    xaxis  label char size 1.560000\n";
+  spe_output << "@    xaxis  label font 4\n";
+  spe_output << "@    xaxis  ticklabel font 4\n";
+  spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+  spe_output << "@    yaxis  label char size 1.560000\n";
+  spe_output << "@    yaxis  label font 4\n";
+  spe_output << "@    yaxis  ticklabel font 4\n";
+  spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
+  spe_output << "@    title font 4\n";
+  spe_output << "@    title size 1.500000\n";
+  spe_output << "@    subtitle \"for each scoring region\"\n";
+  spe_output << "@    subtitle font 4\n";
+  spe_output << "@    subtitle size 1.000000\n";
+
+ 
+  egsInformation("\n\n%s fluence scoring\n"
+                     "=================================\n",particle_name.c_str());
+  for(int j=0; j<Ny; j++) {     
+    for(int i=0; i<Nx; i++) {     
+        int k = i + j*Nx;
+        egsInformation("\nVoxel # %d :",k);
+        spe_output<<"@    s" << k <<" errorbar linestyle 0\n";
+        spe_output<<"@    s" << k <<" legend \""<<
+               "Voxel # " << k <<"\"\n";
+        spe_output<<"@target G0.S"<<k<<"\n";
+        spe_output<<"@type xydy\n";
+        double fe,dfe;
+        double fp,dfp,dfr;
+        fluT->currentResult(k,fe,dfe);
+        if( fe > 0 ) dfe = 100*dfe/fe; else dfe = 100;
+        egsInformation(" total fluence = %10.4le +/- %-7.3lf\%\n",
+              fe*norm/flu_a,dfe);
+        if (verbose) egsInformation("\n   Emid/MeV    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
+                     "---------------------------------------------\n");
+        for(int l=0; l<flu_nbin; l++) {
+            flu[k]->currentResult(l,fe,dfe);
+            EGS_Float e = (l+0.5-flu_b)/flu_a;
+            if( flu_s ) e = exp(e);
+            spe_output<<e<<" "<<fe*norm<<" "<<dfe*norm<< "\n";
+            if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
+                         e,fe*norm,dfe*norm);
+        }
+        spe_output << "&\n";
+    }
+  }
+  spe_output.close();
+       
+}
+
+void EGS_PlanarFluence::reportResults() {
+    egsInformation("\nFluence Scoring (%s)\n",name.c_str());
+    //EGS_Float m_tot = m_fluor+ m_compt + m_ray + m_multiple; char per = '%';
+    egsInformation("======================================================\n");
+    egsInformation("   Total %ss reaching field:       %g\n",particle_name.c_str(),m_tot);
+    egsInformation("   Primary %ss reaching field:     %g\n",particle_name.c_str(),m_primary);
+    //egsInformation("   Non-primary photons reaching field: %g\n",m_tot);
+    egsInformation("======================================================\n");
+
+    ouputResults();
+    
+}
+
+bool EGS_PlanarFluence::storeState(ostream &data) const {
+  if( !egsStoreI64(data,current_ncase)) return false;
+  data << endl;
+  //data << m_primary << " " << m_ray << " " << m_compt << " " << m_fluor << " " << m_multiple;
+  data << m_tot << " " << m_primary;
+  data << endl;
+  if (!data.good()) return false;
+  if( flu ) {
+      for(int j=0; j<Nx*Ny; j++) {
+          if( !flu[j]->storeState(data) ) return false;
+      }
+      if( !fluT->storeState(data) ) return false;
+  }
+  return true;  
+}
+
+bool  EGS_PlanarFluence::setState(istream &data){
+  if( !egsGetI64(data,current_ncase) ) return false;
+  //data >> m_primary >> m_ray >> m_compt >> m_fluor >> m_multiple;
+  data >> m_tot >> m_primary;
+  if (!data.good()) return false;
+  if( flu ) {
+      for(int j=0; j<Nx*Ny; j++) {
+          if( !flu[j]->setState(data) ) return false;
+      }
+      if( !fluT->setState(data) ) return false;
+  }
+  return true;
+}
+
+bool  EGS_PlanarFluence::addState(istream &data){
+   EGS_I64 tmp_case; if( !egsGetI64(data,tmp_case) ) return false;
+   current_ncase += tmp_case;
+   /* individual contributions */
+   //EGS_Float tmp_primary, tmp_fluor, tmp_compt, tmp_ray, tmp_multiple;
+   //data >> tmp_primary >> tmp_ray >> tmp_compt >> tmp_fluor >> tmp_multiple;
+   EGS_Float tmp_tot, tmp_primary;
+   data >> tmp_tot >> tmp_primary;
+   if (!data.good()) return false;
+   m_primary += tmp_primary; 
+   m_tot     += tmp_tot;
+   //m_primary += tmp_primary;m_ray += tmp_ray;m_compt += tmp_compt;
+   //m_fluor += tmp_fluor;m_multiple += tmp_multiple;
+   /* fluence objects */
+   if( flu ) {
+       EGS_ScoringArray tg(flu_nbin);
+       for(int j=0; j<Nx*Ny; j++) {
+           if( !tg.setState(data) ) return false;
+           (*flu[j]) += tg;
+       }
+       EGS_ScoringArray tgT(Nx*Ny);
+       if( !tgT.setState(data) ) return false;
+       (*fluT) += tgT;
+   }
+
+   return true;
+}
+
+/********************************************** 
+ * Class EGS_VolumetricFluence Implementation *
+***********************************************/
+
+EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
+    EGS_AusgabObject(Name,f), scoring_charge(photon), particle_name("photon"),
+    flu_s(0), flu_nbin(128), flu_xmin(0.001), flu_xmax(1.0), norm_u(1.0),
+    flu(0), fluT(0), current_ncase(0), m_primary(0.0), m_tot(0.0), 
+    n_scoring_regions(0), max_reg(-1), active_region(-1), verbose(false)
+#ifdef DEBUG
+    ,one_bin(0), multi_bin(0)
+#endif    
+{
+    otype = "EGS_VolumetricFluence";
+}
+
+/*! Destructor.  */
+EGS_VolumetricFluence::~EGS_VolumetricFluence(){
+
+   if( flu ) {
+       for(int j=0; j<n_scoring_regions; j++) {delete flu[j];}
+       if(flu)  delete [] flu;
+       if(fluT) delete fluT;
+       //if(volume) delete [] volume;
+       //if(is_sensitive) delete [] is_sensitive;
+   }
+}
+
+void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
+
+    EGS_AusgabObject::setApplication(App);
+
+    if( !app ) return;
+
+    if ( f_regionsString.length() > 0 && !f_region.size() ) {
+        getNumberRegions(f_regionsString, f_region);
+        getLabelRegions(f_regionsString, f_region);
+    }
+
+    // Get the number of regions in the geometry.
+    nreg = app->getnRegions();
+
+    // Get the number of scoring regions. If too many, reset to nreg
+    n_scoring_regions = f_region.size() < nreg ? f_region.size() : nreg;
+
+    /* Initialize arrays with defaults */
+    for (int j=0; j<nreg; j++) {
+        is_sensitive.push_back(false);
+        volume.push_back(vol_list[0]);// set to either 1.0 or first volume entered
+    }
+    
+    /* Update arrays with user inputs */
+    for (int i = 0; i < n_scoring_regions; i++) {
+        is_sensitive[f_region[i]] = true;
+        if ( i < vol_list.size() ) {
+            volume[f_region[i]] = vol_list[i];
+        }
+        if ( f_region[i] > max_reg ) max_reg = f_region[i];
+    }
+
+    /* Setup fluence scoring arrays */
+    flu  = new EGS_ScoringArray* [nreg];
+    fluT = new EGS_ScoringArray(nreg);
+    for (int j = 0; j < nreg; j++){ 
+        if (is_sensitive[j])
+           flu[j] = new EGS_ScoringArray(flu_nbin);
+    }
+#ifdef DEBUG 
+    binDist = new EGS_ScoringArray(flu_nbin);
+#endif    
+
+    /* Initialize data required to score charged particle fluence */
+    if ( scoring_charge ){
+       EGS_Float flu_Emin = flu_s ? exp(flu_xmin) : flu_xmin, 
+                 flu_Emax = flu_s ? exp(flu_xmax) : flu_xmax;
+       EGS_Float bw = flu_s ?
+                     (log(flu_Emax / flu_Emin))/flu_nbin :
+                         (flu_Emax - flu_Emin) /flu_nbin;
+       EGS_Float expbw;
+       /* Pre-calculated values for faster evaluation on log scale */
+       if (flu_s){
+          expbw   = exp(bw); // => (Emax/Emin)^(1/nbin)
+          r_const = 1/(expbw-1);
+          DE      = new EGS_Float [flu_nbin];
+          a_const = new EGS_Float [flu_nbin];
+          for ( int i = 0; i < flu_nbin; i++ ){
+            DE[i]      = flu_Emin*pow(expbw,i)*(expbw-1);
+            a_const[i] = 1/flu_Emin*pow(1/expbw,i);
+          }
+       }
+       /* Do not score below ECUT - PRM */
+       if (flu_Emin < app->getEcut() - app->getRM() ){
+           flu_Emin = app->getEcut() - app->getRM() ;
+          /* Decrease number of bins, preserve bin width */
+          flu_nbin = flu_s ?
+                     ceil((log(flu_Emax / flu_Emin))/bw) :
+                     ceil(    (flu_Emax - flu_Emin) /bw);
+       }
+       
+       flu_a_i = bw; flu_a = 1.0/bw;
+       
+       /* Pre-calculated values for faster 1/stpwr evaluation */
+       if (flu_stpwr){
+          
+          int n_media = app->getnMedia(); 
+          
+          EGS_Float lnE, lnEmin, lnEmax, lnEmid;
+
+          i_dedx = new EGS_Interpolator [n_media];// stp powers
+          dedx_i = new EGS_Interpolator [n_media];// its inverse
+          for( int j = 0; j < n_media; j++ ){
+              i_dedx[j] = *(app->eDEDX(j));
+              EGS_Float Emin = i_dedx[j].getXmin();
+              EGS_Float Emax = i_dedx[j].getXmax();
+              int n = 1 + i_dedx[j].getIndex(Emax);// getIndex returns lower bin limit?
+              EGS_Float bwidth = (Emax - Emin)/n;
+#ifdef DEBUG 
+              egsInformation("---> stpwr in %s : Emin=%g Emax=%g n=%d bw=%g\n",
+              app->getMediumName(j), exp(Emin), exp(Emax), n, bwidth);
+#endif             
+              int nbins = n + 1;
+              EGS_Float spwr_i[nbins]; 
+              for (int k = 0; k < nbins; k++ ){
+                  spwr_i[k] = 1.0 / i_dedx[j].interpolate(Emin+k*bwidth);
+              }
+              dedx_i[j].initialize(nbins, Emin, Emax, spwr_i);
+#ifdef DEBUG 
+              Emin = dedx_i[j].getXmin();
+              Emax = dedx_i[j].getXmax();
+              n = 1 + dedx_i[j].getIndex(Emax);// getIndex returns lower bin limit?
+              bwidth = (Emax - Emin)/n;
+              egsInformation("---> 1/stpwr in %s : lnEmin=%g lnEmax=%g n=%d bw=%g index(Emax)=%d\n",
+              app->getMediumName(j), Emin, Emax, n, bwidth, dedx_i[j].getIndexFast(Emax));
+              for (int k = 0; k < nbins; k++ ){
+                egsInformation(" L(%g MeV) = %g MeV/cm 1/L = %g cm/MeV\n", 
+                exp(Emin+k*bwidth),
+                i_dedx[j].interpolate(Emin + k*bwidth), 
+                dedx_i[j].interpolate(Emin + k*bwidth));
+              }
+              
+#endif             
+          }
+
+          /* Determine stpwr at middle of each fluence scoring bin */
+          lnEmin  = flu_s ? log(0.5*flu_Emin*(expbw+1)) : 0;
+          Lmid_i  = new EGS_Float [flu_nbin*n_media];
+          for( int j = 0; j < n_media; j++ ){
+            for ( int i = 0; i < flu_nbin; i++ ){
+                lnEmid = flu_s ? lnEmin + i*bw : log(flu_Emin+bw*(i+0.5));
+                Lmid_i[i+j*flu_nbin] = 1/i_dedx[j].interpolate(lnEmid);
+                //egsInformation(" 1/L(%g MeV) = %g cm/MeV\n",exp(lnEmid),Lmid_i[i+j*flu_nbin]);
+            }
+          }
+       }
+    }
+
+
+    describeMe();
+}
+
+void EGS_VolumetricFluence::getNumberRegions(const string &str, vector<int> &regs) {
+    app->getNumberRegions(str, regs);
+}
+
+void EGS_VolumetricFluence::getLabelRegions(const string &str, vector<int> &regs) {
+    app->getLabelRegions(str, regs);
+}
+
+/* 
+   Takes user inputs and sets up simulation parameters not requiring
+   invoking an application method. This is later done in setApplication.
+*/
+void EGS_VolumetricFluence::initScoring(EGS_Input *inp) {
+
+    if( !inp ) {
+        egsWarning("AO type %s: null input?\n",otype.c_str()); return;
+    }
+
+    vector<string> name; int the_selection = 0;
+    name.push_back("photon"); name.push_back("electron"); name.push_back("positron");
+    the_selection = inp->getInput("scoring particle", name, 0);
+    switch(the_selection){
+        case 1:
+          particle_name="electron";
+          scoring_charge = electron;
+          break;
+        case 2:
+          particle_name="positron";
+          scoring_charge = positron;
+          break;
+        default:
+          particle_name="photon";
+          scoring_charge = photon;
+    }    
+
+    EGS_Float flu_Emin, flu_Emax, norma;
+    int err_n    = inp->getInput("number of bins",flu_nbin);
+    int err_i    = inp->getInput("minimum kinetic energy",flu_Emin);
+    int err_f    = inp->getInput("maximum kinetic energy",flu_Emax);
+    if (err_n) egsFatal("\n**** Missing input: number of bins. Aborting!\n\n");
+    if (err_i) egsFatal("\n**** Missing input: minimum kinetic energy. Aborting!\n\n");
+    if (err_f) egsFatal("\n**** Missing input: maximum kinetic energy. Aborting!\n\n");
+    int err_norm = inp->getInput("normalization",norma);
+    if (!err_norm) norm_u = norma;
+
+    vector<string> scale;
+    scale.push_back("linear"); scale.push_back("logarithmic");
+    flu_s = inp->getInput("scale",scale,0);
+    if( flu_s == 0 ) {
+        flu_xmin = flu_Emin; flu_xmax = flu_Emax;
+    }
+    else {
+        flu_xmin = log(flu_Emin); flu_xmax = log(flu_Emax);
+    }
+    flu_a = flu_nbin; flu_a /= (flu_xmax - flu_xmin);
+    flu_b = -flu_xmin*flu_a;
+
+    vector<string> output_spectra; 
+    output_spectra.push_back("no");
+    output_spectra.push_back("yes");
+    verbose = inp->getInput("verbose",output_spectra,0);
+
+    /* get region volume[s] in g/cm3 */
+    vector <EGS_Float> v_in;
+    inp->getInput("volumes",v_in);
+
+    /* get dose regions */
+    bool using_all_regions=true;
+    vector <int> f_start, f_stop;
+    if (!inp->getInput("regions",f_regionsString) && f_regionsString.length()>0) {
+        using_all_regions = false;    // individual regions
+    }
+    else {
+        int err1 = inp->getInput("start region",f_start);
+        int err2 = inp->getInput("stop region",f_stop);
+        if (!err1 && !err2) {
+            if (f_start.size()==f_stop.size()) { // group of dose regions
+                for (int i=0; i<f_start.size(); i++) {
+                    int ir = f_start[i], fr = f_stop[i];
+                    for (int ireg=ir; ireg<=fr; ireg++) {
+                        f_region.push_back(ireg);
+                    }
+                }
+                using_all_regions = false;
+            }
+            else egsWarning(
+                    "EGS_VolumetricFluence::initScoring: \n"
+                    "  Mismatch in start and stop region groups\n"
+                    "  Calculating fluence in ALL regions.\n");
+        }
+    }
+
+    //================================================
+    // Check if one volume for each group requested.
+    // Otherwise pass volumes read and if there is
+    // a mismatch, then the first volume element
+    // or 1g/cm3 will be used.
+    //=================================================
+    if (! using_all_regions && v_in.size() == f_start.size()) {
+        // groups of regions with same volume
+        for (int i=0; i<f_start.size(); i++) {
+            int i_r = f_start[i], f_r = f_stop[i];
+            for (int ireg=i_r; ireg<=f_r; ireg++) {
+                vol_list.push_back(v_in[i]);
+            }
+        }
+    }
+    else if ( v_in.size() ) {
+        vol_list = v_in;
+    }
+    else{
+        vol_list.push_back(1.0);
+    }
+
+    /* Initialize data required to score charged particle fluence */
+    if ( scoring_charge ){
+       vector<string> method;
+       method.push_back("flurz"); method.push_back("stpwr");   // 3rd order
+                                  method.push_back("stpwrO5"); // 5th order
+       flu_stpwr = eFluType(inp->getInput("method",method,1));
+    }
+}
+
+#define REGIONS_ENTRIES 100
+#define REGIONS_PER_LINE 25
+void EGS_VolumetricFluence::describeMe(){
+    char buf[128];
+    sprintf(buf,"\nVolumetric %s fluence scoring\n",particle_name.c_str());
+    description =  buf;
+    description += "=================================\n";
+
+    description +="\n - scoring regions: ";
+    // Get the number of regions in the geometry.
+    int start = 0, stop = 0, k = 0, entries = 0;
+    /* List up to 100 scoring groups or regions */
+    while (k < nreg && entries < REGIONS_ENTRIES){
+        if( is_sensitive[k] ){
+          start = k;
+          entries++;
+          while( is_sensitive[k] && k < nreg) {
+              k++;
+          }
+          stop = k-1;
+          if ( start < stop )
+             sprintf(buf,"[%d - %d]",start,stop);
+          else if ( k % REGIONS_PER_LINE )
+             sprintf(buf," %d",start);
+          else
+             sprintf(buf," %d\n                    ",start);
+          if (entries == REGIONS_ENTRIES){
+             sprintf(buf,"... %d\n",max_reg);
+          }
+          description += buf;
+        }
+        k++;
+    }
+
+    for (int l = 0; l < nreg; l++){
+        if( is_sensitive[l] ){
+          egsInformation("  ---> region # %d volume = %g cm3\n",l,volume[l]);
+        }
+    }
+
+    description += "\n\n - scoring in the ";
+    EGS_Float Emin = flu_s ? exp(flu_xmin):flu_xmin, 
+              Emax = flu_s ? exp(flu_xmax):flu_xmax;
+    sprintf(buf,"%g MeV and %g MeV energy range",Emin,Emax);
+    description += buf;
+    if (flu_s)
+       description += " on a logarithmic scale \n";
+    else
+       description += " on a linear scale \n";
+
+    if (flu_stpwr){
+      if (flu_stpwr == stpwr){
+         description += "   O(eps^3) approach: accounts for change in stpwr\n";
+         description +=                "   along the step with eps=edep/Eb\n";
+      }
+      else if (flu_stpwr == stpwrO5){
+         description += "   O(eps^5) approach: accounts for change in stpwr\n";
+         description += "   along the step with eps=edep/Eb\n";
+      }
+    }
+    else
+      description += "   Fluence calculated a-la-FLURZ using Lave=EDEP/TVSTEP.\n";
+
+    if (norm_u != 1.0) {
+        description += " Non-unity user-requested normalization = ";
+        sprintf(buf,"%g\n",norm_u);
+        description += buf;
+    }
+
+}
+void EGS_VolumetricFluence::ouputResults(){
+
+  
+  EGS_Float src_norm = 1.0,          // default to number of histories in this run
+            Fsrc = app->getFluence();// Fluence or number of primary histories
+  egsInformation("\n\n last case = %lld source particles or fluence = %g\n\n",
+                  current_ncase, Fsrc);
+
+  if (Fsrc) 
+     src_norm = Fsrc/current_ncase;// fluence or primary histories per histories run
+
+  string normLabel = src_norm == 1 ? "history" : "MeV-1 cm-2";
+  string src_type = app->sourceType();
+  if ( src_type == "EGS_BeamSource" ){ 
+      normLabel = "primary history";
+     egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
+                  src_type.c_str(), src_norm);
+  }
+  else if ( src_type == "EGS_CollimatedSource" || 
+           (src_type == "EGS_ParallelBeam" && src_norm != 1)){ 
+     egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
+                  src_type.c_str(), src_norm);
+  }
+  else{
+        egsInformation("\n\n %s normalization = %g (histories per particle)\n\n",
+                  src_type.c_str(), src_norm);
+
+  }
+#ifdef DEBUG
+  EGS_Float fbins, d_fbins;
+  egsInformation("\nNumber of covered bins distribution\n"
+                 "--------------------------------------\n");
+  
+  int tot_bins = one_bin + multi_bin;
+  egsInformation("\none_bin = %d [%-7.3lf\%] multi_bin = %d [%-7.3lf\%]\n", 
+  one_bin, 100.0*one_bin/tot_bins, multi_bin,100.0*multi_bin/tot_bins);
+  
+  egsInformation("\n  # bins        freq         unc           percentage  \n");               
+  for (int i=0; i<flu_nbin; i++) {
+      binDist->currentResult(i,fbins, d_fbins);
+      if (fbins){
+         d_fbins = 100.0*d_fbins/fbins; fbins = current_ncase*fbins;
+         egsInformation("   %d        %11.2f  [%-7.3lf\%]     %11.2f \%\n", 
+         i+1, fbins, d_fbins, 100.*fbins/tot_bins);
+      }
+  }
+#endif
+
+  string suffix = "_" + particle_name + ".agr";
+  string spe_name = app->constructIOFileName(suffix.c_str(),true);
+  ofstream spe_output(spe_name.c_str(),ios::out); 
+  if (!spe_output){
+      egsFatal("\n EGS_VolumetricFluence: Error: Failed to open file %s\n",spe_name.c_str());
+      exit(1);
+  }
+
+  spe_output << "# Volumetric " << particle_name.c_str() << " fluence \n";
+  spe_output << "# \n";
+  spe_output << "@    legend 0.2, 0.8\n";
+  spe_output << "@    legend box linestyle 0\n";
+  spe_output << "@    legend font 4\n";
+  spe_output << "@    xaxis  label \"energy / MeV\"\n";
+  spe_output << "@    xaxis  label char size 1.560000\n";
+  spe_output << "@    xaxis  label font 4\n";
+  spe_output << "@    xaxis  ticklabel font 4\n";
+  if (src_norm == 1 || normLabel == "primary history")
+     spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+  else{   
+     spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
+  }
+  spe_output << "@    yaxis  label char size 1.560000\n";
+  spe_output << "@    yaxis  label font 4\n";
+  spe_output << "@    yaxis  ticklabel font 4\n";
+  spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
+  spe_output << "@    title font 4\n";
+  spe_output << "@    title size 1.500000\n";
+  spe_output << "@    subtitle \"for each scoring region\"\n";
+  spe_output << "@    subtitle font 4\n";
+  spe_output << "@    subtitle size 1.000000\n";
+ 
+  egsInformation("\n\n%s fluence scoring\n"
+                     "=================================\n",particle_name.c_str());
+  // Get the number of regions in the geometry.
+  for (int j = 0; j < nreg; j++) {
+      if ( !is_sensitive[j] ) continue;
+      EGS_Float norm  = 1.0/src_norm;// per particle or fluence
+                norm *= norm_u;      // user-requested normalization
+                norm /= volume[j];   //per unit volume
+                //norm *= flu_a;     //per unit bin width <- implicit in scoring!
+
+      EGS_Float the_bw = flu_s? 1.0 : flu_a_i;// Implicit for log grid
+
+      if (verbose){
+         egsInformation("\nNormalization = Ncase/Fsrc/V = %g\n",norm);
+         egsInformation("Volume[%d] = %g bw = %g nbins = %d\n",j,volume[j], the_bw, flu_nbin);
+      }
+      egsInformation("region # %d : ",j);
+
+      double fe,dfe,fp,dfp;
+      fluT->currentResult(j,fe,dfe);
+      if (fe > 0) {
+          dfe = 100*dfe/fe;
+      }
+      else {
+          dfe = 100;
+      }
+      egsInformation(" total fluence [cm-2] = %10.4le +/- %-7.3lf\%\n",
+                     fe*norm*the_bw,dfe);
+
+      spe_output<<"@    s"<<j<<" errorbar linestyle 0\n";
+      spe_output<<"@    s"<< j <<" legend \""<< "region # " << j <<"\"\n";
+      spe_output<<"@target G0.S"<<j<<"\n";
+      spe_output<<"@type xydy\n";
+      if (verbose) egsInformation("\n   Emid/MeV    Flu/(MeV-1*cm-2)   DFlu/(MeV-1*cm-2)\n"
+                     "---------------------------------------------------\n");
+      for (int i=0; i<flu_nbin; i++) {
+          flu[j]->currentResult(i,fe,dfe);
+          EGS_Float e = (i+0.5-flu_b)/flu_a;
+          if (flu_s) e = exp(e);
+          spe_output << e <<" "<< fe *norm<<" "<< dfe *norm<< "\n";
+          if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
+                        e, fe*norm, dfe*norm);
+      }
+      spe_output << "&\n";
+
+  }
+
+
+  spe_output.close();
+       
+}
+
+void EGS_VolumetricFluence::reportResults() {
+
+    egsInformation("\nFluence Scoring (%s)\n",name.c_str());
+    egsInformation("======================================================\n");
+
+    ouputResults();
+    
+}
+
+bool EGS_VolumetricFluence::storeState(ostream &data) const {
+  if( !egsStoreI64(data,current_ncase)) return false;
+  data << endl;
+  if (!data.good()) return false;
+  if( flu ) {
+      for(int j = 0; j < nreg; j++) {
+          if ( is_sensitive[j] ){ 
+             if( !flu[j]->storeState(data) ) return false;
+          }
+      }
+      if( !fluT->storeState(data) ) return false;
+  }
+  return true;  
+}
+
+bool  EGS_VolumetricFluence::setState(istream &data){
+  if( !egsGetI64(data,current_ncase) ) return false;
+  if (!data.good()) return false;
+  if( flu ) {
+      for(int j=0; j<nreg; j++) {
+          if ( is_sensitive[j] ){ 
+             if( !flu[j]->setState(data) ) return false;
+          }
+      }
+      if( !fluT->setState(data) ) return false;
+  }
+  return true;
+}
+
+bool  EGS_VolumetricFluence::addState(istream &data){
+   EGS_I64 tmp_case; if( !egsGetI64(data,tmp_case) ) return false;
+   current_ncase += tmp_case;
+   if (!data.good()) return false;
+   /* fluence objects */
+   if( flu ) {
+       EGS_ScoringArray tg(flu_nbin);
+       for(int j = 0; j < nreg; j++) {
+           if ( is_sensitive[j] ){ 
+             if( !tg.setState(data) ) return false;
+             (*flu[j]) += tg;
+           }
+       }
+       EGS_ScoringArray tgT(nreg);
+       if( !tgT.setState(data) ) return false;
+       (*fluT) += tgT;
+   }
+
+   return true;
+}
+
+
+
+extern "C" {
+
+  EGS_FLUENCE_SCORING_EXPORT EGS_AusgabObject* 
+                          createAusgabObject(EGS_Input *input, EGS_ObjectFactory *f) {
+      const static char *func = "createAusgabObject(fluence_scoring)";
+      if( !input ) {
+          egsWarning("%s: null input?\n",func); return 0;
+      }
+  
+      string type;
+      int error = input->getInput("type",type);
+      if ( !error && input->compare("planar",type) ) {
+        EGS_PlanarFluence *result = new EGS_PlanarFluence("", f);
+        result->setName(input);
+        result->initScoring(input);
+        return result;
+      }
+      else if ( !error && input->compare("volumetric",type) ){
+        EGS_VolumetricFluence *result = new EGS_VolumetricFluence("", f);
+        result->setName(input);
+        result->initScoring(input);
+        return result;
+      }
+      else{
+        egsFatal("Invalid fluence type input?\n\n\n"); 
+        return 0;
+      }
+  }
+
+}

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1396,7 +1396,7 @@ void EGS_VolumetricFluence::describeMe() {
         description += "   Fluence calculated a-la-FLURZ using Lave=EDEP/TVSTEP.\n";
     }
 
-    if (norm_u != 1.0D+0) {
+    if (norm_u != 1.0) {
         description += "\n - Non-unity user-requested normalization = ";
         sprintf(buf,"%g\n",norm_u);
         description += buf;

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -619,7 +619,7 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
           i_dedx = new EGS_Interpolator [n_media];// stp powers
           dedx_i = new EGS_Interpolator [n_media];// its inverse
           for( int j = 0; j < n_media; j++ ){
-              i_dedx[j] = *(app->eDEDX(j));
+              i_dedx[j] = *( app->getDEDX( j, scoring_charge ) );
               EGS_Float Emin = i_dedx[j].getXmin();
               EGS_Float Emax = i_dedx[j].getXmax();
               int n = 1 + i_dedx[j].getIndex(Emax);// getIndex returns lower bin limit?

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1263,9 +1263,6 @@ void EGS_VolumetricFluence::describeMe(){
 void EGS_VolumetricFluence::ouputVolumetricFluence( EGS_ScoringArray *fT, const double &norma ){
     double fe,dfe,dfer;
     double norm = norma;
-#ifndef USETVSTEP
-           norm  *= flu_s? 1.0 : flu_a_i; // Implicit for log grid
-#endif           
     int count = 0;
     int ir_digits = getDigits(nreg);
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Ernesto Mainegra-Hing, 2022
 #
-#  Contributors:    
+#  Contributors:
 #
 ###############################################################################
 */
@@ -45,125 +45,145 @@
 #define REGIONS_PER_LINE 25
 
 EGS_FluenceScoring::EGS_FluenceScoring(const string &Name, EGS_ObjectFactory *f) :
-    EGS_AusgabObject(Name,f), particle_name("photon"), 
-    scoring_charge(photon), source_charge(unknown), 
-    n_scoring_regions(0), n_source_regions(0), 
+    EGS_AusgabObject(Name,f), particle_name("photon"),
+    scoring_charge(photon), source_charge(unknown),
+    n_scoring_regions(0), n_source_regions(0),
     max_reg(-1), active_region(-1),
-    flu_s(0), flu_nbin(128), flu_xmin(0.001), flu_xmax(1.0), 
-    norm_u(1.0), flu(0), fluT(0), flu_p(0), fluT_p(0), current_ncase(0), 
+    flu_s(0), flu_nbin(128), flu_xmin(0.001), flu_xmax(1.0),
+    norm_u(1.0), flu(0), fluT(0), flu_p(0), fluT_p(0), current_ncase(0),
     verbose(false), score_primaries(false), score_spe(false),
-    m_primary(0.0), m_tot(0.0)
-{
-       otype = "EGS_FluenceScoring";
-       flu_a = flu_nbin; flu_a /= (flu_xmax - flu_xmin);
-       flu_b = -flu_xmin*flu_a;
+    m_primary(0.0), m_tot(0.0) {
+    otype = "EGS_FluenceScoring";
+    flu_a = flu_nbin;
+    flu_a /= (flu_xmax - flu_xmin);
+    flu_b = -flu_xmin*flu_a;
 }
 
 /*! Destructor. */
-EGS_FluenceScoring::~EGS_FluenceScoring(){
-       if(flu)  delete [] flu;
-       if(fluT) delete fluT;
-       if(flu_p)  delete [] flu_p;
-       if(fluT_p) delete fluT_p;
+EGS_FluenceScoring::~EGS_FluenceScoring() {
+    if (flu) {
+        delete [] flu;
+    }
+    if (fluT) {
+        delete fluT;
+    }
+    if (flu_p) {
+        delete [] flu_p;
+    }
+    if (fluT_p) {
+        delete fluT_p;
+    }
 }
 
 void EGS_FluenceScoring::initScoring(EGS_Input *inp) {
 
-    if( !inp ) {
-        egsWarning("AO type %s: null input?\n",otype.c_str()); return;
+    if (!inp) {
+        egsWarning("AO type %s: null input?\n",otype.c_str());
+        return;
     }
 
-    vector<string> name; int the_selection = 0;
-    name.push_back("photon"); name.push_back("electron"); name.push_back("positron"); 
+    vector<string> name;
+    int the_selection = 0;
+    name.push_back("photon");
+    name.push_back("electron");
+    name.push_back("positron");
     name.push_back("undefined");
     the_selection = inp->getInput("scoring particle", name, 3);
-    switch(the_selection){
-        case 0:
-          particle_name="photon";
-          scoring_charge = photon;
-          break;
-        case 1:
-          particle_name="electron";
-          scoring_charge = electron;
-          break;
-        case 2:
-          particle_name="positron";
-          scoring_charge = positron;
-          break;
-        default:
-          egsFatal("\n*******  ERROR  *******\n"
-                    " Undefined scoring charge!\n"
-                    " Aborting!\n"
-                    "************************\n");
-    }    
+    switch (the_selection) {
+    case 0:
+        particle_name="photon";
+        scoring_charge = photon;
+        break;
+    case 1:
+        particle_name="electron";
+        scoring_charge = electron;
+        break;
+    case 2:
+        particle_name="positron";
+        scoring_charge = positron;
+        break;
+    default:
+        egsFatal("\n*******  ERROR  *******\n"
+                 " Undefined scoring charge!\n"
+                 " Aborting!\n"
+                 "************************\n");
+    }
 
     the_selection = inp->getInput("source particle", name, 3);
-    switch(the_selection){
-        case 0:
-          source_charge = photon;
-          break;
-        case 1:
-          source_charge = electron;
-          break;
-        case 2:
-          source_charge = positron;
-          break;
-        default:
-          source_charge = unknown;
-    }    
+    switch (the_selection) {
+    case 0:
+        source_charge = photon;
+        break;
+    case 1:
+        source_charge = electron;
+        break;
+    case 2:
+        source_charge = positron;
+        break;
+    default:
+        source_charge = unknown;
+    }
 
-    vector<string> choice; 
+    vector<string> choice;
     choice.push_back("no");
     choice.push_back("yes");
     verbose         = inp->getInput("verbose",        choice,0);
     score_primaries = inp->getInput("score primaries",choice,0);
-    score_spe      = inp->getInput( "score spectrum", choice,0);
+    score_spe      = inp->getInput("score spectrum", choice,0);
 
-    if ( score_spe ){
-       EGS_Float flu_Emin, flu_Emax;
-       EGS_Input *eGrid = inp->takeInputItem("energy grid");
-       if( eGrid ) {
-          int err_n    = eGrid->getInput("number of bins",flu_nbin);
-          int err_i    = eGrid->getInput("minimum kinetic energy",flu_Emin);
-          int err_f    = eGrid->getInput("maximum kinetic energy",flu_Emax);
-          if (err_n) egsFatal("\n**** EGS_FluenceScoring::initScoring"
-                              "       Missing input: number of bins.\n"
-                              "       Aborting!\n\n");
-          if (err_i) egsFatal("\n**** EGS_FluenceScoring::initScoring"
-                              "       Missing input: minimum kinetic energy.\n"
-                              "       Aborting!\n\n");
-          if (err_f) egsFatal("\n**** EGS_FluenceScoring::initScoring"
-                              "       Missing input: maximum kinetic energy.\n"
-                              "       Aborting!\n\n");
-       }
-       EGS_Float norma;
-       int err_norm = inp->getInput("normalization",norma);
-       if (!err_norm) norm_u = norma;
-       else           norm_u = 1.0;
-   
-       vector<string> scale;
-       scale.push_back("linear"); scale.push_back("logarithmic");
-       flu_s = inp->getInput("scale",scale,0);
-       if( flu_s == 0 ) {
-           flu_xmin = flu_Emin; flu_xmax = flu_Emax;
-       }
-       else {
-           flu_xmin = log(flu_Emin); flu_xmax = log(flu_Emax);
-       }
-       flu_a = flu_nbin; flu_a /= (flu_xmax - flu_xmin);
-       flu_b = -flu_xmin*flu_a;
-       /****************************************************** 
-          Algorithm assigns E in [Ei,Ei+1), one could add extra
-          bin for E = Emax cases. Alternatively, push those
-          events into last bin (bias?) during scoring.
-          Which approach is correct?
-        ******************************************************/
-       //flu_nbin++;
+    if (score_spe) {
+        EGS_Float flu_Emin, flu_Emax;
+        EGS_Input *eGrid = inp->takeInputItem("energy grid");
+        if (eGrid) {
+            int err_n    = eGrid->getInput("number of bins",flu_nbin);
+            int err_i    = eGrid->getInput("minimum kinetic energy",flu_Emin);
+            int err_f    = eGrid->getInput("maximum kinetic energy",flu_Emax);
+            if (err_n) egsFatal("\n**** EGS_FluenceScoring::initScoring"
+                                    "       Missing input: number of bins.\n"
+                                    "       Aborting!\n\n");
+            if (err_i) egsFatal("\n**** EGS_FluenceScoring::initScoring"
+                                    "       Missing input: minimum kinetic energy.\n"
+                                    "       Aborting!\n\n");
+            if (err_f) egsFatal("\n**** EGS_FluenceScoring::initScoring"
+                                    "       Missing input: maximum kinetic energy.\n"
+                                    "       Aborting!\n\n");
+        }
+        EGS_Float norma;
+        int err_norm = inp->getInput("normalization",norma);
+        if (!err_norm) {
+            norm_u = norma;
+        }
+        else {
+            norm_u = 1.0;
+        }
+
+        vector<string> scale;
+        scale.push_back("linear");
+        scale.push_back("logarithmic");
+        flu_s = inp->getInput("scale",scale,0);
+        if (flu_s == 0) {
+            flu_xmin = flu_Emin;
+            flu_xmax = flu_Emax;
+        }
+        else {
+            flu_xmin = log(flu_Emin);
+            flu_xmax = log(flu_Emax);
+        }
+        flu_a = flu_nbin;
+        flu_a /= (flu_xmax - flu_xmin);
+        flu_b = -flu_xmin*flu_a;
+        /******************************************************
+           Algorithm assigns E in [Ei,Ei+1), one could add extra
+           bin for E = Emax cases. Alternatively, push those
+           events into last bin (bias?) during scoring.
+           Which approach is correct?
+         ******************************************************/
+        //flu_nbin++;
     }
 
-    /* 
+    /*
        Get source regions where interacting particles
-       are not subjected to classification 
+       are not subjected to classification
     */
     vector <int> s_start, s_stop;
     /*
@@ -179,10 +199,10 @@ void EGS_FluenceScoring::initScoring(EGS_Input *inp) {
             if (s_start.size() == s_stop.size()) { // group of dose regions
                 for (int i=0; i<s_start.size(); i++) {
                     int ir = s_start[i], fr = s_stop[i];
-                    if (ir > fr) 
-                       egsFatal("\nEGS_FluenceScoring::initScoring: \n"
-                       "  Decreasing start (%d) / stop %d region in source region group %d\n"
-                       "  Aborting!\n\n", ir, fr, i );
+                    if (ir > fr)
+                        egsFatal("\nEGS_FluenceScoring::initScoring: \n"
+                                 "  Decreasing start (%d) / stop %d region in source region group %d\n"
+                                 "  Aborting!\n\n", ir, fr, i);
                     for (int ireg=ir; ireg<=fr; ireg++) {
                         s_region.push_back(ireg);
                     }
@@ -198,42 +218,45 @@ void EGS_FluenceScoring::initScoring(EGS_Input *inp) {
 
 }
 
-void EGS_FluenceScoring::getSensitiveRegions(EGS_Input *inp){
+void EGS_FluenceScoring::getSensitiveRegions(EGS_Input *inp) {
 
     string listLabel, startLabel, stopLabel;
 
-    if ( otype == "EGS_PlanarFluence" ){
-       listLabel  = "contributing regions";
-       startLabel = "start contributing region";
-       stopLabel  = "stop contributing region";
+    if (otype == "EGS_PlanarFluence") {
+        listLabel  = "contributing regions";
+        startLabel = "start contributing region";
+        stopLabel  = "stop contributing region";
     }
-    else if (otype == "EGS_VolumetricFluence"){
-       listLabel  = "scoring regions";
-       startLabel = "start region";
-       stopLabel  = "stop region";
+    else if (otype == "EGS_VolumetricFluence") {
+        listLabel  = "scoring regions";
+        startLabel = "start region";
+        stopLabel  = "stop region";
     }
-    else
-      egsFatal("\n*** Unknown fluence scoriung type! Aborting!\n\n");
+    else {
+        egsFatal("\n*** Unknown fluence scoriung type! Aborting!\n\n");
+    }
 
     /* get scoring regions */
     if (!inp->getInput(listLabel,f_regionsString) && f_regionsString.length()>0) {
         // Individual regions
-        if ( f_regionsString == "ALL")
-           score_in_all_regions = true;
-        else    
-           score_in_all_regions = false;
+        if (f_regionsString == "ALL") {
+            score_in_all_regions = true;
+        }
+        else {
+            score_in_all_regions = false;
+        }
     }
     else {// Groups of regions
         int err1 = inp->getInput(startLabel,f_start);
         int err2 = inp->getInput(stopLabel, f_stop);
         if (!err1 && !err2) {
-            if ( f_start.size() == f_stop.size() ){ // group of dose regions
-                for ( int i=0; i<f_start.size(); i++ ){
+            if (f_start.size() == f_stop.size()) {  // group of dose regions
+                for (int i=0; i<f_start.size(); i++) {
                     int ir = f_start[i], fr = f_stop[i];
-                    if ( ir > fr ) 
-                       egsFatal("\nEGS_FluenceScoring::initScoring: \n"
-                       "  Decreasing start (%d) / stop (%d) in region group %d\n"
-                       "  Aborting!\n\n", ir, fr, i );
+                    if (ir > fr)
+                        egsFatal("\nEGS_FluenceScoring::initScoring: \n"
+                                 "  Decreasing start (%d) / stop (%d) in region group %d\n"
+                                 "  Aborting!\n\n", ir, fr, i);
                     for (int ireg=ir; ireg<=fr; ireg++) {
                         f_region.push_back(ireg);
                     }
@@ -249,181 +272,197 @@ void EGS_FluenceScoring::getSensitiveRegions(EGS_Input *inp){
     }
 
 }
-void EGS_FluenceScoring::getNumberRegions( const string &str, vector<int> &regs ){
-    if ( !app ) 
-       egsFatal("EGS_FluenceScoring::getNumberRegions\n"
-                "  Undefined parent application! Aborting!\n");
+void EGS_FluenceScoring::getNumberRegions(const string &str, vector<int> &regs) {
+    if (!app)
+        egsFatal("EGS_FluenceScoring::getNumberRegions\n"
+                 "  Undefined parent application! Aborting!\n");
 
     app->getNumberRegions(str, regs);
 }
 
-void EGS_FluenceScoring::getLabelRegions( const string &str, vector<int> &regs ) {
-    if ( !app ) 
-       egsFatal("EGS_FluenceScoring::getLabelRegions\n"
-                "  Undefined parent application! Aborting!\n");
+void EGS_FluenceScoring::getLabelRegions(const string &str, vector<int> &regs) {
+    if (!app)
+        egsFatal("EGS_FluenceScoring::getLabelRegions\n"
+                 "  Undefined parent application! Aborting!\n");
 
     app->getLabelRegions(str, regs);
 }
 
 void EGS_FluenceScoring::setUpRegionFlags() {
 
-    if ( s_regionsString.length() > 0 && !s_region.size() ) {
-        getNumberRegions(s_regionsString, s_region );
-        getLabelRegions( s_regionsString, s_region );
+    if (s_regionsString.length() > 0 && !s_region.size()) {
+        getNumberRegions(s_regionsString, s_region);
+        getLabelRegions(s_regionsString, s_region);
     }
     // Get the number of source regions. If too many, reset to nreg.
     n_source_regions = s_region.size() < nreg ? s_region.size() : nreg;
 
-    if ( !score_in_all_regions ){
-       if ( f_regionsString.length() > 0 && !f_region.size() ){
-          getNumberRegions(f_regionsString, f_region);
-          getLabelRegions(f_regionsString, f_region);
-       }
-       // Get the number of scoring regions. If too many, reset to nreg
-       n_scoring_regions = f_region.size() < nreg ? f_region.size() : nreg;
+    if (!score_in_all_regions) {
+        if (f_regionsString.length() > 0 && !f_region.size()) {
+            getNumberRegions(f_regionsString, f_region);
+            getLabelRegions(f_regionsString, f_region);
+        }
+        // Get the number of scoring regions. If too many, reset to nreg
+        n_scoring_regions = f_region.size() < nreg ? f_region.size() : nreg;
     }
-    else if ( score_in_all_regions ){
+    else if (score_in_all_regions) {
         n_scoring_regions = nreg;
         for (int j=0; j<nreg; j++) {
             f_region.push_back(j);
         }
     }
 
-    if ( n_source_regions == nreg && score_primaries ) 
-       egsWarning("=> Warning: Setting n_source_regions = nreg \n"
-                  "            effectively supresses classification\n"
-                  "            of primaries and secondaries!");
+    if (n_source_regions == nreg && score_primaries)
+        egsWarning("=> Warning: Setting n_source_regions = nreg \n"
+                   "            effectively supresses classification\n"
+                   "            of primaries and secondaries!");
     for (int i = 0; i < n_source_regions; i++) {
         is_source[s_region[i]] = true;
     }
 
     for (int i = 0; i < n_scoring_regions; i++) {
         is_sensitive[f_region[i]] = true;
-        if ( f_region[i] > max_reg ) max_reg = f_region[i];
+        if (f_region[i] > max_reg) {
+            max_reg = f_region[i];
+        }
     }
 }
 
-void EGS_FluenceScoring::describeMe(){
+void EGS_FluenceScoring::describeMe() {
 
     char buf[128];
 
     // Report scoring regions in the geometry.
-    if ( n_scoring_regions == nreg )
-       description += "ALL\n";
-    else{
-       int start = 0, stop = 0, k = 0, entries = 0;
-       bool line_ended;
-       /* List up to 100 scoring groups or regions */
-       while (k < nreg && entries < REGIONS_ENTRIES){
-           line_ended = false;
-           if( is_sensitive[k] ){
-             start = k;
-             entries++;
-             while( is_sensitive[k] && k < nreg) {
-                 k++;
-             }
-             stop = k-1;
-             if ( start < stop ){
-                sprintf(buf,"%d-%d",start,stop);
-             }
-             else if ( k % REGIONS_PER_LINE ){
-                sprintf(buf," %d",start);
-             }
-             else{
-                sprintf(buf," %d\n",start);
-                line_ended = true;
-             }
-             if (entries == REGIONS_ENTRIES){
-                sprintf(buf,"... %d\n",max_reg);
-                line_ended = true;
-             }
-             description += buf;
-           }
-           k++;
-       }
-       if (!line_ended) description += "\n";
+    if (n_scoring_regions == nreg) {
+        description += "ALL\n";
+    }
+    else {
+        int start = 0, stop = 0, k = 0, entries = 0;
+        bool line_ended;
+        /* List up to 100 scoring groups or regions */
+        while (k < nreg && entries < REGIONS_ENTRIES) {
+            line_ended = false;
+            if (is_sensitive[k]) {
+                start = k;
+                entries++;
+                while (is_sensitive[k] && k < nreg) {
+                    k++;
+                }
+                stop = k-1;
+                if (start < stop) {
+                    sprintf(buf,"%d-%d",start,stop);
+                }
+                else if (k % REGIONS_PER_LINE) {
+                    sprintf(buf," %d",start);
+                }
+                else {
+                    sprintf(buf," %d\n",start);
+                    line_ended = true;
+                }
+                if (entries == REGIONS_ENTRIES) {
+                    sprintf(buf,"... %d\n",max_reg);
+                    line_ended = true;
+                }
+                description += buf;
+            }
+            k++;
+        }
+        if (!line_ended) {
+            description += "\n";
+        }
     }
 
-    if ( score_primaries ){
-       if ( source_charge == unknown ){
-           source_charge = scoring_charge;
-           description += " - Unknown source charge due to multi-particle source\n";
-           description += "   and no user input defining source particle type!\n";
-           description += "   Defaulting to scoring charge: ";
-       }
-       else{
-           description += " - source charge: ";
-       }
-       sprintf(buf,"%d\n",source_charge);
-       description += buf;
+    if (score_primaries) {
+        if (source_charge == unknown) {
+            source_charge = scoring_charge;
+            description += " - Unknown source charge due to multi-particle source\n";
+            description += "   and no user input defining source particle type!\n";
+            description += "   Defaulting to scoring charge: ";
+        }
+        else {
+            description += " - source charge: ";
+        }
+        sprintf(buf,"%d\n",source_charge);
+        description += buf;
     }
 
-    if (score_spe){
-       description += " - scoring in the ";
-       EGS_Float Emin = flu_s ? exp(flu_xmin):flu_xmin, 
-                 Emax = flu_s ? exp(flu_xmax):flu_xmax;
-       sprintf(buf,"%g MeV and %g MeV energy range",Emin,Emax);
-       description += buf;
-       if (flu_s)
-          description += " on a logarithmic scale \n";
-       else
-          description += " on a linear scale \n";
+    if (score_spe) {
+        description += " - scoring in the ";
+        EGS_Float Emin = flu_s ? exp(flu_xmin):flu_xmin,
+                  Emax = flu_s ? exp(flu_xmax):flu_xmax;
+        sprintf(buf,"%g MeV and %g MeV energy range",Emin,Emax);
+        description += buf;
+        if (flu_s) {
+            description += " on a logarithmic scale \n";
+        }
+        else {
+            description += " on a linear scale \n";
+        }
     }
 }
-/********************************************** 
+/**********************************************
  * Class EGS_PlanarFluence Implementation *
 ***********************************************/
 
 
 EGS_PlanarFluence::EGS_PlanarFluence(const string &Name, EGS_ObjectFactory *f) :
-    EGS_FluenceScoring(Name,f), hits_field(false), Nx(1), Ny(1)
-{
+    EGS_FluenceScoring(Name,f), hits_field(false), Nx(1), Ny(1) {
     otype = "EGS_PlanarFluence";
     m_midpoint = EGS_Vector(0,0,5);
     m_R  =  5;
     m_R2 = 25;
-    field_type = circle; Area = M_PI * m_R2;
+    field_type = circle;
+    Area = M_PI * m_R2;
     m_normal = EGS_Vector(0,0,1);
     m_d = m_normal*m_midpoint;
 }
 
 /*! Destructor.  */
-EGS_PlanarFluence::~EGS_PlanarFluence(){
+EGS_PlanarFluence::~EGS_PlanarFluence() {
 
-   if( flu ) {
-       for(int j=0; j<Nx*Ny; j++) {delete flu[j];}
-   }
-   if( flu_p ) {
-       for(int j=0; j<Nx*Ny; j++) {delete flu_p[j];}
-   }
+    if (flu) {
+        for (int j=0; j<Nx*Ny; j++) {
+            delete flu[j];
+        }
+    }
+    if (flu_p) {
+        for (int j=0; j<Nx*Ny; j++) {
+            delete flu_p[j];
+        }
+    }
 }
 
 void EGS_PlanarFluence::setApplication(EGS_Application *App) {
 
     EGS_AusgabObject::setApplication(App);
 
-    if( !app ) return;
+    if (!app) {
+        return;
+    }
 
-    /*********************************************************** 
-       Defaults to charge of application source. This applies most 
-       of the time, except for bremsstrahlung targets and multiple 
-       particle sources such as radiactive sources. 
+    /***********************************************************
+       Defaults to charge of application source. This applies most
+       of the time, except for bremsstrahlung targets and multiple
+       particle sources such as radiactive sources.
        Can be changed via 'source particle' input.
     *************************************************************/
-    if ( source_charge == unknown )
-         source_charge = (ParticleType)app->sourceCharge();
+    if (source_charge == unknown) {
+        source_charge = (ParticleType)app->sourceCharge();
+    }
 
 
-   // Get the number of regions in the geometry.
+    // Get the number of regions in the geometry.
     nreg = app->getnRegions();
 
     /* Initialize arrays with defaults */
     for (int j=0; j<nreg; j++) {
 
-        if ( !score_in_all_regions )
-           is_sensitive.push_back(false);
-        else
-           is_sensitive.push_back(true);
+        if (!score_in_all_regions) {
+            is_sensitive.push_back(false);
+        }
+        else {
+            is_sensitive.push_back(true);
+        }
 
         is_source.push_back(false);
     }
@@ -433,21 +472,21 @@ void EGS_PlanarFluence::setApplication(EGS_Application *App) {
 
     /* Setup fluence scoring arrays, Nx*Ny = 1 for the circle */
     fluT = new EGS_ScoringArray(Nx*Ny);
-    if ( score_spe ){
-       flu  = new EGS_ScoringArray* [Nx*Ny];
-       for (int j = 0; j < Nx*Ny; j++) {
-           flu[j] = new EGS_ScoringArray(flu_nbin);
-       }
+    if (score_spe) {
+        flu  = new EGS_ScoringArray* [Nx*Ny];
+        for (int j = 0; j < Nx*Ny; j++) {
+            flu[j] = new EGS_ScoringArray(flu_nbin);
+        }
     }
 
-    if ( score_primaries ){
-       fluT_p = new EGS_ScoringArray(Nx*Ny);
-       if ( score_spe ){
-          flu_p  = new EGS_ScoringArray* [Nx*Ny];
-          for (int j = 0; j < Nx*Ny; j++){ 
-              flu_p[j] = new EGS_ScoringArray(flu_nbin);
-          }           
-       }
+    if (score_primaries) {
+        fluT_p = new EGS_ScoringArray(Nx*Ny);
+        if (score_spe) {
+            flu_p  = new EGS_ScoringArray* [Nx*Ny];
+            for (int j = 0; j < Nx*Ny; j++) {
+                flu_p[j] = new EGS_ScoringArray(flu_nbin);
+            }
+        }
     }
 
     describeMe();
@@ -457,15 +496,16 @@ void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
 
     EGS_Input *pScoringInput;
 
-    if( !inp ) {
-        egsFatal("AO type %s: null input?\n",otype.c_str()); return;
+    if (!inp) {
+        egsFatal("AO type %s: null input?\n",otype.c_str());
+        return;
     }
-    else{
-       pScoringInput = inp->takeInputItem("planar scoring");
-       if( ! pScoringInput ){
-           egsFatal("AO type %s: Missing planar scoring input?\n",otype.c_str()); 
-           return;
-       }
+    else {
+        pScoringInput = inp->takeInputItem("planar scoring");
+        if (! pScoringInput) {
+            egsFatal("AO type %s: Missing planar scoring input?\n",otype.c_str());
+            return;
+        }
     }
 
     EGS_FluenceScoring::initScoring(inp);// common inputs
@@ -477,17 +517,19 @@ void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
     // Specific plane input
     vector<EGS_Float> tmp_field;
     int err2 = pScoringInput->getInput("scoring circle",tmp_field);
-    if( err2 ) {
+    if (err2) {
         int err3 =  pScoringInput->getInput("scoring rectangle",tmp_field);
-        if( err3 || tmp_field.size() != 4) {
+        if (err3 || tmp_field.size() != 4) {
             egsWarning(
-            "\n\n***  Wrong/missing 'scoring rectangle' input "
-            "setting it to 10 cm X 10 cm field at origin!\n\n");
+                "\n\n***  Wrong/missing 'scoring rectangle' input "
+                "setting it to 10 cm X 10 cm field at origin!\n\n");
             m_midpoint = EGS_Vector();
-            ax = 10; ay = 10;
-            field_type = rectangle; Area = ax*ay;
+            ax = 10;
+            ay = 10;
+            field_type = rectangle;
+            Area = ax*ay;
         }
-        else{
+        else {
             EGS_Float xmin = tmp_field[0],xmax = tmp_field[1],
                       ymin = tmp_field[2],ymax = tmp_field[3];
             /* scoring plane location in space */
@@ -495,99 +537,116 @@ void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
             /* scoring plane normal */
             m_normal = EGS_Vector(0,0,1); // default normal along positive z-axis
             /* define unit vectors on right-handed scoring plane */
-            ux = EGS_Vector(1,0,0); uy = EGS_Vector(0,1,0);
+            ux = EGS_Vector(1,0,0);
+            uy = EGS_Vector(0,1,0);
             /* Request a scoring plane transformation for initial position and orientation */
             EGS_AffineTransform *t = EGS_AffineTransform::getTransformation(inp);
-            if (t){
-                t->rotate(m_normal) ; t->transform(m_midpoint);
-                t->rotate(ux); t->rotate(uy);
+            if (t) {
+                t->rotate(m_normal) ;
+                t->transform(m_midpoint);
+                t->rotate(ux);
+                t->rotate(uy);
                 delete t;
             }
-            
+
             /* get screen resolution */
             vector<int> screen;
             int err4 = pScoringInput->getInput("resolution",screen);
-            if( err4 ) {
-              Nx=1; Ny=1;
-              egsWarning(
-              "\n\n***  Missing/wrong 'resolution' input "
-              "     Scoring in the whole field\n\n");
-              
+            if (err4) {
+                Nx=1;
+                Ny=1;
+                egsWarning(
+                    "\n\n***  Missing/wrong 'resolution' input "
+                    "     Scoring in the whole field\n\n");
+
             }
-            else if (screen.size()==1){ Nx = screen[0];Ny = screen[0];}
-            else if (screen.size()==2){ Nx = screen[0];Ny = screen[1];}
-            else if (screen.size()> 2){ Nx = screen[0];Ny = screen[1];
-              egsWarning(
-              "\n\n***  Too many 'resolution' inputs\n"
-              "     Using first two entries\n\n");
+            else if (screen.size()==1) {
+                Nx = screen[0];
+                Ny = screen[0];
+            }
+            else if (screen.size()==2) {
+                Nx = screen[0];
+                Ny = screen[1];
+            }
+            else if (screen.size()> 2) {
+                Nx = screen[0];
+                Ny = screen[1];
+                egsWarning(
+                    "\n\n***  Too many 'resolution' inputs\n"
+                    "     Using first two entries\n\n");
 
             }
 
-            ax = xmax - xmin; ay = ymax-ymin;
-            vx = ax/Nx; vy = ay/Ny;
-            field_type = rectangle; Area = vx*vy;
+            ax = xmax - xmin;
+            ay = ymax-ymin;
+            vx = ax/Nx;
+            vy = ay/Ny;
+            field_type = rectangle;
+            Area = vx*vy;
         }
     }
-    else if( tmp_field.size() != 4 ) {
+    else if (tmp_field.size() != 4) {
         egsWarning(
-        "\n\n***  Wrong/missing 'scoring circle' input "
-        "setting it to 10 cm diameter field at origin!\n\n");
+            "\n\n***  Wrong/missing 'scoring circle' input "
+            "setting it to 10 cm diameter field at origin!\n\n");
         m_midpoint = EGS_Vector();
         m_R  =  5;
         m_R2 = 25;
-        field_type = circle; Area = M_PI * m_R2;
+        field_type = circle;
+        Area = M_PI * m_R2;
     }
-    else{
+    else {
         vector<EGS_Float> tmp_normal;
         int err1 = pScoringInput->getInput("scoring plane normal",tmp_normal);
-        if( err1 || tmp_normal.size() != 3 ) {
-          egsWarning(
-          "\n\n***  Wrong/missing 'scoring plane normal' input. "
-          "Set along positive z-axis\n\n");
-          m_normal = EGS_Vector(0,0,1);// Default along positive z-axis
+        if (err1 || tmp_normal.size() != 3) {
+            egsWarning(
+                "\n\n***  Wrong/missing 'scoring plane normal' input. "
+                "Set along positive z-axis\n\n");
+            m_normal = EGS_Vector(0,0,1);// Default along positive z-axis
         }
-        else{
-          m_normal = EGS_Vector(tmp_normal[0],tmp_normal[1],
-                                tmp_normal[2]);
-          m_normal.normalize();
+        else {
+            m_normal = EGS_Vector(tmp_normal[0],tmp_normal[1],
+                                  tmp_normal[2]);
+            m_normal.normalize();
         }
         m_midpoint = EGS_Vector(tmp_field[0],tmp_field[1],
                                 tmp_field[2]);
-        m_R = tmp_field[3]; 
+        m_R = tmp_field[3];
         m_R2 = tmp_field[3]*tmp_field[3];
-        field_type = circle; Area = M_PI * m_R2;
+        field_type = circle;
+        Area = M_PI * m_R2;
     }
 
     m_d = m_normal*m_midpoint;
 }
 
-void EGS_PlanarFluence::describeMe(){
+void EGS_PlanarFluence::describeMe() {
     char buf[128];
     sprintf(buf,"\nPlanar %s fluence scoring\n",particle_name.c_str());
     description =  buf;
     description += "================================\n";
 
     description += " - scoring field normal      = ";
-    sprintf(buf,"(%g %g %g)\n",m_normal.x,m_normal.y,m_normal.z); 
+    sprintf(buf,"(%g %g %g)\n",m_normal.x,m_normal.y,m_normal.z);
     description += buf;
     description += " - scoring field center      = ";
-    sprintf(buf,"(%g %g %g)\n",m_midpoint.x,m_midpoint.y,m_midpoint.z); 
+    sprintf(buf,"(%g %g %g)\n",m_midpoint.x,m_midpoint.y,m_midpoint.z);
     description += buf;
-    if (field_type == circle){
-       description += " - scoring field radius      = ";
-       sprintf(buf,"%g cm\n",m_R); 
-       description += buf;
+    if (field_type == circle) {
+        description += " - scoring field radius      = ";
+        sprintf(buf,"%g cm\n",m_R);
+        description += buf;
     }
     else if (field_type == rectangle) {
-       description += " - scoring field             = ";
-       sprintf(buf,"%g cm X %g cm\n",ax,ay); 
-       description += buf;
-       description += " - scoring field resolution  = ";
-       sprintf(buf,"%d X %d\n",Nx,Ny); 
-       description += buf;
+        description += " - scoring field             = ";
+        sprintf(buf,"%g cm X %g cm\n",ax,ay);
+        description += buf;
+        description += " - scoring field resolution  = ";
+        sprintf(buf,"%d X %d\n",Nx,Ny);
+        description += buf;
     }
     description += " - scoring field distance from origin = ";
-    sprintf(buf,"%g cm\n",m_d); 
+    sprintf(buf,"%g cm\n",m_d);
     description += buf;
 
     description +=" - scoring from region(s): ";
@@ -596,246 +655,277 @@ void EGS_PlanarFluence::describeMe(){
 
 }
 
-void EGS_PlanarFluence::score(const EGS_Particle& p, const int& ivoxel){
-     EGS_Float up = p.u*m_normal, aup = fabs(up); 
-     /********************************************************** 
-      Prevent large weights from particles very close to plane.
-     ***********************************************************/
-     if( aup < 0.08 ) aup = 0.0871557;// Limit incident angle to 85 degrees
-     EGS_Float e = p.q ? p.E - app->getRM() : p.E;
-     if( flu_s ) {e = log(e);} // log scale
-     EGS_Float ae; int je;
-     EGS_Float auxp = p.wt/aup;
-     /* Score total fluence in corresponding pixel */
-     fluT->score(ivoxel,auxp);
-     if (score_primaries && !p.latch) 
+void EGS_PlanarFluence::score(const EGS_Particle &p, const int &ivoxel) {
+    EGS_Float up = p.u*m_normal, aup = fabs(up);
+    /**********************************************************
+     Prevent large weights from particles very close to plane.
+    ***********************************************************/
+    if (aup < 0.08) {
+        aup = 0.0871557;    // Limit incident angle to 85 degrees
+    }
+    EGS_Float e = p.q ? p.E - app->getRM() : p.E;
+    if (flu_s) {
+        e = log(e);   // log scale
+    }
+    EGS_Float ae;
+    int je;
+    EGS_Float auxp = p.wt/aup;
+    /* Score total fluence in corresponding pixel */
+    fluT->score(ivoxel,auxp);
+    if (score_primaries && !p.latch) {
         fluT_p->score(ivoxel,auxp);
-     /* Score differential fluence in corresponding pixel */
-     if( score_spe && e > flu_xmin && e <= flu_xmax ){
-          ae = flu_a*e + flu_b; 
-          /****************************************************** 
-            Algorithm assigns E in [Ei,Ei+1), hence push events
-            with E = Emax into last bin (bias?) during scoring.
-            Alternatively add extra bin for E = Emax cases.
-            Which approach is correct?
-          ******************************************************/
-          je = min((int)ae,flu_nbin-1);//je = (int) ae;
-         /******************************************************/
-          if (ivoxel < 0 || ivoxel > Nx*Ny)
-             egsFatal("\n-> Scoring out of bounds, ivoxel = %d\n",ivoxel);
-          EGS_ScoringArray *aux   = flu[ivoxel];
-          if (je < 0 || je >= flu_nbin )
-             egsFatal("\n-> Scoring out of bounds, ibin = %d ae = %g E = %g MeV\n",je,ae,e);
-          aux->score(je,auxp);
-          if (score_primaries && !p.latch) {
-             flu_p[ivoxel]->score(je,auxp);
-          }
-     }
+    }
+    /* Score differential fluence in corresponding pixel */
+    if (score_spe && e > flu_xmin && e <= flu_xmax) {
+        ae = flu_a*e + flu_b;
+        /******************************************************
+          Algorithm assigns E in [Ei,Ei+1), hence push events
+          with E = Emax into last bin (bias?) during scoring.
+          Alternatively add extra bin for E = Emax cases.
+          Which approach is correct?
+        ******************************************************/
+        je = min((int)ae,flu_nbin-1);//je = (int) ae;
+        /******************************************************/
+        if (ivoxel < 0 || ivoxel > Nx*Ny) {
+            egsFatal("\n-> Scoring out of bounds, ivoxel = %d\n",ivoxel);
+        }
+        EGS_ScoringArray *aux   = flu[ivoxel];
+        if (je < 0 || je >= flu_nbin) {
+            egsFatal("\n-> Scoring out of bounds, ibin = %d ae = %g E = %g MeV\n",je,ae,e);
+        }
+        aux->score(je,auxp);
+        if (score_primaries && !p.latch) {
+            flu_p[ivoxel]->score(je,auxp);
+        }
+    }
 }
 
-int EGS_PlanarFluence::hitsField(const EGS_Particle& p, EGS_Float* dist){
-     if ( field_type==circle ){
-         EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
-         if( (up > 0 && m_d > xp ) || 
-             (up < 0 && m_d < xp ) ){
-             EGS_Float t = (m_d - xp)/up;
-             EGS_Vector x1(p.x + p.u*t - m_midpoint);
-             if( dist ) *dist = t;
-             return x1.length2() < m_R*m_R ? 0:-1;
-         }
-         return -1;
-     }
-     else if ( field_type == rectangle ){
-         EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
-         if( (up > 0 && m_d > xp) || (up < 0 && m_d < xp) ) {
-             EGS_Float t = (m_d - xp)/up; // distance to plane along u
-             EGS_Vector x1(p.x + p.u*t - m_midpoint);// vector on scoring plane
-             EGS_Float xcomp = x1*ux;// x-direction component
-             EGS_Float ycomp = x1*uy;// y-direction component
-                       xcomp = 2*xcomp + ax;
-                       ycomp = 2*ycomp + ay;
-             if( xcomp > 0 && xcomp < 2*ax && 
-                 ycomp > 0 && ycomp < 2*ay ){
-                 int i = int(xcomp/(2*vx)),
-                     j = int(ycomp/(2*vy)),
-                     k = i + j*Nx;
-                 if( dist ) *dist = t;
-                 return k;
-             }
-         }
-         return -1;
-     }
-     else return -1;
+int EGS_PlanarFluence::hitsField(const EGS_Particle &p, EGS_Float *dist) {
+    if (field_type==circle) {
+        EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
+        if ((up > 0 && m_d > xp) ||
+                (up < 0 && m_d < xp)) {
+            EGS_Float t = (m_d - xp)/up;
+            EGS_Vector x1(p.x + p.u*t - m_midpoint);
+            if (dist) {
+                *dist = t;
+            }
+            return x1.length2() < m_R*m_R ? 0:-1;
+        }
+        return -1;
+    }
+    else if (field_type == rectangle) {
+        EGS_Float xp = p.x*m_normal, up = p.u*m_normal;
+        if ((up > 0 && m_d > xp) || (up < 0 && m_d < xp)) {
+            EGS_Float t = (m_d - xp)/up; // distance to plane along u
+            EGS_Vector x1(p.x + p.u*t - m_midpoint);// vector on scoring plane
+            EGS_Float xcomp = x1*ux;// x-direction component
+            EGS_Float ycomp = x1*uy;// y-direction component
+            xcomp = 2*xcomp + ax;
+            ycomp = 2*ycomp + ay;
+            if (xcomp > 0 && xcomp < 2*ax &&
+                    ycomp > 0 && ycomp < 2*ay) {
+                int i = int(xcomp/(2*vx)),
+                    j = int(ycomp/(2*vy)),
+                    k = i + j*Nx;
+                if (dist) {
+                    *dist = t;
+                }
+                return k;
+            }
+        }
+        return -1;
+    }
+    else {
+        return -1;
+    }
 }
 
-void EGS_PlanarFluence::ouputPlanarFluence( EGS_ScoringArray *fT, const double &norma ){
+void EGS_PlanarFluence::ouputPlanarFluence(EGS_ScoringArray *fT, const double &norma) {
     double fe,dfe,dfer;
     int count = 0;
     int ix_digits = getDigits(Nx);
     int iy_digits = getDigits(Ny);
     int xy_digits = getDigits(Nx*Ny);
 
-    if (field_type == circle){
-       egsInformation("\n  pixel#    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
-                        "-----------------------------------------------------\n");
+    if (field_type == circle) {
+        egsInformation("\n  pixel#    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
+                       "-----------------------------------------------------\n");
     }
-    else{
-       egsInformation("\n  %*s %*s pixel#    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
-                        "-----------------------------------------------------\n",
-                      iy_digits,"iy",ix_digits,"ix",&count);
+    else {
+        egsInformation("\n  %*s %*s pixel#    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
+                       "-----------------------------------------------------\n",
+                       iy_digits,"iy",ix_digits,"ix",&count);
     }
-    if (field_type == circle){
-       int k = 0;
-       egsInformation("   %*d      ",xy_digits,k);
-       fT->currentResult(k,fe,dfe);
-       if( fe > 0 ) dfer = 100*dfe/fe; else dfer = 100;
-       egsInformation(" %10.4le +/- %10.4le [%-7.3lf\%]\n",fe*norma,dfe*norma,dfer);
+    if (field_type == circle) {
+        int k = 0;
+        egsInformation("   %*d      ",xy_digits,k);
+        fT->currentResult(k,fe,dfe);
+        if (fe > 0) {
+            dfer = 100*dfe/fe;
+        }
+        else {
+            dfer = 100;
+        }
+        egsInformation(" %10.4le +/- %10.4le [%-7.3lf\%]\n",fe*norma,dfe*norma,dfer);
     }
-    else{
-       for(int j=0; j<Ny; j++) {     
-         for(int i=0; i<Nx; i++) {     
-             int k = i + j*Nx;
-             egsInformation("   %*d  %*d  %*d      ",iy_digits,j,ix_digits,i,xy_digits,k);
-             fT->currentResult(k,fe,dfe);
-             if( fe > 0 ) dfer = 100*dfe/fe; else dfer = 100;
-             egsInformation(" %10.4le +/- %10.4le [%-7.3lf\%]\n",fe*norma,dfe*norma,dfer);
-         }
-       }
+    else {
+        for (int j=0; j<Ny; j++) {
+            for (int i=0; i<Nx; i++) {
+                int k = i + j*Nx;
+                egsInformation("   %*d  %*d  %*d      ",iy_digits,j,ix_digits,i,xy_digits,k);
+                fT->currentResult(k,fe,dfe);
+                if (fe > 0) {
+                    dfer = 100*dfe/fe;
+                }
+                else {
+                    dfer = 100;
+                }
+                egsInformation(" %10.4le +/- %10.4le [%-7.3lf\%]\n",fe*norma,dfe*norma,dfer);
+            }
+        }
     }
 }
 
-void EGS_PlanarFluence::ouputResults(){
+void EGS_PlanarFluence::ouputResults() {
 
     EGS_Float src_norm = 1.0,          // default to number of histories in this run
               Fsrc = app->getFluence();// Fluence or number of primary histories
     egsInformation("\n\n last case = %lld source particles or fluence = %g\n\n",
-                    current_ncase, Fsrc);
-  
-    if (Fsrc) 
-       src_norm = Fsrc/current_ncase;// fluence or primary histories per histories run
-  
+                   current_ncase, Fsrc);
+
+    if (Fsrc) {
+        src_norm = Fsrc/current_ncase;    // fluence or primary histories per histories run
+    }
+
     string normLabel = src_norm == 1 ? "history" : "MeV-1 cm-2";
     string src_type = app->sourceType();
-    if ( src_type == "EGS_BeamSource" ){ 
+    if (src_type == "EGS_BeamSource") {
         normLabel = "primary history";
-       egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
-                    src_type.c_str(), src_norm);
+        egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
+                       src_type.c_str(), src_norm);
     }
-    else if ( src_type == "EGS_CollimatedSource" || 
-             (src_type == "EGS_ParallelBeam" && src_norm != 1)){ 
-       egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
-                    src_type.c_str(), src_norm);
+    else if (src_type == "EGS_CollimatedSource" ||
+             (src_type == "EGS_ParallelBeam" && src_norm != 1)) {
+        egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
+                       src_type.c_str(), src_norm);
     }
-    else{
-          egsInformation("\n\n %s normalization = %g (histories per particle)\n\n",
-                    src_type.c_str(), src_norm);
-  
+    else {
+        egsInformation("\n\n %s normalization = %g (histories per particle)\n\n",
+                       src_type.c_str(), src_norm);
+
     }
-  
-  
+
+
     double norm = 1.0/src_norm;  //per fluence or particle depending on source
-           norm /= Area;         //per unit area
-           norm *= norm_u;       // times user-requested normalization
-  
+    norm /= Area;         //per unit area
+    norm *= norm_u;       // times user-requested normalization
+
     //egsInformation("  Normalization = %g\n",norm);
-  
-    egsInformation(  "\n\n            Integral fluence\n"
-                         "            ================\n\n");
+
+    egsInformation("\n\n            Integral fluence\n"
+                   "            ================\n\n");
 
     egsInformation("\n\n               Total %s fluence\n", particle_name.c_str());
-    ouputPlanarFluence( fluT, norm );
-    
-    if ( score_primaries ){
-       egsInformation("\n\n                   Primary fluence\n");
-       ouputPlanarFluence( fluT_p, norm );
-    }
-  
-    if ( score_spe ){
-       norm *= flu_a;//per unit bin width
-       string suffix = "_" + particle_name + ".agr";
-       string spe_name = app->constructIOFileName(suffix.c_str(),true);
-       ofstream spe_output(spe_name.c_str(),ios::out); 
-       if (!spe_output){
-           egsFatal("\n EGS_PlanarFluence: Error: Failed to open file %s\n",spe_name.c_str());
-           exit(1);
-       }
-     
-       spe_output << "# " << particle_name.c_str() << " fluence \n";
-       spe_output << "# \n";
-       spe_output << "@    legend 0.2, 0.8\n";
-       spe_output << "@    legend box linestyle 0\n";
-       spe_output << "@    legend font 4\n";
-       spe_output << "@    xaxis  label \"energy / MeV\"\n";
-       spe_output << "@    xaxis  label char size 1.560000\n";
-       spe_output << "@    xaxis  label font 4\n";
-       spe_output << "@    xaxis  ticklabel font 4\n";
-       spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
-       spe_output << "@    yaxis  label char size 1.560000\n";
-       spe_output << "@    yaxis  label font 4\n";
-       spe_output << "@    yaxis  ticklabel font 4\n";
-       spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
-       spe_output << "@    title font 4\n";
-       spe_output << "@    title size 1.500000\n";
-       spe_output << "@    subtitle \"for each scoring region\"\n";
-       spe_output << "@    subtitle font 4\n";
-       spe_output << "@    subtitle size 1.000000\n";
-     
-       egsInformation(  "\n\n            Differential fluence\n"
-                            "            ====================\n\n");
+    ouputPlanarFluence(fluT, norm);
 
-       int i_graph = 0;
-       double fe,dfe;
-       for(int j=0; j<Ny; j++) {     
-         for(int i=0; i<Nx; i++) {     
-             int k = i + j*Nx;
-             if (verbose) egsInformation("\nPixel # %d :",k);
-             spe_output<<"@    s" << i_graph <<" errorbar linestyle 0\n";
-             spe_output<<"@    s" << i_graph <<" legend \""<<
-                    "Voxel # " << k <<"\"\n";
-             spe_output<<"@target G0.S"<< i_graph <<"\n";
-             spe_output<<"@type xydy\n";
-             if (verbose) {
-                 egsInformation(  "\n\n           Total \n\n");
-                 egsInformation("\n   Emid/MeV    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
-                                  "---------------------------------------------\n");
-             }
-             for(int l=0; l<flu_nbin; l++) {
-                 flu[k]->currentResult(l,fe,dfe);
-                 EGS_Float e = (l+0.5-flu_b)/flu_a;
-                 if( flu_s ) e = exp(e);
-                 spe_output<<e<<" "<<fe*norm<<" "<<dfe*norm<< "\n";
-                 if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
-                              e,fe*norm,dfe*norm);
-             }
-             spe_output << "&\n";
-     
-             if ( score_primaries ){
+    if (score_primaries) {
+        egsInformation("\n\n                   Primary fluence\n");
+        ouputPlanarFluence(fluT_p, norm);
+    }
+
+    if (score_spe) {
+        norm *= flu_a;//per unit bin width
+        string suffix = "_" + particle_name + ".agr";
+        string spe_name = app->constructIOFileName(suffix.c_str(),true);
+        ofstream spe_output(spe_name.c_str(),ios::out);
+        if (!spe_output) {
+            egsFatal("\n EGS_PlanarFluence: Error: Failed to open file %s\n",spe_name.c_str());
+            exit(1);
+        }
+
+        spe_output << "# " << particle_name.c_str() << " fluence \n";
+        spe_output << "# \n";
+        spe_output << "@    legend 0.2, 0.8\n";
+        spe_output << "@    legend box linestyle 0\n";
+        spe_output << "@    legend font 4\n";
+        spe_output << "@    xaxis  label \"energy / MeV\"\n";
+        spe_output << "@    xaxis  label char size 1.560000\n";
+        spe_output << "@    xaxis  label font 4\n";
+        spe_output << "@    xaxis  ticklabel font 4\n";
+        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+        spe_output << "@    yaxis  label char size 1.560000\n";
+        spe_output << "@    yaxis  label font 4\n";
+        spe_output << "@    yaxis  ticklabel font 4\n";
+        spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
+        spe_output << "@    title font 4\n";
+        spe_output << "@    title size 1.500000\n";
+        spe_output << "@    subtitle \"for each scoring region\"\n";
+        spe_output << "@    subtitle font 4\n";
+        spe_output << "@    subtitle size 1.000000\n";
+
+        egsInformation("\n\n            Differential fluence\n"
+                       "            ====================\n\n");
+
+        int i_graph = 0;
+        double fe,dfe;
+        for (int j=0; j<Ny; j++) {
+            for (int i=0; i<Nx; i++) {
+                int k = i + j*Nx;
                 if (verbose) {
-                    egsInformation(  "\n\n           Primary\n\n");
-                    egsInformation("\n   Emid/MeV    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
-                                     "---------------------------------------------\n");
+                    egsInformation("\nPixel # %d :",k);
                 }
-                spe_output<<"@    s" << ++i_graph <<" errorbar linestyle 0\n";
+                spe_output<<"@    s" << i_graph <<" errorbar linestyle 0\n";
                 spe_output<<"@    s" << i_graph <<" legend \""<<
-                       "Voxel # " << k <<" (primary)\"\n";
+                          "Voxel # " << k <<"\"\n";
                 spe_output<<"@target G0.S"<< i_graph <<"\n";
                 spe_output<<"@type xydy\n";
-                for(int l=0; l<flu_nbin; l++) {
-                    flu_p[k]->currentResult(l,fe,dfe);
+                if (verbose) {
+                    egsInformation("\n\n           Total \n\n");
+                    egsInformation("\n   Emid/MeV    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
+                                   "---------------------------------------------\n");
+                }
+                for (int l=0; l<flu_nbin; l++) {
+                    flu[k]->currentResult(l,fe,dfe);
                     EGS_Float e = (l+0.5-flu_b)/flu_a;
-                    if( flu_s ) e = exp(e);
-                    spe_output<<e<<" "<<fe*norm<<" "<<dfe*norm<< "\n";
+                    if (flu_s) {
+                        e = exp(e);
+                    }
+                    spe_output<<e<<" "<<fe *norm<<" "<<dfe *norm<< "\n";
                     if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
-                                 e,fe*norm,dfe*norm);
+                                                    e,fe*norm,dfe*norm);
                 }
                 spe_output << "&\n";
-             }
-             i_graph++;
-         }
-       }
-       spe_output.close();
+
+                if (score_primaries) {
+                    if (verbose) {
+                        egsInformation("\n\n           Primary\n\n");
+                        egsInformation("\n   Emid/MeV    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
+                                       "---------------------------------------------\n");
+                    }
+                    spe_output<<"@    s" << ++i_graph <<" errorbar linestyle 0\n";
+                    spe_output<<"@    s" << i_graph <<" legend \""<<
+                              "Voxel # " << k <<" (primary)\"\n";
+                    spe_output<<"@target G0.S"<< i_graph <<"\n";
+                    spe_output<<"@type xydy\n";
+                    for (int l=0; l<flu_nbin; l++) {
+                        flu_p[k]->currentResult(l,fe,dfe);
+                        EGS_Float e = (l+0.5-flu_b)/flu_a;
+                        if (flu_s) {
+                            e = exp(e);
+                        }
+                        spe_output<<e<<" "<<fe *norm<<" "<<dfe *norm<< "\n";
+                        if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
+                                                        e,fe*norm,dfe*norm);
+                    }
+                    spe_output << "&\n";
+                }
+                i_graph++;
+            }
+        }
+        spe_output.close();
     }
-       
+
 }
 
 void EGS_PlanarFluence::reportResults() {
@@ -848,112 +938,149 @@ void EGS_PlanarFluence::reportResults() {
     egsInformation("======================================================\n");
 
     ouputResults();
-    
+
 }
 
 bool EGS_PlanarFluence::storeState(ostream &data) const {
-  if( !egsStoreI64(data,current_ncase)) return false;
-  data << endl;
-  //data << m_primary << " " << m_ray << " " << m_compt << " " << m_fluor << " " << m_multiple;
-  data << m_tot << " " << m_primary;
-  data << endl;
-  if (!data.good()) return false;
+    if (!egsStoreI64(data,current_ncase)) {
+        return false;
+    }
+    data << endl;
+    //data << m_primary << " " << m_ray << " " << m_compt << " " << m_fluor << " " << m_multiple;
+    data << m_tot << " " << m_primary;
+    data << endl;
+    if (!data.good()) {
+        return false;
+    }
 
-  if( !fluT->storeState(data) ) return false;
+    if (!fluT->storeState(data)) {
+        return false;
+    }
 
-  if( score_spe ) {
-      for(int j=0; j<Nx*Ny; j++) {
-          if( !flu[j]->storeState(data) ) return false;
-      }
-  }
+    if (score_spe) {
+        for (int j=0; j<Nx*Ny; j++) {
+            if (!flu[j]->storeState(data)) {
+                return false;
+            }
+        }
+    }
 
-  if ( score_primaries ){
-     if( !fluT_p->storeState(data) ) return false;
-     if( score_spe ) {
-         for(int j=0; j<Nx*Ny; j++) {
-             if( !flu_p[j]->storeState(data) ) return false;
-         }
-     }
-  }
+    if (score_primaries) {
+        if (!fluT_p->storeState(data)) {
+            return false;
+        }
+        if (score_spe) {
+            for (int j=0; j<Nx*Ny; j++) {
+                if (!flu_p[j]->storeState(data)) {
+                    return false;
+                }
+            }
+        }
+    }
 
-  return true;  
+    return true;
 }
 
-bool  EGS_PlanarFluence::setState(istream &data){
-  if( !egsGetI64(data,current_ncase) ) return false;
-  //data >> m_primary >> m_ray >> m_compt >> m_fluor >> m_multiple;
-  data >> m_tot >> m_primary;
-  if (!data.good()) return false;
+bool  EGS_PlanarFluence::setState(istream &data) {
+    if (!egsGetI64(data,current_ncase)) {
+        return false;
+    }
+    //data >> m_primary >> m_ray >> m_compt >> m_fluor >> m_multiple;
+    data >> m_tot >> m_primary;
+    if (!data.good()) {
+        return false;
+    }
 
-  if( !fluT->setState(data) ) return false;
+    if (!fluT->setState(data)) {
+        return false;
+    }
 
-  if( score_spe ) {
-      for(int j=0; j<Nx*Ny; j++) {
-          if( !flu[j]->setState(data) ) return false;
-      }
-  }
+    if (score_spe) {
+        for (int j=0; j<Nx*Ny; j++) {
+            if (!flu[j]->setState(data)) {
+                return false;
+            }
+        }
+    }
 
-  if ( score_primaries ){
+    if (score_primaries) {
 
-     if( !fluT_p->setState(data) ) return false;
-   
-     if( score_spe ) {
-         for(int j=0; j<Nx*Ny; j++) {
-             if( !flu_p[j]->setState(data) ) return false;
-         }
-     }
+        if (!fluT_p->setState(data)) {
+            return false;
+        }
 
-  }
-  return true;
+        if (score_spe) {
+            for (int j=0; j<Nx*Ny; j++) {
+                if (!flu_p[j]->setState(data)) {
+                    return false;
+                }
+            }
+        }
+
+    }
+    return true;
 }
 
-bool  EGS_PlanarFluence::addState(istream &data){
-   EGS_I64 tmp_case; if( !egsGetI64(data,tmp_case) ) return false;
-   current_ncase += tmp_case;
-   /* individual contributions */
-   //EGS_Float tmp_primary, tmp_fluor, tmp_compt, tmp_ray, tmp_multiple;
-   //data >> tmp_primary >> tmp_ray >> tmp_compt >> tmp_fluor >> tmp_multiple;
-   EGS_Float tmp_tot, tmp_primary;
-   data >> tmp_tot >> tmp_primary;
-   if (!data.good()) return false;
-   m_primary += tmp_primary; 
-   m_tot     += tmp_tot;
-   //m_primary += tmp_primary;m_ray += tmp_ray;m_compt += tmp_compt;
-   //m_fluor += tmp_fluor;m_multiple += tmp_multiple;
-   /* fluence objects */
+bool  EGS_PlanarFluence::addState(istream &data) {
+    EGS_I64 tmp_case;
+    if (!egsGetI64(data,tmp_case)) {
+        return false;
+    }
+    current_ncase += tmp_case;
+    /* individual contributions */
+    //EGS_Float tmp_primary, tmp_fluor, tmp_compt, tmp_ray, tmp_multiple;
+    //data >> tmp_primary >> tmp_ray >> tmp_compt >> tmp_fluor >> tmp_multiple;
+    EGS_Float tmp_tot, tmp_primary;
+    data >> tmp_tot >> tmp_primary;
+    if (!data.good()) {
+        return false;
+    }
+    m_primary += tmp_primary;
+    m_tot     += tmp_tot;
+    //m_primary += tmp_primary;m_ray += tmp_ray;m_compt += tmp_compt;
+    //m_fluor += tmp_fluor;m_multiple += tmp_multiple;
+    /* fluence objects */
 
-   EGS_ScoringArray tgT(Nx*Ny);
-   if( !tgT.setState(data) ) return false;
-   (*fluT) += tgT;
+    EGS_ScoringArray tgT(Nx*Ny);
+    if (!tgT.setState(data)) {
+        return false;
+    }
+    (*fluT) += tgT;
 
-   if( score_spe ) {
-       EGS_ScoringArray tg(flu_nbin);
-       for(int j=0; j<Nx*Ny; j++) {
-           if( !tg.setState(data) ) return false;
-           (*flu[j]) += tg;
-       }
-   }
+    if (score_spe) {
+        EGS_ScoringArray tg(flu_nbin);
+        for (int j=0; j<Nx*Ny; j++) {
+            if (!tg.setState(data)) {
+                return false;
+            }
+            (*flu[j]) += tg;
+        }
+    }
 
-   if ( score_primaries ){
- 
-       EGS_ScoringArray tgT_p(Nx*Ny);
-       if( !tgT_p.setState(data) ) return false;
-       (*fluT_p) += tgT_p;
-    
-       if( score_spe ) {
-           EGS_ScoringArray tg_p(flu_nbin);
-           for(int j=0; j<Nx*Ny; j++) {
-               if( !tg_p.setState(data) ) return false;
-               (*flu_p[j]) += tg_p;
-           }
-       }
-   }
+    if (score_primaries) {
 
-   return true;
+        EGS_ScoringArray tgT_p(Nx*Ny);
+        if (!tgT_p.setState(data)) {
+            return false;
+        }
+        (*fluT_p) += tgT_p;
+
+        if (score_spe) {
+            EGS_ScoringArray tg_p(flu_nbin);
+            for (int j=0; j<Nx*Ny; j++) {
+                if (!tg_p.setState(data)) {
+                    return false;
+                }
+                (*flu_p[j]) += tg_p;
+            }
+        }
+    }
+
+    return true;
 }
 
 
-/********************************************** 
+/**********************************************
  * Class EGS_VolumetricFluence Implementation *
 ***********************************************/
 
@@ -962,28 +1089,34 @@ EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFacto
     EGS_FluenceScoring(Name,f)
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
-#endif    
+#endif
 {
-   otype = "EGS_VolumetricFluence";
+    otype = "EGS_VolumetricFluence";
 }
 
 /*! Destructor.  */
-EGS_VolumetricFluence::~EGS_VolumetricFluence(){
+EGS_VolumetricFluence::~EGS_VolumetricFluence() {
 
-   if( flu ) {
-       for(int j=0; j<n_scoring_regions; j++) {delete flu[j];}
-   }
-   if( flu_p ) {
-       for(int j=0; j<n_scoring_regions; j++) {delete flu_p[j];}
-   }
+    if (flu) {
+        for (int j=0; j<n_scoring_regions; j++) {
+            delete flu[j];
+        }
+    }
+    if (flu_p) {
+        for (int j=0; j<n_scoring_regions; j++) {
+            delete flu_p[j];
+        }
+    }
 
-#ifdef DEBUG 
-   if (binDist) delete binDist;
-   if( scoring_charge ) {
-       delete stepDist;
-       delete relStepDiff;
-   }
-#endif    
+#ifdef DEBUG
+    if (binDist) {
+        delete binDist;
+    }
+    if (scoring_charge) {
+        delete stepDist;
+        delete relStepDiff;
+    }
+#endif
 
 }
 
@@ -991,16 +1124,19 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
 
     EGS_AusgabObject::setApplication(App);
 
-    if( !app ) return;
+    if (!app) {
+        return;
+    }
 
-    /*********************************************************** 
-       Defaults to charge of application source. This applies most 
-       of the time, except for bremsstrahlung targets and multiple 
-       particle sources such as radiactive sources. 
+    /***********************************************************
+       Defaults to charge of application source. This applies most
+       of the time, except for bremsstrahlung targets and multiple
+       particle sources such as radiactive sources.
        Can be changed via 'source particle' input.
     *************************************************************/
-    if ( source_charge == unknown ) 
-         source_charge = (ParticleType)app->sourceCharge();
+    if (source_charge == unknown) {
+        source_charge = (ParticleType)app->sourceCharge();
+    }
 
     // Get the number of regions in the geometry.
     nreg = app->getnRegions();
@@ -1011,146 +1147,151 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
         is_source.push_back(false);
         volume.push_back(vol_list[0]);// set to either 1.0 or first volume entered
     }
-    
+
     /* Flag scoring and source regions*/
     setUpRegionFlags();
 
     /* Update arrays with user inputs */
     for (int i = 0; i < n_scoring_regions; i++) {
-        if ( i < vol_list.size() ) {
+        if (i < vol_list.size()) {
             volume[f_region[i]] = vol_list[i];
         }
     }
 
     /* Setup fluence scoring arrays */
     fluT = new EGS_ScoringArray(nreg);
-    if ( score_spe ){
-       flu  = new EGS_ScoringArray* [nreg];
-       for (int j = 0; j < nreg; j++){ 
-           if (is_sensitive[j])
-              flu[j] = new EGS_ScoringArray(flu_nbin);
-       }
+    if (score_spe) {
+        flu  = new EGS_ScoringArray* [nreg];
+        for (int j = 0; j < nreg; j++) {
+            if (is_sensitive[j]) {
+                flu[j] = new EGS_ScoringArray(flu_nbin);
+            }
+        }
     }
-    if ( score_primaries ){
-       fluT_p = new EGS_ScoringArray(nreg);
-       if ( score_spe ){
-          flu_p  = new EGS_ScoringArray* [nreg];
-          for (int j = 0; j < nreg; j++){ 
-              if (is_sensitive[j])
-                 flu_p[j] = new EGS_ScoringArray(flu_nbin);
-          }
-       }
+    if (score_primaries) {
+        fluT_p = new EGS_ScoringArray(nreg);
+        if (score_spe) {
+            flu_p  = new EGS_ScoringArray* [nreg];
+            for (int j = 0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    flu_p[j] = new EGS_ScoringArray(flu_nbin);
+                }
+            }
+        }
     }
-#ifdef DEBUG 
+#ifdef DEBUG
     binDist = new EGS_ScoringArray(flu_nbin);
     int imed_max_range;
 #endif
 
-    EGS_Float flu_Emin = flu_s ? exp(flu_xmin) : flu_xmin, 
+    EGS_Float flu_Emin = flu_s ? exp(flu_xmin) : flu_xmin,
               flu_Emax = flu_s ? exp(flu_xmax) : flu_xmax;
     EGS_Float bw = flu_s ?(log(flu_Emax / flu_Emin))/flu_nbin :
-                          (flu_Emax - flu_Emin) /flu_nbin;
-    flu_a_i = bw; flu_a = 1.0/bw;
-       
+                   (flu_Emax - flu_Emin) /flu_nbin;
+    flu_a_i = bw;
+    flu_a = 1.0/bw;
+
     /* Initialize data required to score charged particle fluence */
-    if ( scoring_charge ){
-       EGS_Float expbw;
-       /* Pre-calculated values for faster evaluation on log scale */
-       if (flu_s){
-          expbw   = exp(bw); // => (Emax/Emin)^(1/nbin)
-          r_const = 1/(expbw-1);
-          DE      = new EGS_Float [flu_nbin];
-          a_const = new EGS_Float [flu_nbin];
-          for ( int i = 0; i < flu_nbin; i++ ){
-            DE[i]      = flu_Emin*pow(expbw,i)*(expbw-1);
-            a_const[i] = 1/flu_Emin*pow(1/expbw,i);
-          }
-       }
-       /* Do not score below ECUT - PRM */
-       if (flu_Emin < app->getEcut() - app->getRM() ){
-           flu_Emin = app->getEcut() - app->getRM() ;
-          /* Decrease number of bins, preserve bin width */
-          flu_nbin = flu_s ?
-                     ceil((log(flu_Emax / flu_Emin))/bw) :
-                     ceil(    (flu_Emax - flu_Emin) /bw);
-       }
-       
-       /* Pre-calculated values for faster 1/stpwr evaluation */
-       if (flu_stpwr){
-          
-          int n_media = app->getnMedia(); 
-          
-          EGS_Float lnE, lnEmin, lnEmax, lnEmid;
+    if (scoring_charge) {
+        EGS_Float expbw;
+        /* Pre-calculated values for faster evaluation on log scale */
+        if (flu_s) {
+            expbw   = exp(bw); // => (Emax/Emin)^(1/nbin)
+            r_const = 1/(expbw-1);
+            DE      = new EGS_Float [flu_nbin];
+            a_const = new EGS_Float [flu_nbin];
+            for (int i = 0; i < flu_nbin; i++) {
+                DE[i]      = flu_Emin*pow(expbw,i)*(expbw-1);
+                a_const[i] = 1/flu_Emin*pow(1/expbw,i);
+            }
+        }
+        /* Do not score below ECUT - PRM */
+        if (flu_Emin < app->getEcut() - app->getRM()) {
+            flu_Emin = app->getEcut() - app->getRM() ;
+            /* Decrease number of bins, preserve bin width */
+            flu_nbin = flu_s ?
+                       ceil((log(flu_Emax / flu_Emin))/bw) :
+                       ceil((flu_Emax - flu_Emin) /bw);
+        }
 
-          i_dedx = new EGS_Interpolator [n_media];// stp powers
-          dedx_i = new EGS_Interpolator [n_media];// its inverse
-          for( int j = 0; j < n_media; j++ ){
-              /* Gets charged partcle stopping powers based on the scoring charge */
-              i_dedx[j] = *( app->getDEDX( j, scoring_charge ) );
-              EGS_Float Emin = i_dedx[j].getXmin();
-              EGS_Float Emax = i_dedx[j].getXmax();
-              int n = 1 + i_dedx[j].getIndex(Emax);// getIndex returns lower bin limit?
-              EGS_Float bwidth = (Emax - Emin)/n;
-#ifdef DEBUG 
-              egsInformation("---> stpwr in %s : Emin=%g Emax=%g n=%d bw=%g\n",
-              app->getMediumName(j), exp(Emin), exp(Emax), n, bwidth);
-#endif             
-              int nbins = n + 1;
-              EGS_Float spwr_i[nbins]; 
-              for (int k = 0; k < nbins; k++ ){
-                  spwr_i[k] = 1.0 / i_dedx[j].interpolate(Emin+k*bwidth);
-              }
-              dedx_i[j].initialize(nbins, Emin, Emax, spwr_i);
-#ifdef DEBUG 
-              Emin = dedx_i[j].getXmin();
-              Emax = dedx_i[j].getXmax();
-              n = 1 + dedx_i[j].getIndex(Emax);// getIndex returns lower bin limit?
-              bwidth = (Emax - Emin)/n;
-              egsInformation("---> 1/stpwr in %s : lnEmin=%g lnEmax=%g n=%d bw=%g index(Emax)=%d\n",
-              app->getMediumName(j), Emin, Emax, n, bwidth, dedx_i[j].getIndexFast(Emax));
-              for (int k = 0; k < nbins; k++ ){
-                egsInformation(" L(%g MeV) = %g MeV/cm 1/L = %g cm/MeV\n", 
-                exp(Emin+k*bwidth),
-                i_dedx[j].interpolate(Emin + k*bwidth), 
-                dedx_i[j].interpolate(Emin + k*bwidth));
-              }
-#endif             
-          }
+        /* Pre-calculated values for faster 1/stpwr evaluation */
+        if (flu_stpwr) {
 
-          /* Determine stpwr at middle of each fluence scoring bin */
-          lnEmin  = flu_s ? log(0.5*flu_Emin*(expbw+1)) : 0;
-          Lmid_i  = new EGS_Float [flu_nbin*n_media];
-          for( int j = 0; j < n_media; j++ ){
-#ifdef DEBUG 
-            EGS_Float med_max_step = 0, logEmax, logEmin;
-#endif             
-            for ( int i = 0; i < flu_nbin; i++ ){
-                lnEmid = flu_s ? lnEmin + i*bw : log(flu_Emin+bw*(i+0.5));
-                Lmid_i[i+j*flu_nbin] = 1/i_dedx[j].interpolate(lnEmid);
-                //egsInformation(" 1/L(%g MeV) = %g cm/MeV\n",exp(lnEmid),Lmid_i[i+j*flu_nbin]);
-#ifdef DEBUG 
-                // Set max_step to maximum range
-                if ( i > 0){
-                   logEmin = flu_s ? lnEmin + (i-1)*bw : log(flu_Emin+bw*(i-1)); 
-                   logEmax = flu_s ? lnEmin +     i*bw : log(flu_Emin+bw*i);
-                   if (i_dedx[j].interpolate(logEmax) < i_dedx[j].interpolate(logEmin))
-                      med_max_step += 1.02*(exp(logEmax) - exp(logEmin))/i_dedx[j].interpolate(logEmax);
-                   else
-                      med_max_step += 1.02*(exp(logEmax) - exp(logEmin))*i_dedx[j].interpolate(logEmin);
+            int n_media = app->getnMedia();
+
+            EGS_Float lnE, lnEmin, lnEmax, lnEmid;
+
+            i_dedx = new EGS_Interpolator [n_media];// stp powers
+            dedx_i = new EGS_Interpolator [n_media];// its inverse
+            for (int j = 0; j < n_media; j++) {
+                /* Gets charged partcle stopping powers based on the scoring charge */
+                i_dedx[j] = *(app->getDEDX(j, scoring_charge));
+                EGS_Float Emin = i_dedx[j].getXmin();
+                EGS_Float Emax = i_dedx[j].getXmax();
+                int n = 1 + i_dedx[j].getIndex(Emax);// getIndex returns lower bin limit?
+                EGS_Float bwidth = (Emax - Emin)/n;
+#ifdef DEBUG
+                egsInformation("---> stpwr in %s : Emin=%g Emax=%g n=%d bw=%g\n",
+                               app->getMediumName(j), exp(Emin), exp(Emax), n, bwidth);
+#endif
+                int nbins = n + 1;
+                EGS_Float spwr_i[nbins];
+                for (int k = 0; k < nbins; k++) {
+                    spwr_i[k] = 1.0 / i_dedx[j].interpolate(Emin+k*bwidth);
                 }
-#endif             
+                dedx_i[j].initialize(nbins, Emin, Emax, spwr_i);
+#ifdef DEBUG
+                Emin = dedx_i[j].getXmin();
+                Emax = dedx_i[j].getXmax();
+                n = 1 + dedx_i[j].getIndex(Emax);// getIndex returns lower bin limit?
+                bwidth = (Emax - Emin)/n;
+                egsInformation("---> 1/stpwr in %s : lnEmin=%g lnEmax=%g n=%d bw=%g index(Emax)=%d\n",
+                               app->getMediumName(j), Emin, Emax, n, bwidth, dedx_i[j].getIndexFast(Emax));
+                for (int k = 0; k < nbins; k++) {
+                    egsInformation(" L(%g MeV) = %g MeV/cm 1/L = %g cm/MeV\n",
+                                   exp(Emin+k*bwidth),
+                                   i_dedx[j].interpolate(Emin + k*bwidth),
+                                   dedx_i[j].interpolate(Emin + k*bwidth));
+                }
+#endif
             }
-#ifdef DEBUG 
-            if ( med_max_step > max_step ){
-                max_step = med_max_step;
-                imed_max_range = j;
+
+            /* Determine stpwr at middle of each fluence scoring bin */
+            lnEmin  = flu_s ? log(0.5*flu_Emin*(expbw+1)) : 0;
+            Lmid_i  = new EGS_Float [flu_nbin*n_media];
+            for (int j = 0; j < n_media; j++) {
+#ifdef DEBUG
+                EGS_Float med_max_step = 0, logEmax, logEmin;
+#endif
+                for (int i = 0; i < flu_nbin; i++) {
+                    lnEmid = flu_s ? lnEmin + i*bw : log(flu_Emin+bw*(i+0.5));
+                    Lmid_i[i+j*flu_nbin] = 1/i_dedx[j].interpolate(lnEmid);
+                    //egsInformation(" 1/L(%g MeV) = %g cm/MeV\n",exp(lnEmid),Lmid_i[i+j*flu_nbin]);
+#ifdef DEBUG
+                    // Set max_step to maximum range
+                    if (i > 0) {
+                        logEmin = flu_s ? lnEmin + (i-1)*bw : log(flu_Emin+bw*(i-1));
+                        logEmax = flu_s ? lnEmin +     i*bw : log(flu_Emin+bw*i);
+                        if (i_dedx[j].interpolate(logEmax) < i_dedx[j].interpolate(logEmin)) {
+                            med_max_step += 1.02*(exp(logEmax) - exp(logEmin))/i_dedx[j].interpolate(logEmax);
+                        }
+                        else {
+                            med_max_step += 1.02*(exp(logEmax) - exp(logEmin))*i_dedx[j].interpolate(logEmin);
+                        }
+                    }
+#endif
+                }
+#ifdef DEBUG
+                if (med_max_step > max_step) {
+                    max_step = med_max_step;
+                    imed_max_range = j;
+                }
+#endif
             }
-#endif             
-          }
-       }
+        }
     }
 
-#ifdef DEBUG 
+#ifdef DEBUG
     EGS_Float RCSDA = max_step;
     //max_step /= 4.0; // Set to a quarter of the CSDA range
     //if ( max_step > 1.0 ) max_step = 1.0;
@@ -1161,13 +1302,13 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
     stepDist    = new EGS_ScoringArray(n_step_bins);
     eCases = 0;
     egsInformation("\n===> RCSDA(%s) = %g cm  for Emax = %g MeV, max_step = %g cm bin width = %g cm\n",
-                  app->getMediumName(imed_max_range), RCSDA, 
-                  flu_s ? exp(flu_Emax) : flu_Emax, max_step, 1.0/step_a);
+                   app->getMediumName(imed_max_range), RCSDA,
+                   flu_s ? exp(flu_Emax) : flu_Emax, max_step, 1.0/step_a);
 #endif
     describeMe();
 }
 
-/* 
+/*
    Takes user inputs and sets up simulation parameters not requiring
    invoking an application method. This is later done in setApplication.
 */
@@ -1175,15 +1316,16 @@ void EGS_VolumetricFluence::initScoring(EGS_Input *inp) {
 
     EGS_Input *vScoringInput;
 
-    if( !inp ) {
-        egsFatal("AO type %s: null input?\n",otype.c_str()); return;
+    if (!inp) {
+        egsFatal("AO type %s: null input?\n",otype.c_str());
+        return;
     }
-    else{
-       vScoringInput = inp->takeInputItem("volumetric scoring");
-       if( ! vScoringInput ){
-           egsFatal("AO type %s: Missing volumetric scoring input?\n",otype.c_str()); 
-           return;
-       }
+    else {
+        vScoringInput = inp->takeInputItem("volumetric scoring");
+        if (! vScoringInput) {
+            egsFatal("AO type %s: Missing volumetric scoring input?\n",otype.c_str());
+            return;
+        }
     }
 
     EGS_FluenceScoring::initScoring(inp);// common inputs
@@ -1211,25 +1353,26 @@ void EGS_VolumetricFluence::initScoring(EGS_Input *inp) {
             }
         }
     }
-    else if ( v_in.size() ) {
+    else if (v_in.size()) {
         vol_list = v_in;
     }
-    else{
+    else {
         vol_list.push_back(1.0);
     }
 
     /* Initialize data required to score charged particle fluence */
-    if ( scoring_charge ){
-       vector<string> method;
-       method.push_back("flurz"); method.push_back("stpwr");   // 3rd order
-                                  method.push_back("stpwrO5"); // 5th order
-       flu_stpwr = eFluType(vScoringInput->getInput("method",method,1));
+    if (scoring_charge) {
+        vector<string> method;
+        method.push_back("flurz");
+        method.push_back("stpwr");   // 3rd order
+        method.push_back("stpwrO5"); // 5th order
+        flu_stpwr = eFluType(vScoringInput->getInput("method",method,1));
 
     }
 
 }
 
-void EGS_VolumetricFluence::describeMe(){
+void EGS_VolumetricFluence::describeMe() {
     char buf[128];
     sprintf(buf,"\nVolumetric %s fluence scoring\n",particle_name.c_str());
     description =  buf;
@@ -1239,18 +1382,19 @@ void EGS_VolumetricFluence::describeMe(){
 
     EGS_FluenceScoring::describeMe();
 
-    if (flu_stpwr){
-      if (flu_stpwr == stpwr){
-         description += "   O(eps^3) approach: accounts for change in stpwr\n";
-         description +=                "   along the step with eps=edep/Emid\n";
-      }
-      else if (flu_stpwr == stpwrO5){
-         description += "   O(eps^5) approach: accounts for change in stpwr\n";
-         description += "   along the step with eps=edep/Emid\n";
-      }
+    if (flu_stpwr) {
+        if (flu_stpwr == stpwr) {
+            description += "   O(eps^3) approach: accounts for change in stpwr\n";
+            description +=                "   along the step with eps=edep/Emid\n";
+        }
+        else if (flu_stpwr == stpwrO5) {
+            description += "   O(eps^5) approach: accounts for change in stpwr\n";
+            description += "   along the step with eps=edep/Emid\n";
+        }
     }
-    else
-      description += "   Fluence calculated a-la-FLURZ using Lave=EDEP/TVSTEP.\n";
+    else {
+        description += "   Fluence calculated a-la-FLURZ using Lave=EDEP/TVSTEP.\n";
+    }
 
     if (norm_u != 1.0D+0) {
         description += "\n - Non-unity user-requested normalization = ";
@@ -1260,217 +1404,239 @@ void EGS_VolumetricFluence::describeMe(){
 
 }
 
-void EGS_VolumetricFluence::ouputVolumetricFluence( EGS_ScoringArray *fT, const double &norma ){
+void EGS_VolumetricFluence::ouputVolumetricFluence(EGS_ScoringArray *fT, const double &norma) {
     double fe,dfe,dfer;
     double norm = norma;
     int count = 0;
     int ir_digits = getDigits(nreg);
 
     egsInformation("\n  region#    Flu/(MeV*cm2)   DFlu/(MeV*cm2)\n"
-                     "-----------------------------------------------------\n");
-    for( int k=0; k<nreg; k++ ){     
-       if ( !is_sensitive[k] ) continue;
-       norm /= volume[k];               //per volume
-       egsInformation("  %*d      ",ir_digits,k);
-       fT->currentResult(k,fe,dfe);
-       if( fe > 0 ) dfer = 100*dfe/fe; else dfer = 100;
-       egsInformation(" %10.4le +/- %10.4le [%-7.3lf%]\n",fe*norm,dfe*norm,dfer);
+                   "-----------------------------------------------------\n");
+    for (int k=0; k<nreg; k++) {
+        if (!is_sensitive[k]) {
+            continue;
+        }
+        norm /= volume[k];               //per volume
+        egsInformation("  %*d      ",ir_digits,k);
+        fT->currentResult(k,fe,dfe);
+        if (fe > 0) {
+            dfer = 100*dfe/fe;
+        }
+        else {
+            dfer = 100;
+        }
+        egsInformation(" %10.4le +/- %10.4le [%-7.3lf%]\n",fe*norm,dfe*norm,dfer);
     }
 }
 
-void EGS_VolumetricFluence::ouputResults(){
+void EGS_VolumetricFluence::ouputResults() {
 
-  
-  EGS_Float src_norm = 1.0,          // default to number of histories in this run
-            Fsrc = app->getFluence();// Fluence or number of primary histories
-  egsInformation("\n\n last case = %lld source particles or fluence = %g\n\n",
-                  current_ncase, Fsrc);
 
-  if (Fsrc) 
-     src_norm = Fsrc/current_ncase;// fluence or primary histories per histories run
+    EGS_Float src_norm = 1.0,          // default to number of histories in this run
+              Fsrc = app->getFluence();// Fluence or number of primary histories
+    egsInformation("\n\n last case = %lld source particles or fluence = %g\n\n",
+                   current_ncase, Fsrc);
 
-  string normLabel = src_norm == 1 ? "history" : "MeV-1 cm-2";
-  string src_type = app->sourceType();
-  if ( src_type == "EGS_BeamSource" ){ 
-      normLabel = "primary history";
-     egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
-                  src_type.c_str(), src_norm);
-  }
-  else if ( src_type == "EGS_CollimatedSource" || 
-           (src_type == "EGS_ParallelBeam" && src_norm != 1)){ 
-     egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
-                  src_type.c_str(), src_norm);
-  }
-  else{
+    if (Fsrc) {
+        src_norm = Fsrc/current_ncase;    // fluence or primary histories per histories run
+    }
+
+    string normLabel = src_norm == 1 ? "history" : "MeV-1 cm-2";
+    string src_type = app->sourceType();
+    if (src_type == "EGS_BeamSource") {
+        normLabel = "primary history";
+        egsInformation("\n\n %s normalization = %g (primary histories per particle)\n\n",
+                       src_type.c_str(), src_norm);
+    }
+    else if (src_type == "EGS_CollimatedSource" ||
+             (src_type == "EGS_ParallelBeam" && src_norm != 1)) {
+        egsInformation("\n\n %s normalization = %g (fluence per particle)\n\n",
+                       src_type.c_str(), src_norm);
+    }
+    else {
         egsInformation("\n\n %s normalization = %g (histories per particle)\n\n",
-                  src_type.c_str(), src_norm);
+                       src_type.c_str(), src_norm);
 
-  }
+    }
 #ifdef DEBUG
-  EGS_Float fbins, d_fbins;
-  egsInformation("\nNumber of covered bins distribution\n"
-                 "--------------------------------------\n");
-  
-  int tot_bins = one_bin + multi_bin;
-  egsInformation("\none_bin = %d [%-7.3lf\%] multi_bin = %d [%-7.3lf\%]\n", 
-  one_bin, 100.0*one_bin/tot_bins, multi_bin,100.0*multi_bin/tot_bins);
-  
-  egsInformation("\n  # bins        freq         unc           percentage  \n");               
-  int bdigits = getDigits(flu_nbin);
-  for (int i=0; i<flu_nbin; i++) {
-      binDist->currentResult(i,fbins, d_fbins);
-      if (fbins){
-         d_fbins = 100.0*d_fbins/fbins; fbins = current_ncase*fbins;
-         egsInformation("   %*d        %11.2f  [%-7.3lf\%]     %11.2f \%\n", 
-         bdigits, i+1, fbins, d_fbins, 100.*fbins/tot_bins);
-      }
-  }
+    EGS_Float fbins, d_fbins;
+    egsInformation("\nNumber of covered bins distribution\n"
+                   "--------------------------------------\n");
 
-  if ( scoring_charge ){
-     egsInformation("\nDistribution of ratio between computed and taken steps\n"
-                      "------------------------------------------------------\n"
-                      "   (Omitted bins with differences less than 0.01\%)\n");
-      /*
-       //egsInformation(" Relative step difference: %8.4f%% +/- %8.4f%% [%8.4lf%%]\n",
-       //egsInformation(" Relative step ratio: %10.4le +/- %10.4le [%8.4lf%%]\n",
-       */
-   
-      EGS_Float step_diff, step_diff_std, step_diff_err, stepMid;
-      EGS_Float f_scores, f_scores_std;
-      int idigits = getDigits(eCases);
-      egsInformation("\n   step / cm        # scores      ratio       rel unc\n"
-                       "---------------------------------------------------------\n"); 
-      for (int i=0; i < n_step_bins; i++) {
-          stepDist->currentResult( i, f_scores, f_scores_std );
-          if ( f_scores > 0 ){
-             stepMid = (i + 0.5 - step_b)/step_a;
-             relStepDiff->currentResult( i, step_diff, step_diff_std );
-             if( step_diff > 0 ) 
-               step_diff_err = 100*step_diff_std/step_diff; 
-             else 
-               step_diff_err = 100;
-             if ( abs(step_diff/f_scores - 1.0) > 0.0001D+0 )
-                egsInformation("   %10.4le      %*d      %10.4le [%8.4lf\%]\n", 
-                stepMid, idigits, int(f_scores*current_ncase), step_diff/f_scores, step_diff_err);
-          }
-      }
+    int tot_bins = one_bin + multi_bin;
+    egsInformation("\none_bin = %d [%-7.3lf\%] multi_bin = %d [%-7.3lf\%]\n",
+                   one_bin, 100.0*one_bin/tot_bins, multi_bin,100.0*multi_bin/tot_bins);
 
-  }
+    egsInformation("\n  # bins        freq         unc           percentage  \n");
+    int bdigits = getDigits(flu_nbin);
+    for (int i=0; i<flu_nbin; i++) {
+        binDist->currentResult(i,fbins, d_fbins);
+        if (fbins) {
+            d_fbins = 100.0*d_fbins/fbins;
+            fbins = current_ncase*fbins;
+            egsInformation("   %*d        %11.2f  [%-7.3lf\%]     %11.2f \%\n",
+                           bdigits, i+1, fbins, d_fbins, 100.*fbins/tot_bins);
+        }
+    }
+
+    if (scoring_charge) {
+        egsInformation("\nDistribution of ratio between computed and taken steps\n"
+                       "------------------------------------------------------\n"
+                       "   (Omitted bins with differences less than 0.01\%)\n");
+        /*
+         //egsInformation(" Relative step difference: %8.4f%% +/- %8.4f%% [%8.4lf%%]\n",
+         //egsInformation(" Relative step ratio: %10.4le +/- %10.4le [%8.4lf%%]\n",
+         */
+
+        EGS_Float step_diff, step_diff_std, step_diff_err, stepMid;
+        EGS_Float f_scores, f_scores_std;
+        int idigits = getDigits(eCases);
+        egsInformation("\n   step / cm        # scores      ratio       rel unc\n"
+                       "---------------------------------------------------------\n");
+        for (int i=0; i < n_step_bins; i++) {
+            stepDist->currentResult(i, f_scores, f_scores_std);
+            if (f_scores > 0) {
+                stepMid = (i + 0.5 - step_b)/step_a;
+                relStepDiff->currentResult(i, step_diff, step_diff_std);
+                if (step_diff > 0) {
+                    step_diff_err = 100*step_diff_std/step_diff;
+                }
+                else {
+                    step_diff_err = 100;
+                }
+                if (abs(step_diff/f_scores - 1.0) > 0.0001D+0)
+                    egsInformation("   %10.4le      %*d      %10.4le [%8.4lf\%]\n",
+                                   stepMid, idigits, int(f_scores*current_ncase), step_diff/f_scores, step_diff_err);
+            }
+        }
+
+    }
 
 #endif
 
-  EGS_Float norm  = 1.0/src_norm;              // per particle or fluence
-            norm *= norm_u;                    // user-requested normalization
+    EGS_Float norm  = 1.0/src_norm;              // per particle or fluence
+    norm *= norm_u;                    // user-requested normalization
 
- egsInformation("\n\n                 Integral fluence output\n"
-                    "                 =======================\n\n");
+    egsInformation("\n\n                 Integral fluence output\n"
+                   "                 =======================\n\n");
 
-  egsInformation("\n\n                 Total %s fluence\n", particle_name.c_str());
-  ouputVolumetricFluence( fluT, norm );
-  
-  if ( score_primaries ){
-     egsInformation("\n\n                   Primary fluence\n");
-     ouputVolumetricFluence( fluT_p, norm );
-  }
+    egsInformation("\n\n                 Total %s fluence\n", particle_name.c_str());
+    ouputVolumetricFluence(fluT, norm);
 
-  if (verbose){
-     egsInformation("\nbw = %g nbins = %d\n", flu_a_i, flu_nbin);
-  }
+    if (score_primaries) {
+        egsInformation("\n\n                   Primary fluence\n");
+        ouputVolumetricFluence(fluT_p, norm);
+    }
 
-  if ( score_spe ){
-     string suffix = "_" + particle_name + ".agr";
-     string spe_name = app->constructIOFileName(suffix.c_str(),true);
-     ofstream spe_output(spe_name.c_str(),ios::out); 
-     if (!spe_output){
-         egsFatal("\n EGS_VolumetricFluence: Error: Failed to open file %s\n",spe_name.c_str());
-         exit(1);
-     }
-   
-     spe_output << "# Volumetric " << particle_name.c_str() << " fluence \n";
-     spe_output << "# \n";
-     spe_output << "@    legend 0.2, 0.8\n";
-     spe_output << "@    legend box linestyle 0\n";
-     spe_output << "@    legend font 4\n";
-     spe_output << "@    xaxis  label \"energy / MeV\"\n";
-     spe_output << "@    xaxis  label char size 1.560000\n";
-     spe_output << "@    xaxis  label font 4\n";
-     spe_output << "@    xaxis  ticklabel font 4\n";
-     if (src_norm == 1 || normLabel == "primary history")
-        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
-     else{   
-        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
-     }
-     spe_output << "@    yaxis  label char size 1.560000\n";
-     spe_output << "@    yaxis  label font 4\n";
-     spe_output << "@    yaxis  ticklabel font 4\n";
-     spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
-     spe_output << "@    title font 4\n";
-     spe_output << "@    title size 1.500000\n";
-     spe_output << "@    subtitle \"for each scoring region\"\n";
-     spe_output << "@    subtitle font 4\n";
-     spe_output << "@    subtitle size 1.000000\n";
-    
-     if ( verbose ) 
-        egsInformation("\n\n                 Differential fluence output\n"
+    if (verbose) {
+        egsInformation("\nbw = %g nbins = %d\n", flu_a_i, flu_nbin);
+    }
+
+    if (score_spe) {
+        string suffix = "_" + particle_name + ".agr";
+        string spe_name = app->constructIOFileName(suffix.c_str(),true);
+        ofstream spe_output(spe_name.c_str(),ios::out);
+        if (!spe_output) {
+            egsFatal("\n EGS_VolumetricFluence: Error: Failed to open file %s\n",spe_name.c_str());
+            exit(1);
+        }
+
+        spe_output << "# Volumetric " << particle_name.c_str() << " fluence \n";
+        spe_output << "# \n";
+        spe_output << "@    legend 0.2, 0.8\n";
+        spe_output << "@    legend box linestyle 0\n";
+        spe_output << "@    legend font 4\n";
+        spe_output << "@    xaxis  label \"energy / MeV\"\n";
+        spe_output << "@    xaxis  label char size 1.560000\n";
+        spe_output << "@    xaxis  label font 4\n";
+        spe_output << "@    xaxis  ticklabel font 4\n";
+        if (src_norm == 1 || normLabel == "primary history") {
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+        }
+        else {
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
+        }
+        spe_output << "@    yaxis  label char size 1.560000\n";
+        spe_output << "@    yaxis  label font 4\n";
+        spe_output << "@    yaxis  ticklabel font 4\n";
+        spe_output << "@    title \""<< particle_name.c_str() << " fluence" <<"\"\n";
+        spe_output << "@    title font 4\n";
+        spe_output << "@    title size 1.500000\n";
+        spe_output << "@    subtitle \"for each scoring region\"\n";
+        spe_output << "@    subtitle font 4\n";
+        spe_output << "@    subtitle size 1.000000\n";
+
+        if (verbose)
+            egsInformation("\n\n                 Differential fluence output\n"
                            "                 =============================\n\n");
-     int i_graph = 0;
-     double fe, dfe;
-     norm *= scoring_charge ? 1 : flu_a;//per bin width <- implicit for charged particles!
-     // Loop through the number of regions in the geometry.
-     for (int j = 0; j < nreg; j++) {
-   
-         if ( !is_sensitive[j] ) continue;
-   
-         norm /= volume[j];                 //per volume
-   
-         egsInformation("region # %d : ",j);
-   
-         if (verbose){
-            egsInformation("Volume[%d] = %g", j, volume[j]);
-            egsInformation(" Normalization = Ncase/Fsrc/V = %g\n",norm);
-         }
-         
-         if (verbose) egsInformation("\nTotal fluence:\n");
-         spe_output<<"@    s"<< i_graph <<" errorbar linestyle 0\n";
-         spe_output<<"@    s"<< i_graph <<" legend \""<< "total (ir # " << j <<")\"\n";
-         spe_output<<"@target G0.S"<< i_graph <<"\n";
-         spe_output<<"@type xydy\n";
-         if (verbose) egsInformation("\n   Emid/MeV    Flu/(MeV-1*cm-2)   DFlu/(MeV-1*cm-2)\n"
-                        "---------------------------------------------------\n");
-         for (int i=0; i<flu_nbin; i++) {
-             flu[j]->currentResult(i,fe,dfe);
-             EGS_Float e = (i+0.5-flu_b)/flu_a;
-             if (flu_s) e = exp(e);
-             spe_output << e <<" "<< fe *norm<<" "<< dfe *norm<< "\n";
-             if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
-                           e, fe*norm, dfe*norm);
-         }
-         spe_output << "&\n";
-   
-         if ( score_primaries ){
-            if (verbose) egsInformation("\nPrimary fluence:\n");
-            spe_output<<"@    s"<< ++i_graph <<" errorbar linestyle 0\n";
-            spe_output<<"@    s"<< i_graph <<" legend \""<< "primary (ir # " << j <<")\"\n";
+        int i_graph = 0;
+        double fe, dfe;
+        norm *= scoring_charge ? 1 : flu_a;//per bin width <- implicit for charged particles!
+        // Loop through the number of regions in the geometry.
+        for (int j = 0; j < nreg; j++) {
+
+            if (!is_sensitive[j]) {
+                continue;
+            }
+
+            norm /= volume[j];                 //per volume
+
+            egsInformation("region # %d : ",j);
+
+            if (verbose) {
+                egsInformation("Volume[%d] = %g", j, volume[j]);
+                egsInformation(" Normalization = Ncase/Fsrc/V = %g\n",norm);
+            }
+
+            if (verbose) {
+                egsInformation("\nTotal fluence:\n");
+            }
+            spe_output<<"@    s"<< i_graph <<" errorbar linestyle 0\n";
+            spe_output<<"@    s"<< i_graph <<" legend \""<< "total (ir # " << j <<")\"\n";
             spe_output<<"@target G0.S"<< i_graph <<"\n";
             spe_output<<"@type xydy\n";
             if (verbose) egsInformation("\n   Emid/MeV    Flu/(MeV-1*cm-2)   DFlu/(MeV-1*cm-2)\n"
-                           "---------------------------------------------------\n");
+                                            "---------------------------------------------------\n");
             for (int i=0; i<flu_nbin; i++) {
-                flu_p[j]->currentResult(i,fe,dfe);
+                flu[j]->currentResult(i,fe,dfe);
                 EGS_Float e = (i+0.5-flu_b)/flu_a;
-                if (flu_s) e = exp(e);
+                if (flu_s) {
+                    e = exp(e);
+                }
                 spe_output << e <<" "<< fe *norm<<" "<< dfe *norm<< "\n";
                 if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
-                              e, fe*norm, dfe*norm);
+                                                e, fe*norm, dfe*norm);
             }
             spe_output << "&\n";
-         }
-         i_graph++;
-     }
 
-     spe_output.close();
-       
-  }
+            if (score_primaries) {
+                if (verbose) {
+                    egsInformation("\nPrimary fluence:\n");
+                }
+                spe_output<<"@    s"<< ++i_graph <<" errorbar linestyle 0\n";
+                spe_output<<"@    s"<< i_graph <<" legend \""<< "primary (ir # " << j <<")\"\n";
+                spe_output<<"@target G0.S"<< i_graph <<"\n";
+                spe_output<<"@type xydy\n";
+                if (verbose) egsInformation("\n   Emid/MeV    Flu/(MeV-1*cm-2)   DFlu/(MeV-1*cm-2)\n"
+                                                "---------------------------------------------------\n");
+                for (int i=0; i<flu_nbin; i++) {
+                    flu_p[j]->currentResult(i,fe,dfe);
+                    EGS_Float e = (i+0.5-flu_b)/flu_a;
+                    if (flu_s) {
+                        e = exp(e);
+                    }
+                    spe_output << e <<" "<< fe *norm<<" "<< dfe *norm<< "\n";
+                    if (verbose) egsInformation("%11.6f  %14.6e  %14.6e\n",
+                                                    e, fe*norm, dfe*norm);
+                }
+                spe_output << "&\n";
+            }
+            i_graph++;
+        }
+
+        spe_output.close();
+
+    }
 
 }
 
@@ -1480,155 +1646,203 @@ void EGS_VolumetricFluence::reportResults() {
     egsInformation("======================================================\n");
 
     ouputResults();
-    
+
 }
 
 bool EGS_VolumetricFluence::storeState(ostream &data) const {
-  if( !egsStoreI64(data,current_ncase)) return false;
-  data << endl;
+    if (!egsStoreI64(data,current_ncase)) {
+        return false;
+    }
+    data << endl;
 
-  if (!data.good()) return false;
+    if (!data.good()) {
+        return false;
+    }
 
 #ifdef DEBUG
-  if ( scoring_charge ){
-    if( !relStepDiff->storeState(data) ) return false;
-    if( !stepDist->storeState(data) ) return false;
-  }
+    if (scoring_charge) {
+        if (!relStepDiff->storeState(data)) {
+            return false;
+        }
+        if (!stepDist->storeState(data)) {
+            return false;
+        }
+    }
 #endif
 
-  if( !fluT->storeState(data) ) return false;
-  if( score_spe ) {
-      for(int j = 0; j < nreg; j++) {
-          if ( is_sensitive[j] ){ 
-             if( !flu[j]->storeState(data) ) return false;
-          }
-      }
-  }
-
-  if ( score_primaries ){
-     if( !fluT_p->storeState(data) ) return false;
-     if( score_spe ) {
-         for(int j=0; j < nreg; j++) {
-            if ( is_sensitive[j] ){ 
-               if( !flu_p[j]->storeState(data) ) return false;
+    if (!fluT->storeState(data)) {
+        return false;
+    }
+    if (score_spe) {
+        for (int j = 0; j < nreg; j++) {
+            if (is_sensitive[j]) {
+                if (!flu[j]->storeState(data)) {
+                    return false;
+                }
             }
-         }
-     }
-  }
+        }
+    }
 
-  return true;  
+    if (score_primaries) {
+        if (!fluT_p->storeState(data)) {
+            return false;
+        }
+        if (score_spe) {
+            for (int j=0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!flu_p[j]->storeState(data)) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
 }
 
-bool  EGS_VolumetricFluence::setState(istream &data){
-  
-  if( !egsGetI64(data,current_ncase) ) return false;
+bool  EGS_VolumetricFluence::setState(istream &data) {
 
-  if (!data.good()) return false;
+    if (!egsGetI64(data,current_ncase)) {
+        return false;
+    }
+
+    if (!data.good()) {
+        return false;
+    }
 
 #ifdef DEBUG
-  if ( scoring_charge ){
-    if( !relStepDiff->setState(data) ) return false;
-    if( !stepDist->setState(data) ) return false;
-  }
+    if (scoring_charge) {
+        if (!relStepDiff->setState(data)) {
+            return false;
+        }
+        if (!stepDist->setState(data)) {
+            return false;
+        }
+    }
 #endif
 
-  if( !fluT->setState(data) ) return false;
-  if( score_spe ) {
-      for(int j=0; j<nreg; j++) {
-          if ( is_sensitive[j] ){ 
-             if( !flu[j]->setState(data) ) return false;
-          }
-      }
-  }
-
-  if ( score_primaries ){
-     if( !fluT_p->setState(data) ) return false;
-     if( score_spe ) {
-         for(int j=0; j < nreg; j++) {
-            if ( is_sensitive[j] ){ 
-               if( !flu_p[j]->setState(data) ) return false;
+    if (!fluT->setState(data)) {
+        return false;
+    }
+    if (score_spe) {
+        for (int j=0; j<nreg; j++) {
+            if (is_sensitive[j]) {
+                if (!flu[j]->setState(data)) {
+                    return false;
+                }
             }
-         }
-     }
-  }
+        }
+    }
 
-  return true;
+    if (score_primaries) {
+        if (!fluT_p->setState(data)) {
+            return false;
+        }
+        if (score_spe) {
+            for (int j=0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!flu_p[j]->setState(data)) {
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    return true;
 }
 
-bool  EGS_VolumetricFluence::addState(istream &data){
-   EGS_I64 tmp_case; if( !egsGetI64(data,tmp_case) ) return false;
-   current_ncase += tmp_case;
+bool  EGS_VolumetricFluence::addState(istream &data) {
+    EGS_I64 tmp_case;
+    if (!egsGetI64(data,tmp_case)) {
+        return false;
+    }
+    current_ncase += tmp_case;
 
-   if (!data.good()) return false;
+    if (!data.good()) {
+        return false;
+    }
 
 #ifdef DEBUG
-  if ( scoring_charge ){
-     EGS_ScoringArray tmpRelStepDiff(1);
-     if( !tmpRelStepDiff.setState(data) ) return false;
-     (*relStepDiff) += tmpRelStepDiff;
-  }
+    if (scoring_charge) {
+        EGS_ScoringArray tmpRelStepDiff(1);
+        if (!tmpRelStepDiff.setState(data)) {
+            return false;
+        }
+        (*relStepDiff) += tmpRelStepDiff;
+    }
 #endif
-   /* fluence objects */
+    /* fluence objects */
 
-   EGS_ScoringArray tgT(nreg);
-   if( !tgT.setState(data) ) return false;
-   (*fluT) += tgT;
+    EGS_ScoringArray tgT(nreg);
+    if (!tgT.setState(data)) {
+        return false;
+    }
+    (*fluT) += tgT;
 
-   if( score_spe ) {
-       EGS_ScoringArray tg(flu_nbin);
-       for(int j = 0; j < nreg; j++) {
-           if ( is_sensitive[j] ){ 
-             if( !tg.setState(data) ) return false;
-             (*flu[j]) += tg;
-           }
-       }
-   }
+    if (score_spe) {
+        EGS_ScoringArray tg(flu_nbin);
+        for (int j = 0; j < nreg; j++) {
+            if (is_sensitive[j]) {
+                if (!tg.setState(data)) {
+                    return false;
+                }
+                (*flu[j]) += tg;
+            }
+        }
+    }
 
-   if ( score_primaries ){
-       EGS_ScoringArray tgT_p(nreg);
-       if( !tgT_p.setState(data) ) return false;
-       (*fluT_p) += tgT_p;
-       if( score_spe ) {
-           EGS_ScoringArray tg_p(flu_nbin);
-           for(int j=0; j < nreg; j++) {
-              if ( is_sensitive[j] ){ 
-                 if( !tg_p.setState(data) ) return false;
-                   (*flu_p[j]) += tg_p;
-              }
-           }
-       }
-   }
+    if (score_primaries) {
+        EGS_ScoringArray tgT_p(nreg);
+        if (!tgT_p.setState(data)) {
+            return false;
+        }
+        (*fluT_p) += tgT_p;
+        if (score_spe) {
+            EGS_ScoringArray tg_p(flu_nbin);
+            for (int j=0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!tg_p.setState(data)) {
+                        return false;
+                    }
+                    (*flu_p[j]) += tg_p;
+                }
+            }
+        }
+    }
 
-   return true;
+    return true;
 }
 
 extern "C" {
 
-  EGS_FLUENCE_SCORING_EXPORT EGS_AusgabObject* 
-                          createAusgabObject(EGS_Input *input, EGS_ObjectFactory *f) {
-      const static char *func = "createAusgabObject(fluence_scoring)";
-      if( !input ) {
-          egsWarning("%s: null input?\n",func); return 0;
-      }
-  
-      string type;
-      int error = input->getInput("type",type);
-      if ( !error && input->compare("planar",type) ) {
-        EGS_PlanarFluence *result = new EGS_PlanarFluence("", f);
-        result->setName(input);
-        result->initScoring(input);
-        return result;
-      }
-      else if ( !error && input->compare("volumetric",type) ){
-        EGS_VolumetricFluence *result = new EGS_VolumetricFluence("", f);
-        result->setName(input);
-        result->initScoring(input);
-        return result;
-      }
-      else{
-        egsFatal("Invalid fluence type input?\n\n\n"); 
-        return 0;
-      }
-  }
+    EGS_FLUENCE_SCORING_EXPORT EGS_AusgabObject *
+    createAusgabObject(EGS_Input *input, EGS_ObjectFactory *f) {
+        const static char *func = "createAusgabObject(fluence_scoring)";
+        if (!input) {
+            egsWarning("%s: null input?\n",func);
+            return 0;
+        }
+
+        string type;
+        int error = input->getInput("type",type);
+        if (!error && input->compare("planar",type)) {
+            EGS_PlanarFluence *result = new EGS_PlanarFluence("", f);
+            result->setName(input);
+            result->initScoring(input);
+            return result;
+        }
+        else if (!error && input->compare("volumetric",type)) {
+            EGS_VolumetricFluence *result = new EGS_VolumetricFluence("", f);
+            result->setName(input);
+            result->initScoring(input);
+            return result;
+        }
+        else {
+            egsFatal("Invalid fluence type input?\n\n\n");
+            return 0;
+        }
+    }
 
 }

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -163,7 +163,7 @@ void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
             EGS_Float xmin = tmp_field[0],xmax = tmp_field[1],
                       ymin = tmp_field[2],ymax = tmp_field[3];
             /* scoring plane location in space */
-            m_midpoint = EGS_Vector((xmax+xmin)/2.,(ymax+ymin)/2.,0); // plane at origin by default
+            m_midpoint = EGS_Vector((xmax+xmin)/2.,(ymax+ymin)/2.,0); // at origin by default
             /* scoring plane normal */
             m_normal = EGS_Vector(0,0,1); // default normal along positive z-axis
             /* define unit vectors on right-handed scoring plane */
@@ -215,8 +215,8 @@ void EGS_PlanarFluence::initScoring(EGS_Input *inp) {
         if( err1 || tmp_normal.size() != 3 ) {
           egsWarning(
           "\n\n***  Wrong/missing 'scoring plane normal' input. "
-          "Set to null vector\n\n");
-          m_normal = EGS_Vector();// set to null vector
+          "Set along positive z-axis\n\n");
+          m_normal = EGS_Vector(0,0,1);// Default along positive z-axis
         }
         else{
           m_normal = EGS_Vector(tmp_normal[0],tmp_normal[1],

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -1,0 +1,623 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ fluence scoring object header
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Ernesto Mainegra-Hing, 2022
+#
+#  Contributors:    
+#
+###############################################################################
+
+/*! \file egs_fluence_scoring.h
+    \brief A fluence scoring object : header
+  
+\ingroup AusgabObjects
+
+
+NEEDS UPDATING ... !
+
+This ausgab object can be used to score particle fluence during 
+run time and to output this information into a file
+This ausgab object is specified via
+\verbatim
+:start ausgab object:
+    library = egs_fluence_scoring
+    name    = some_name
+    score photons   = yes or no # optional, yes assumed if missing
+    score electrons = yes or no # optional, yes assumed if missing
+    score positrons = yes or no # optional, yes assumed if missing
+    start scoring   = event_number # optional, 0 assumed if missing
+    stop  scoring   = event_number # optional, 1024 assumed if missing
+    buffer size     = size         # optional, 1024 assumed if missing
+    file name addition = some_string # optional, empty string assumed if missing
+:stop ausgab object:
+\endverbatim
+The output file name is normally constructed from the output file name, 
+the string specified by <code>file name addition</code> (if present and not empty), 
+and <code>_wJob</code> in case of parallel runs. The extension given is <code>ptracks</code>. 
+Using <code>start scoring</code> and <code>stop scoring</code> one can select a 
+range of histories for which to score the particle track info. One can also 
+select specific particle type(s). 
+ */
+
+#ifndef EGS_FLUENCE_SCORING_
+#define EGS_FLUENCE_SCORING_
+
+#include "egs_ausgab_object.h"
+#include "egs_transformations.h"
+#include "egs_interpolator.h"
+#include <egs_scoring.h>
+
+#include <fstream>
+using namespace std;
+
+
+#ifdef WIN32
+
+#ifdef BUILD_FLUENCE_SCORING_DLL
+#define EGS_FLUENCE_SCORING_EXPORT __declspec(dllexport)
+#else
+#define EGS_FLUENCE_SCORING_EXPORT __declspec(dllimport)
+#endif
+#define EGS_FLUENCE_SCORING_LOCAL 
+
+#else
+
+#ifdef HAVE_VISIBILITY
+#define EGS_FLUENCE_SCORING_EXPORT __attribute__ ((visibility ("default")))
+#define EGS_FLUENCE_SCORING_LOCAL  __attribute__ ((visibility ("hidden")))
+#else
+#define EGS_FLUENCE_SCORING_EXPORT
+#define EGS_FLUENCE_SCORING_LOCAL
+#endif
+
+#endif
+
+/*! Field type */
+enum FieldType { circle=0, rectangle=1 };
+
+/*! Particle type */
+enum ParticleType { electron = -1, photon = 0, positron = 1 };
+
+/*! Charged particle fluence calculation type */
+enum eFluType { flurz=0, stpwr=1, stpwrO5=2 };
+
+class EGS_AdvancedApplication;
+
+class EGS_FLUENCE_SCORING_EXPORT EGS_PlanarFluence : public EGS_AusgabObject {
+
+public:
+   /*! Constructors */
+   EGS_PlanarFluence(const string &Name="", EGS_ObjectFactory *f = 0);
+   /*! Destructor.  */
+  ~EGS_PlanarFluence();
+   EGS_Float area(){return Area;};
+   //bool needsCall(EGS_Application::AusgabCall iarg) const { return true; };
+   bool needsCall(EGS_Application::AusgabCall iarg) const {
+       if (iarg == EGS_Application::BeforeTransport ||
+           iarg == EGS_Application::AfterTransport ){
+           return true;
+       }
+       else {
+           return false;
+       }
+   };
+
+   inline int hitsField(const EGS_Particle& p, EGS_Float* dist);
+   inline void    score(const EGS_Particle& p, const int& ivoxel);
+   void describeMe();//!< Sets fluence scoring object \c description
+   void initScoring(EGS_Input *inp);
+   void setApplication(EGS_Application *App);
+   void ouputResults();
+   void reportResults();
+   int processEvent(EGS_Application::AusgabCall iarg) {
+
+       int q = app->top_p.q;
+
+       if (q != scoring_charge ) return 0;
+
+       /* Quantify photon contribution to scoring field */
+       if( iarg == EGS_Application::BeforeTransport ){
+           ixy = hitsField(app->top_p,&distance);
+           if (ixy >= 0){
+              x0 = app->top_p.x; hits_field = true; 
+           }
+           else{hits_field = false; }
+       }
+
+       if( iarg == EGS_Application::AfterTransport && hits_field ){
+           EGS_Vector xstep = app->top_p.x - x0;
+           if (xstep.length() >= distance){// crossed scoring field
+              //if (!app->top_p.latch ) m_primary += app->top_p.wt;
+              m_tot  += app->top_p.wt;
+              score( app->top_p, ixy );
+           }
+           hits_field = false;
+       }
+
+       return 0;
+
+   };
+   void setCurrentCase(EGS_I64 ncase) {
+        if( ncase != current_ncase ) {
+            current_ncase = ncase;
+            if (flu){
+              for (int j = 0; j < Nx*Ny; j++)
+                   flu[j]->setHistory(ncase);
+              fluT->setHistory(ncase);
+            }
+        }
+   };
+   void resetCounter(){
+      current_ncase = 0; 
+      if (flu){
+        for (int j = 0; j < Nx*Ny; j++)
+             flu[j]->reset();
+        fluT->reset();
+      }
+   }
+   bool storeState(ostream &data) const;
+   bool setState(istream &data);
+   bool addState(istream &data);
+
+private:   
+
+  FieldType field_type;
+
+  ParticleType scoring_charge;
+
+  string particle_name;
+
+  EGS_ScoringArray** flu;  
+  EGS_ScoringArray*  fluT;  
+  /* Circular scoring field parameters */  
+  EGS_Vector      m_normal,
+                  m_midpoint,
+                  ux, uy;
+  EGS_Vector      x0;
+  EGS_Float     m_R, m_R2, // scoring field
+                norm_u;         // User normalization
+  /* Rectangular field parameters */  
+  EGS_Float     ax, ay, vx, vy;
+  int           Nx, Ny, n_sensitive_regs, ixy;
+  /* Energy grid inputs */
+  EGS_Float Area, flu_a,
+                  flu_b,
+                  flu_xmin,
+                  flu_xmax;
+  int             flu_s,
+                  flu_nbin;
+  
+  EGS_Float     m_d;       // distance from origin to center of scoring field
+  EGS_Float     distance; // distance to scoring field along particle's direction
+  EGS_Float     m_primary, 
+                m_tot;
+//  int fluence_scoring, energy_scoring;
+  bool     hits_field;
+  EGS_I64  current_ncase;                  
+
+  bool verbose;
+
+};
+
+class EGS_FLUENCE_SCORING_EXPORT EGS_VolumetricFluence : public EGS_AusgabObject {
+
+public:
+   /*! Constructors */
+   EGS_VolumetricFluence(const string &Name="", EGS_ObjectFactory *f = 0);
+
+   /*! Destructor.  */
+  ~EGS_VolumetricFluence();
+
+   bool needsCall(EGS_Application::AusgabCall iarg) const {
+       if (iarg == EGS_Application::BeforeTransport ||
+           iarg == EGS_Application::UserDiscard ){
+           return true;
+       }
+       else {
+           return false;
+       }
+   };
+
+   void describeMe();//!< Sets fluence scoring object \c description
+
+   void initScoring(EGS_Input *inp);
+
+   void setApplication(EGS_Application *App);
+
+   void ouputResults();
+
+   void reportResults();
+
+   int processEvent(EGS_Application::AusgabCall iarg) {
+
+       int q = app->top_p.q;
+       if ( q != scoring_charge ) return 0;
+
+       int ir = app->top_p.ir;
+       if ( ir < 0 || !is_sensitive[ir] ) return 0;
+
+       /* Scoring photon about to be transported in geometry */
+       if ( !q && iarg == EGS_Application::BeforeTransport ) {
+          /* Track-Length scoring (classic) */
+          EGS_Float e = app->top_p.E,
+          wtstep  = app->top_p.wt*app->getTVSTEP();
+          if (flu_s) {
+               e = log(e);
+          }
+          EGS_Float ae;
+          int je;
+          if (e > flu_xmin && e <= flu_xmax) {
+              ae = flu_a*e + flu_b;
+              je = min((int)ae,flu_nbin-1);
+              EGS_ScoringArray *aux = flu[ir];
+              aux->score(je,wtstep);
+              fluT->score(ir,wtstep);
+          }
+          return 0;
+       }
+
+       EGS_Float edep = app->getEdep();
+
+       /* Scoring charged particle about to be transported in geometry */
+       if ( q && edep &&
+          ( iarg == EGS_Application::BeforeTransport || 
+            iarg == EGS_Application::UserDiscard )   ){
+          /***** Initialization *****/
+          EGS_Float Eb = app->top_p.E - app->getRM(),
+                    Ee = Eb - edep,
+                    weight = app->top_p.wt;
+          EGS_Float xb, xe;
+          /*********************************/
+          if( flu_s ) {
+              xb = log(Eb);
+              if( Ee > 0 )
+                  xe = log(Ee);
+              else xe = -15;
+          }
+          else{
+            xb = Eb; xe = Ee;
+          }
+          EGS_Float ab, ae; int jb, je;
+          if( xb > flu_xmin && xe < flu_xmax ) {
+              /* Fraction of the initial bin covered */
+              if( xb < flu_xmax ) {
+                  ab = flu_a*xb + flu_b; jb = (int) ab;
+                  /* Variable bin-width for log scale*/
+                  if (flu_s){
+                     ab = (Eb*a_const[jb]-1)*r_const;
+                  }
+                  else{ ab -= jb;}// particle's energy above Emax
+              }
+              else { xb = flu_xmax; ab = 1; jb = flu_nbin - 1; }
+              /* Fraction of the final bin covered */
+              if( xe > flu_xmin ) {
+                  ae = flu_a*xe + flu_b; je = (int) ae;
+                  /* Variable bin-width for log scale*/
+                  if (flu_s){
+                     ae = (Ee*a_const[je]-1)*r_const;
+                  }
+                  else{ ae -= je; }
+              }
+              else { xe = flu_xmin; ae = 0; je = 0; }// extends below Emin
+
+#ifdef DEBUG 
+              //egsInformation("iarg = %d jb = %d je = %d edep = %g MeV weight = %g\n",iarg,jb,je,edep,weight);                    
+              if (jb == je) 
+                one_bin++;
+              else{          
+                multi_bin++;
+                //egsInformation("\niarg = %d jb = %d je = %d edep = %g MeV ab = %g ae = %g",iarg,jb,je,edep,ab,ae);                    
+              }
+              binDist->score(jb-je,weight);
+#endif
+              EGS_ScoringArray *aux = flu[ir];
+              EGS_ScoringArray *auxT = fluT;
+
+              /************************************************
+               * Approach A:
+               * -----------
+               * Uses either an O(3) or O(5) series expansion of the
+               * integral of the inverse of the stopping power with
+               * respect to energy. The stopping power is represented
+               * as a linear interpolation over a log energy grid. It
+               * accounts for stopping power variation along the particle's
+               * step within the resolution of the scoring array. This
+               * is more accurate than the method used in FLURZnrc albeit
+               * about 10% slower in electron beam cases.
+               *
+               * BEWARE: For this approach to work, no range rejection
+               * ------  nor Russian Roulette should be used.
+               *
+               ************************************************/
+              if (flu_stpwr){
+                 int imed = app->getMedium(ir);
+                 // Initial and final energies in same bin
+                 EGS_Float step;
+                 if( jb == je ){
+                     step = weight*(ab-ae)*getStepPerFraction(imed,xb,xe);
+                     aux->score(jb,step);
+                     if (flu_s)
+                        auxT->score(ir,step*DE[jb]);
+                     else
+                        auxT->score(ir,step);
+                 }
+                 else {
+                     //EGS_Float flu_a_i = 1/flu_a;
+                     // First bin
+                     Ee = flu_xmin + jb*flu_a_i; Eb=xb;
+                     step = weight*ab*getStepPerFraction(imed,Eb,Ee);
+                     aux->score(jb,step);
+                     if (flu_s)
+                        auxT->score(ir,step*DE[jb]);
+                     else
+                        auxT->score(ir,step);
+                     // Last bin
+                     Ee = xe; Eb = flu_xmin+(je+1)*flu_a_i;
+                     step = weight*(1-ae)*getStepPerFraction(imed,Eb,Ee);
+                     aux->score(je,step);
+                     if (flu_s)
+                        auxT->score(ir,step*DE[je]);
+                     else
+                        auxT->score(ir,step);
+                     // intermediate bins
+                     for(int j=je+1; j<jb; j++){
+                        if (flu_stpwr == stpwrO5){
+                          Ee = Eb; Eb = flu_xmin + (j+1)*flu_a_i;
+                         /* O(eps^5) would require more pre-computed values
+                          * than just 1/Lmid. One requires lnEmid[i] to get
+                          * the b parameter and eps[i]=1-E[i]/E[i+1]. Not
+                          * impossible, but seems unnecessary considering
+                          * the excellent agreement with O(eps^3), which
+                          * should be always used.
+                          */
+                          step = weight*getStepPerFraction(imed,Eb,Ee);
+                        }
+                        else{// use pre-computed values of 1/Lmid
+                         step = weight*Lmid_i[j + imed*flu_nbin];
+                        }
+                        aux->score(j,step);
+                        if (flu_s)
+                          auxT->score(ir,step*DE[j]);
+                        else
+                          auxT->score(ir,step);
+                     }
+                 }
+              }
+              /***************************************************
+               * -----------------------
+               * Approach B (FLURZnrc):
+               * ----------------------
+               * Path length at each energy interval from energy
+               * deposited edep and total particle step tvstep. It
+               * assumes stopping power constancy along the particle's
+               * step. It might introduce artifacts if ESTEPE or the
+               * scoring bin width are too large.
+               *
+               * BEWARE: For this approach to work, no range rejection
+               * ------  nor Russian Roulette should be used.
+               **************************************************/
+              else{
+                 EGS_Float step, wtstep = weight*app->getTVSTEP()/edep;
+                 // Initial and final energies in same bin
+                 if( jb == je ){
+                   step = wtstep*(ab-ae);
+                   aux->score(jb,step);
+                   if (flu_s)
+                     auxT->score(ir,step*DE[jb]);
+                   else
+                     auxT->score(ir,step);
+                 }
+                 else {
+                     // First bin
+                     step = wtstep*ab;
+                     aux->score(jb,step);
+                     if (flu_s)
+                       auxT->score(ir,step*DE[jb]);
+                     else
+                       auxT->score(ir,step);
+                     // Last bin
+                     step = wtstep*(1-ae);
+                     aux->score(je,step);
+                     if (flu_s)
+                       auxT->score(ir,step*DE[je]);
+                     else
+                       auxT->score(ir,step);
+                     // intermediate bins
+                     for(int j=je+1; j<jb; j++){
+                         aux->score(j,wtstep);
+                         if (flu_s)
+                           auxT->score(ir,wtstep*DE[j]);
+                         else
+                           auxT->score(ir,wtstep);
+                     }
+                 }
+              }
+          }
+       }
+
+       return 0;
+   };
+
+    /*! Computes path per energy bin-width traveled by a charged particle when
+     *  slowing down from Eb to Ee.
+     *
+     * Computes the path-length traveled while slowing down from energy Eb to energy
+     * Ee, both energies falling in the same energy bin assuming full coverage.
+     * The returned value should be multiplied by the actual fraction of the
+     * energy bin covered by Eb-Ee.
+     * If using a logarithmic energy interpolation, Eb and Ee are actually the
+     * logarithms of the initial and final energies. The expression is based on
+     * linear interpolation in a logarithmic energy grid as used in EGSnrc
+     * (i.e. dedx = a + b*log(E) ) and a power series expansion of the ExpIntegralEi
+     * function that is the result of the integration of the inverse of the stopping
+     * power with respect to energy.
+     */
+    EGS_Float getStepPerFraction( const int & imed,
+                                      const EGS_Float & Eb,
+                                      const EGS_Float & Ee){
+        EGS_Float stpFrac, eps, lnEmid;
+        if (flu_s){//Using log(E)
+          eps     = 1 - exp(Ee-Eb);
+          /* 4th order series expansion of log([Eb+Ee]/2) */
+          lnEmid  = 0.5*(Eb+Ee+0.25*eps*eps*(1+eps*(1+0.875*eps)));
+        }
+        else{//Using E
+          if (flu_stpwr == stpwrO5)
+             eps  = 1 - Ee/Eb;
+          lnEmid  = log(0.5*(Eb+Ee));
+        }
+
+        EGS_Float dedxmid_i = dedx_i[imed].interpolate(lnEmid);
+        // Used in cavity:
+        // EGS_Float dedxmid_i = 1./i_dedx[imed].interpolate(lnEmid);
+#ifdef DEBUG
+if (!isfinite(dedxmid_i)){
+  if (isnan(dedxmid_i))
+    egsInformation("\n Is NaN? dedxmid_i = %g",dedxmid_i);
+  else    
+    egsInformation("\n Is infinite? dedxmid_i = %g",dedxmid_i);
+}
+else{
+  if (dedxmid_i<0){
+    egsInformation("\n Is negative? dedxmid_i = %g Emid = %g lnEmid = %g index = %d",
+    dedxmid_i,exp(lnEmid),lnEmid, dedx_i[imed].getIndex(lnEmid) );
+  }
+  if (dedxmid_i > 1.E10)
+    egsInformation("\n Is very large? dedxmid_i = %g Emid = %g lnEmid = %g",dedxmid_i,exp(lnEmid),lnEmid);
+      
+}
+#endif        
+        /* O(eps^3) approach */
+        if (flu_stpwr == stpwr) return dedxmid_i;
+        
+        /* O(eps^5) approach */
+        EGS_Float b = i_dedx[imed].get_b(i_dedx[imed].getIndexFast(lnEmid));
+        EGS_Float aux = b*dedxmid_i;
+        aux = aux*(1+2*aux)*pow(eps/(2-eps),2)/6;
+        //aux = aux*(1+2*aux)*eps*eps/((2-eps)*(2-eps))*0.16666666667;
+        stpFrac = dedxmid_i*(1+aux);
+        return stpFrac;
+    }
+
+
+   void setCurrentCase(EGS_I64 ncase) {
+        if( ncase != current_ncase ) {
+            current_ncase = ncase;
+            if (flu){
+              for (int j = 0; j < nreg; j++){
+                  if ( is_sensitive[j] ) 
+                     flu[j]->setHistory(ncase);
+              }
+              fluT->setHistory(ncase);
+            }
+        }
+#ifdef DEBUG
+        binDist->setHistory(ncase);
+#endif        
+
+   };
+   void resetCounter(){
+      current_ncase = 0; 
+      if (flu){
+        for (int j = 0; j < nreg; j++)
+            if ( is_sensitive[j] ) 
+               flu[j]->reset();
+        fluT->reset();
+      }
+#ifdef DEBUG
+      binDist->reset();
+#endif
+   }
+   void getNumberRegions(const string &str, vector<int> &regs);
+
+   void getLabelRegions(const string &str, vector<int> &regs);
+   
+   bool storeState(ostream &data) const;
+   
+   bool setState(istream &data);
+   
+   bool addState(istream &data);
+
+private:   
+
+  ParticleType scoring_charge;
+
+  string particle_name;
+
+  EGS_I64  current_ncase;                  
+
+  /* Fluence Scoring Arrays */
+  EGS_ScoringArray** flu;  
+  EGS_ScoringArray*  fluT;  
+
+  /*******************************************/
+  /* Charged particle fluence: Required data */
+  /*******************************************/
+  EGS_Interpolator* i_dedx; // stopping power for each medium
+  EGS_Interpolator* dedx_i; // inverse stopping power for each medium
+  EGS_Float*        Lmid_i; // pre-computed inverse of bin midpoint stpwr
+  eFluType       flu_stpwr; // flurz   => ave. stpwr = edep/tvstep,
+                            // stpwr   => 3rd order in edep/Eb,
+                            // stpwrO5 => 5th order in edep/Eb
+  /**************************************************************
+   * Parameters required for calculations on a log-scale
+   * The main issue here is that the bin width is not constant
+   *************************************************************/
+   EGS_Float       r_const;    // inverse of (Emax/Emin)**1/flu_nbin - 1 = exp(binwidth)-1
+   EGS_Float      *a_const;    // constant needed to determine bin fractions on log scale
+   EGS_Float      *DE;         // bin width of logarithmic scale
+  /*****************************************************************/
+
+  vector<EGS_Float> volume;// volume of each scoring region
+  int       active_region;    // Region showing calculation progress
+  int       n_scoring_regions; // number of scoring regions
+  int       nreg;              // regions in geometry
+  int max_reg ;             // maximum scoring region number
+  vector<bool> is_sensitive;// flag scoring regions
+  EGS_Float norm_u;         // User normalization
+  /* Energy grid inputs */
+  EGS_Float flu_a, flu_a_i,
+            flu_b,
+            flu_xmin,
+            flu_xmax;
+  int       flu_s,
+            flu_nbin;
+  /* Classification variables */
+  EGS_Float m_primary, 
+            m_tot;
+  /* Auxiliary input variables*/
+  vector <EGS_Float> vol_list;      // Input list of region volumes
+  vector <int>       f_region;      // Input list of scoring regions
+  string             f_regionsString;// Input string of scoring regions or labels
+
+#ifdef DEBUG
+  /* Debugging information */
+  int one_bin, multi_bin;
+  EGS_ScoringArray *binDist;  
+#endif
+
+  bool verbose;
+
+};
+
+#endif

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -242,14 +242,14 @@ protected:
   A linear track-length estimator in the zero-thickness limit is used to
   compute fluence for either a circular field or a rectangular screen of
   arbitrary resolution (pixels). Rectangular fields are by default at Z = 0
-  directed along the positive z-axis. An affine transofrmation can be included
+  directed along the positive z-axis. An affine transformation can be included
   to place a rectangular field anywhere in space. User can request to score primary
   fluence as well as differential fluence. If fluence for more than one particle type
   is desired, multiple AOs are required.
 
   For charged particle fluence scoring this method can be inefficient as
   it checks at every single step whether a charged particle is aimed at scoring field.
-  To improve the efficieny for charged particles, one has the option to define contributing regions
+  To improve the efficiency for charged particles, one has the option to define contributing regions
   from where to score. However, users must be careful to select all regions from where
   charged particles can cross the scoring field. This option has the added benefit of
   allowing to estimate the contribution to the fluence from specific regions in the geometry.
@@ -477,7 +477,7 @@ private:
   desired, multiple AOs are required.
 
   Differential fluence for charged particles is calculated accounting for
-  continuos energy losses along the path. As these particles slow down in medium,
+  continuous energy losses along the path. As these particles slow down in medium,
   their contribution to fluence will spread over several energy bins. Two methods
   to account for this are provided. One method follows the FLURZnrc implementation,
   whereby stopping power is assumed constant along the step and estimated as the

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -26,45 +26,15 @@
 #  Contributors:    
 #
 ###############################################################################
-
-Ausgab objects (AOs) for fluence scoring in arbitrary geometrical regions or at 
-circular  or rectangular scoring fields located anywhere in space for a specific 
-particle type. Fluence can be scored for multiple particle types by definining 
-different AOs. An option exists for scoring the fluence of primary particles. 
-Classification into primary and secondary particles follows the definition used 
-in FLURZnrc for IPRIMARY = 2 (primaries) and IPRIMARY = 4 (secondaries).
-
-The basic definition of a fluence scoring AO is
-
-    :start ausgab object:
-        name    = a_name
-        library = egs_fluence_scoring
-        type = planar # planar or volumetric
-        scoring particle = electron # or photon, or positron
-        # Define scoring (volumetric) or contributing (planar) regions
-        scoring regions = ir1 ir2 ... irn
-        # Alternatively:
-        # start region = iri_1, iri_2, ..., iri_n
-        # stop region =  irf_1, irf_2, ..., irf_n
-        volumes = V1, V2, ..., VN # Enter as many as scoring regions. If same number
-                                  # of entries as group of regions, assumes groups of 
-                                  # equal volume regions. If only one entry, assumes 
-                                  # equal volumes in all regions. Defaults to 1.
-        # score primaries = yes # or no, optional
-        # source regions = sr1 sr2 ... srN # <- no classification in these regions
-        # source particle = photon, electron, or positron #<- brems targets or multi-particle sources
-        # scoring grid
-        number of bins = 100
-        minimum kinetic energy = 0.001
-        maximum kinetic energy = 1.000
-        normalization  = 1 # user-normalization optional
-        scale = linear # or logarithmic
-        # Scoring field for planar scoring
-        scoring circle = 0 0 5.0 5.0
-        scoring plane normal = 0 0 1
-        verbose = yes # optional
-    :stop ausgab object:
-
+# 
+# Ausgab objects (AOs) for fluence scoring in arbitrary geometrical regions or at 
+# circular  or rectangular scoring fields located anywhere in space for a specific 
+# particle type. Fluence can be scored for multiple particle types by definining 
+# different AOs. An option exists for scoring the fluence of primary particles. 
+# Classification into primary and secondary particles follows the definition used 
+# in FLURZnrc for IPRIMARY = 2 (primaries) and IPRIMARY = 4 (secondaries).
+#
+############################################################################### 
 */
 
 /*! \file egs_fluence_scoring.h
@@ -114,7 +84,7 @@ enum ParticleType { electron = -1, photon = 0, positron = 1, unknown = -99 };
 /*! Charged particle fluence calculation type */
 enum eFluType { flurz=0, stpwr=1, stpwrO5=2 };
 
-/*! \brief Base class for fluence scoring ausgab objects 
+/*! \brief Base class for fluence scoring. 
 
   \ingroup AusgabObjects
 
@@ -122,32 +92,6 @@ enum eFluType { flurz=0, stpwr=1, stpwrO5=2 };
   particle type, scoring regions, and whether to score primary fluence. 
   Provides the method for defining primary and secondary particles.
 
-A basic fluence scoring ausgab object is specified via
-\verbatim
-:start ausgab object:
-    name    = a_name
-    library = egs_fluence_scoring
-    type = a_type # planar or volumetric
-    scoring particle = a_particle # photon, electron, or positron
-    # Define scoring (volumetric) or contributing (planar) regions
-    scoring regions = ir1 ir2 ... irn
-    ### Alternatively:
-    # start region = iri_1, iri_2, ..., iri_n
-    # stop region =  irf_1, irf_2, ..., irf_n
-    ###
-    # score primaries = yes # or no, optional
-    ###
-    # source regions = sr1 sr2 ... srN # <- no classification in these regions
-    # source particle = photon, electron, or positron #<- multi-particle sources or brems targets
-    ### scoring grid
-    number of bins = 100
-    minimum kinetic energy = 0.001
-    maximum kinetic energy = 1.000
-    # normalization  = 1 # user-normalization optional, defaults to 1
-    scale = a_scale # linear or logarithmic
-    verbose = yes # or no, optional
-:stop ausgab object:
-\endverbatim
   \todo Total kerma scoring
   \todo Account for multiple app geometries
   \todo Fluence for any particle type?
@@ -292,53 +236,80 @@ protected:
 
   \ingroup AusgabObjects
 
-  A linear track-length estimator in the zero thickness limit is used to compute 
-  fluence and fluence-related quantities such as total kerma and cema if the user 
-  requestes it. Differencial and total fluence is estimated for a specific particle 
-  type. If fluence for more than one particle type is desired, multiple AOs are 
-  required. For charged particle fluence scoring this method can be inefficient as 
-  it checks at every single step whether a charged particle is aimed at scoring field.
+  A linear track-length estimator in the zero-thickness limit is used to 
+  compute fluence for either a circular field or a rectangular screen of 
+  arbitrary resolution (pixels). Rectangular fields are by default at Z = 0 
+  directed along the positive z-axis. An affine transofrmation can be included
+  to place a rectangular field anywhere in space. User can request to score primary 
+  fluence as well as differential fluence. If fluence for more than one particle type 
+  is desired, multiple AOs are required. 
   
-  To improve the efficieny for charged particles, one has the option to define regions 
+  For charged particle fluence scoring this method can be inefficient as 
+  it checks at every single step whether a charged particle is aimed at scoring field.
+  To improve the efficieny for charged particles, one has the option to define contributing regions 
   from where to score. However, users must be careful to select all regions from where
   charged particles can cross the scoring field. This option has the added benefit of 
   allowing to estimate the contribution to the fluence from specific regions in the geometry.
 
-  Scoring field can be either a circular field or a rectangular screen of arbitrary 
-  resolution (pixels). For rectangular fields, fluence is computed at each screen element (pixel)
-
   To define an EGS_PlanarFluence AO use the syntax below:
   \verbatim
-  :start ausgab object:
-      name    = a_name
-      library = egs_fluence_scoring
-      type = volumetric
-      scoring particle = electron # or photon, or positron
-      # Scoring field for planar scoring
-      scoring circle = 0 0 5.0 5.0
-      scoring plane normal = 0 0 1
-      ### Define contributing regions
-      # scoring regions = ir1 ir2 ... irn # optional, defaults to ALL
-      ### Alternatively:
-      # start region = iri_1, iri_2, ..., iri_n
-      # stop region =  irf_1, irf_2, ..., irf_n
-      ###
-      # score primaries = yes # or no, optional
-      # source regions = sr1 sr2 ... srN # <- no classification in these regions
-      # source particle = photon, electron, or positron #<- multi-particle sources or brems targets
-      ### scoring grid
-      number of bins = 100
-      minimum kinetic energy = 0.001
-      maximum kinetic energy = 1.000
-      normalization  = 1 # user-normalization optional
-      scale = linear # or logarithmic
-      verbose = yes # optional
-  :stop ausgab object:
+:start ausgab object:
+    name    = id-string            # Arbitrary identifying string
+    library = egs_fluence_scoring  # Library name
+    type    = planar               # Score on circular or square field
+    scoring particle = photon, or electron, or positron
+    source particle  = photon, or electron, or positron 
+                                   # Optional. Only required to score primary fluence.
+                                   # Defaults to source particles if all the same.
+                                   # In the case of multiple particles, 
+                                   # defaults to scoring particle. Useful for
+                                   # bremsstrahlung targets and radioactive sources.
+    score primaries = yes or no    # Defaults to `no`.
+    score spectrum  = yes or no    # Defaults to `no`.
+    verbose         = yes or no    # Defaults to `no`.
+    normalization   = norm         # User-requested normalization. Defaults to 1.
+    #########
+    # If scoring spectrum, define energy grid
+    # Default: 128 linear energy bins between 1 keV and 1 MeV
+    #########
+    :start energy grid:
+      number of bins = nbins
+      minimum kinetic energy = Emin
+      maximum kinetic energy = Emax
+      scale = linear or logarithmic # Defaults to `linear`.
+    :stop energy grid:
+    ########
+    # Define scoring based on type
+    ########
+    :start planar scoring:
+       # Define contributing regions
+       contributing regions = ir1 ir2 ... irn
+       ### Alternatively:
+       # start contributing region = iri_1, iri_2, ..., iri_n
+       # stop contributing region =  irf_1, irf_2, ..., irf_n
+       ###
+       ################################
+       # If a circular field desired:
+       ################################
+       scoring circle = x y z R
+       scoring plane normal = ux uy uz
+       ########################################################
+       # If a rectangular field desired:
+       #
+       #scoring rectangle = xmin xmax ymin ymax
+       #####
+       # See documentation for EGS_AffineTransform
+       #####
+       #:start transformation:
+       #   rotation = 2, 3 or 9 floating point numbers
+       #   translation = tx, ty, tz
+       #:stop transformation:
+       ##########################################################
+    :stop planar scoring:
+:stop ausgab object:
   \endverbatim
 
   \todo Store results in a 2D binary file for visualization
-  \todo Add option for (total) kerma scoring
-  \todo Add option for CEMA scoring ???
 */
 class EGS_FLUENCE_SCORING_EXPORT EGS_PlanarFluence : public EGS_FluenceScoring {
 
@@ -417,11 +388,8 @@ public:
         *         Other applications might use latch for other purposes!
         *********************************************************************/
        if ( score_primaries && ir >= 0 && !is_source[ir]){
-   
           flagSecondaries( iarg, q );
-   
        }
-
 
        return 0;
 
@@ -493,44 +461,86 @@ private:
 
   \ingroup AusgabObjects
 
-  A linear track-lenght estimator is used to compute fluence and fluence-related 
-  quantities such as total kerma and cema if the user requestes it. Differencial 
-  and total fluence is estimated for a specific particle type. If fluence for more 
-  than one particle type is desired, multiple AOs are required.
+  A linear track-length estimator is used to compute fluence in specific 
+  geometrical regions. User can request to score primary fluence as well 
+  as differential fluence. If fluence for more than one particle type is 
+  desired, multiple AOs are required.
+
+  Differential fluence for charged particle is calculated accounting for 
+  continuos energy losses along the path using two methods. One method follows 
+  the FLURZnrc implementation, whereby stopping power is assumed constant along 
+  the step and estimated as the ratio EDEP/TVSTEP. The contributions to each 
+  energy bin of width \f$\Delta E_i\f$ is obtained as the energy fraction 
+  TVSTEP*\f$\Delta E_i\f$/EDEP.
+
+  The second method follows the approach currently used in the EGSnrc 
+  application \ref cavity "cavity", which accounts for stopping power 
+  changes within a scoring energy bin. It uses a series expansion of the 
+  integral of the inverse of the stopping power with respect to energy. 
+  Stopping power is represented as a linear interpolation over a log energy grid. 
+  A technical note is in preparation providing more details about this implementation.
 
   To define an EGS_VolumetricFluence AO use the syntax below:
   \verbatim
-  :start ausgab object:
-      name    = a_name
-      library = egs_fluence_scoring
-      type = volumetric
-      scoring particle = electron # or photon, or positron
-      # Define individual scoring regions
-      scoring regions = ir1 ir2 ... irn
-      ### Alternatively use groups of regions:
-      # start region = iri_1, iri_2, ..., iri_n
-      # stop region =  irf_1, irf_2, ..., irf_n
-      ###
-      volumes = V1, V2, ..., VN # Enter as many as scoring regions. If same number
-                                # of entries as group of regions, assumes groups of 
-                                # equal volume regions. If only one entry, assumes 
-                                # equal volumes in all regions. Defaults to 1.
-      # score primaries = yes # or no, optional
-      # source regions = sr1 sr2 ... srN # <- no classification in these regions
-      # source particle = photon, electron, or positron #<- multi-particle sources or brems targets
-      # scoring grid
-      number of bins = 100
-      minimum kinetic energy = 0.001
-      maximum kinetic energy = 1.000
-      normalization  = 1 # user-normalization optional
-      scale = linear # or logarithmic
-      verbose = yes # optional
-  :stop ausgab object:
+:start ausgab object:
+    name    = id-string            # Arbitrary identifying string
+    library = egs_fluence_scoring  # Library name
+    type    = volumetric           # Score in a volume
+    scoring particle = photon, or electron, or positron
+    source particle  = photon, or electron, or positron 
+                                   # Optional. Only required to score primary fluence.
+                                   # Defaults to source particles if all the same.
+                                   # In the case of multiple particles, 
+                                   # defaults to scoring particle. Useful for
+                                   # bremsstrahlung targets and radioactive sources.
+    score primaries = yes or no    # Defaults to `no`.
+    score spectrum  = yes or no    # Defaults to `no`.
+    verbose         = yes or no    # Defaults to `no`.
+    normalization   = norm         # User-requested normalization. Defaults to 1.
+    # If scoring spectrum, define energy grid
+    # Default: 128 linear energy bins between 1 keV and 1 MeV
+    :start energy grid:
+      number of bins = nbins
+      minimum kinetic energy = Emin
+      maximum kinetic energy = Emax
+      scale = linear or logarithmic # Defaults to `linear`.
+    :stop energy grid:
+    :start volumetric scoring:
+        scoring regions = ir1 ir2 ... irn
+        ### Alternatively:
+        #start region = iri_1, iri_2, ..., iri_n
+        #stop region  = irf_1, irf_2, ..., irf_n
+        ###
+        volumes = V1, V2, ..., VN # Enter as many as scoring regions. If same number
+                                  # of entries as group of regions, assumes groups of 
+                                  # equal volume regions. If only one entry, assumes 
+                                  # equal volumes in all regions. Defaults to 1.
+        method  = flurz or stpwr or stpwrO5 # For charged particle scoring.
+                  # 
+                  # flurz   => FLURZnrc algorithm
+                  # 
+                  # Path length at each energy interval from energy
+                  # deposited EDEP and total particle step TVSTEP. 
+                  # Assumes stopping power constancy along the particle's
+                  # step. It might introduce artifacts if ESTEPE or the
+                  # scoring bin width are too large.
+                  # 
+                  # stpwr   => Accounts for stopping power variation 
+                  #          along the particle's step. More accurate 
+                  #          than method used in FLURZnrc albeit about
+                  #          about 10% slower in electron beam cases.
+                  #
+                  # Uses an O(3) series expansion of the integral of the
+                  # inverse of the stopping power with respect to energy. 
+                  # Stopping power is represented as a linear interpolation 
+                  # over a log energy grid.
+                  # 
+                  # stpwrO5 => Uses an O(5) series expansion. Slightly slower.
+                  # 
+                  # Defaults to `stpwr`.
+    :stop volumetric scoring:
+:stop ausgab object:
   \endverbatim
-
-  \todo Add option for (total) kerma scoring
-  \todo Add option for CEMA scoring
-
 */
 class EGS_FLUENCE_SCORING_EXPORT EGS_VolumetricFluence : public EGS_FluenceScoring {
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -23,22 +23,22 @@
 #
 #  Author:          Ernesto Mainegra-Hing, 2022
 #
-#  Contributors:    
+#  Contributors:
 #
 ###############################################################################
-# 
-# Ausgab objects (AOs) for fluence scoring in arbitrary geometrical regions or at 
-# circular or rectangular scoring fields located anywhere in space for a specific 
-# particle type. Fluence can be scored for multiple particle types by definining 
-# different AOs. An option exists for scoring the fluence of primary particles. 
-# Classification into primary and secondary particles follows the definition used 
+#
+# Ausgab objects (AOs) for fluence scoring in arbitrary geometrical regions or at
+# circular or rectangular scoring fields located anywhere in space for a specific
+# particle type. Fluence can be scored for multiple particle types by definining
+# different AOs. An option exists for scoring the fluence of primary particles.
+# Classification into primary and secondary particles follows the definition used
 # in FLURZnrc for IPRIMARY = 2 (primaries) and IPRIMARY = 4 (secondaries).
 #
-############################################################################### 
+###############################################################################
 */
 
 /*! \file egs_fluence_scoring.h
- *  \brief A fluence scoring object : header 
+ *  \brief A fluence scoring object : header
  *  \EM
 */
 
@@ -56,22 +56,22 @@ using namespace std;
 
 #ifdef WIN32
 
-#ifdef BUILD_FLUENCE_SCORING_DLL
-#define EGS_FLUENCE_SCORING_EXPORT __declspec(dllexport)
-#else
-#define EGS_FLUENCE_SCORING_EXPORT __declspec(dllimport)
-#endif
-#define EGS_FLUENCE_SCORING_LOCAL 
+    #ifdef BUILD_FLUENCE_SCORING_DLL
+        #define EGS_FLUENCE_SCORING_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_FLUENCE_SCORING_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_FLUENCE_SCORING_LOCAL
 
 #else
 
-#ifdef HAVE_VISIBILITY
-#define EGS_FLUENCE_SCORING_EXPORT __attribute__ ((visibility ("default")))
-#define EGS_FLUENCE_SCORING_LOCAL  __attribute__ ((visibility ("hidden")))
-#else
-#define EGS_FLUENCE_SCORING_EXPORT
-#define EGS_FLUENCE_SCORING_LOCAL
-#endif
+    #ifdef HAVE_VISIBILITY
+        #define EGS_FLUENCE_SCORING_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_FLUENCE_SCORING_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_FLUENCE_SCORING_EXPORT
+        #define EGS_FLUENCE_SCORING_LOCAL
+    #endif
 
 #endif
 
@@ -84,12 +84,12 @@ enum ParticleType { electron = -1, photon = 0, positron = 1, unknown = -99 };
 /*! Charged particle fluence calculation type */
 enum eFluType { flurz=0, stpwr=1, stpwrO5=2 };
 
-/*! \brief Base class for fluence scoring. 
+/*! \brief Base class for fluence scoring.
 
   \ingroup AusgabObjects
 
   Contains the basic ingredients for fluence scoring such as energy grid,
-  particle type, scoring regions, and whether to score primary fluence. 
+  particle type, scoring regions, and whether to score primary fluence.
   Provides the method for defining primary and secondary particles.
 
   \todo Account for multiple app geometries
@@ -98,156 +98,160 @@ enum eFluType { flurz=0, stpwr=1, stpwrO5=2 };
 class EGS_FLUENCE_SCORING_EXPORT EGS_FluenceScoring : public EGS_AusgabObject {
 
 public:
-   /*! Constructors */
-   EGS_FluenceScoring(const string &Name="", EGS_ObjectFactory *f = 0);
-   /*! Destructor.  */
-  ~EGS_FluenceScoring();
+    /*! Constructors */
+    EGS_FluenceScoring(const string &Name="", EGS_ObjectFactory *f = 0);
+    /*! Destructor.  */
+    ~EGS_FluenceScoring();
 
-   void initScoring(EGS_Input *inp);
+    void initScoring(EGS_Input *inp);
 
-   void getSensitiveRegions(EGS_Input *inp);
+    void getSensitiveRegions(EGS_Input *inp);
 
-   void getNumberRegions( const string &str, vector<int> &regs );
+    void getNumberRegions(const string &str, vector<int> &regs);
 
-   void getLabelRegions( const string &str, vector<int> &regs );
+    void getLabelRegions(const string &str, vector<int> &regs);
 
-   void setUpRegionFlags();
+    void setUpRegionFlags();
 
-   void describeMe();
+    void describeMe();
 
-   int getDigits(int i) {
+    int getDigits(int i) {
         int imax = 10;
         while (i>=imax) {
             imax*=10;
         }
         return (int)log10((float)imax);
-   };
+    };
 
-   void flagSecondaries( const int &iarg, const int &q ){
-       int npold = app->getNpOld(), 
-              np = app->getNp();
-       if ( scoring_charge ){
-          /*************************************************************** 
-           DEFAULT: 
-           FLURZnrc IPRIMARY = 2 (primaries) IPRIMARY = 4 (secondaries)
-               Secondary charged particles defined as those resulting 
-               from charged particle interactions, atomic relaxations 
-               following EII, brems and annihilation photons. 
+    void flagSecondaries(const int &iarg, const int &q) {
+        int npold = app->getNpOld(),
+            np = app->getNp();
+        if (scoring_charge) {
+            /***************************************************************
+             DEFAULT:
+             FLURZnrc IPRIMARY = 2 (primaries) IPRIMARY = 4 (secondaries)
+                 Secondary charged particles defined as those resulting
+                 from charged particle interactions, atomic relaxations
+                 following EII, brems and annihilation photons.
 
-           OPTIONAL:
-           FLURZnrc IPRIMARY = 1 (e- from brems as primaries)
-               Set `source particle` to 'photon' in the input file to not flag
-               brems photons so that when scoring charged particle fluence in 
-               photon beams, first generation e- are primaries. This is
-               implicit for photon interactions when scoring charged particle 
-               fluence. But one must explicitly account for that during brems events.
-          ****************************************************************/
-          if ( iarg == EGS_Application::AfterBrems       || 
-               iarg == EGS_Application::AfterMoller      ||
-               iarg == EGS_Application::AfterAnnihFlight || 
-               iarg == EGS_Application::AfterAnnihRest   ){
-               /************************************************************************ 
-                Skip block below for a photon beam. First generation e- are primaries.
-                This will apply to ALL brems events in a photon beam simulation. One
-                could fine tune it to only brems events in certain regions, for instance
-                a bremsstrahlung target, by using the is_source flag for those regions.
-               *************************************************************************/
-               if (!(iarg == EGS_Application::AfterBrems && source_charge == photon)){
-                 for(int ip = npold+1; ip <= np; ip++) {
+             OPTIONAL:
+             FLURZnrc IPRIMARY = 1 (e- from brems as primaries)
+                 Set `source particle` to 'photon' in the input file to not flag
+                 brems photons so that when scoring charged particle fluence in
+                 photon beams, first generation e- are primaries. This is
+                 implicit for photon interactions when scoring charged particle
+                 fluence. But one must explicitly account for that during brems events.
+            ****************************************************************/
+            if (iarg == EGS_Application::AfterBrems       ||
+                    iarg == EGS_Application::AfterMoller      ||
+                    iarg == EGS_Application::AfterAnnihFlight ||
+                    iarg == EGS_Application::AfterAnnihRest) {
+                /************************************************************************
+                 Skip block below for a photon beam. First generation e- are primaries.
+                 This will apply to ALL brems events in a photon beam simulation. One
+                 could fine tune it to only brems events in certain regions, for instance
+                 a bremsstrahlung target, by using the is_source flag for those regions.
+                *************************************************************************/
+                if (!(iarg == EGS_Application::AfterBrems && source_charge == photon)) {
+                    for (int ip = npold+1; ip <= np; ip++) {
+                        app->setLatch(ip,1);
+                    }
+                }
+            }
+            else if (iarg == EGS_Application::AfterBhabha) {
+                if (q == -1) {
+                    app->setLatch(np,1);
+                }
+                else {
+                    app->setLatch(np-1,1);
+                }
+            }
+        }
+        else {
+            /***************************************************************
+             FLURZnrc IPRIMARY = 3
+                Flag scattered photons, secondaries, and relaxation
+                particles as secondaries
+            ****************************************************************/
+            if (iarg == EGS_Application::AfterPair     ||
+                    iarg == EGS_Application::AfterCompton  ||
+                    iarg == EGS_Application::AfterPhoto    ||
+                    iarg == EGS_Application::AfterRayleigh) {
+                for (int ip = npold; ip <= np; ip++) {
                     app->setLatch(ip,1);
-                 }
-               }
-          }
-          else if ( iarg == EGS_Application::AfterBhabha ){
-               if (q == -1) app->setLatch(np,1);
-               else         app->setLatch(np-1,1);
-          }
-       }
-       else{
-          /*************************************************************** 
-           FLURZnrc IPRIMARY = 3
-              Flag scattered photons, secondaries, and relaxation 
-              particles as secondaries
-          ****************************************************************/
-          if ( iarg == EGS_Application::AfterPair     || 
-               iarg == EGS_Application::AfterCompton  || 
-               iarg == EGS_Application::AfterPhoto    || 
-               iarg == EGS_Application::AfterRayleigh ){
-               for(int ip = npold; ip <= np; ip++) {
-                  app->setLatch(ip,1);
-               }
-          }
-       }
-     
-   };
-   
-protected:   
+                }
+            }
+        }
 
-  EGS_I64 current_ncase;                  
+    };
 
-  ParticleType scoring_charge;// charge of scored particles
-  ParticleType source_charge; // charge of source particles
+protected:
 
-  /* Fluence Scoring Arrays */
-  EGS_ScoringArray **flu;   // differential fluence: primaries + secondaries
-  EGS_ScoringArray **flu_p; // differential fluence: primaries only 
-  EGS_ScoringArray  *fluT;  // Total fluence: primaries + secondaries
-  EGS_ScoringArray  *fluT_p;// Total fluence: primaries only
+    EGS_I64 current_ncase;
 
-  /* Regions flags */
-  vector<bool> is_sensitive;     // flag scoring regions
-  vector<bool> is_source;        // Flag regions such as brems target or radiactive source
-                                 // Interacting particles not subjected to classification
-  vector <int> f_start, f_stop;  // Markers for group regions input
-  vector <int> f_region;         // Input list of scoring regions
-  vector <int> s_region;         // Input list of source regions
-  string       f_regionsString;  // Input string of scoring regions or labels
-  string       s_regionsString;  // Input string of source regions or labels
-  int          n_scoring_regions;// number of scoring regions
-  int          n_source_regions; // number of source regions
-  int          nreg;             // regions in geometry
-  int          max_reg;          // maximum scoring region number
-  int          active_region;    // Region showing calculation progress
-  bool score_in_all_regions;
-  bool source_in_all_regions;
+    ParticleType scoring_charge;// charge of scored particles
+    ParticleType source_charge; // charge of source particles
 
-  EGS_Float norm_u;              // User normalization
+    /* Fluence Scoring Arrays */
+    EGS_ScoringArray **flu;   // differential fluence: primaries + secondaries
+    EGS_ScoringArray **flu_p; // differential fluence: primaries only
+    EGS_ScoringArray  *fluT;  // Total fluence: primaries + secondaries
+    EGS_ScoringArray  *fluT_p;// Total fluence: primaries only
 
-  /* Energy grid inputs */
-  EGS_Float flu_a, flu_a_i,
-            flu_b,
-            flu_xmin,
-            flu_xmax;
-  int       flu_s,
-            flu_nbin;
-  /* Classification variables */
-  EGS_Float m_primary, 
-            m_tot;
+    /* Regions flags */
+    vector<bool> is_sensitive;     // flag scoring regions
+    vector<bool> is_source;        // Flag regions such as brems target or radiactive source
+    // Interacting particles not subjected to classification
+    vector <int> f_start, f_stop;  // Markers for group regions input
+    vector <int> f_region;         // Input list of scoring regions
+    vector <int> s_region;         // Input list of source regions
+    string       f_regionsString;  // Input string of scoring regions or labels
+    string       s_regionsString;  // Input string of source regions or labels
+    int          n_scoring_regions;// number of scoring regions
+    int          n_source_regions; // number of source regions
+    int          nreg;             // regions in geometry
+    int          max_reg;          // maximum scoring region number
+    int          active_region;    // Region showing calculation progress
+    bool score_in_all_regions;
+    bool source_in_all_regions;
 
-  string  particle_name;
-  /* Auxiliary input variables*/
-  bool    verbose, 
-          score_spe,
-          score_primaries;
+    EGS_Float norm_u;              // User normalization
+
+    /* Energy grid inputs */
+    EGS_Float flu_a, flu_a_i,
+              flu_b,
+              flu_xmin,
+              flu_xmax;
+    int       flu_s,
+              flu_nbin;
+    /* Classification variables */
+    EGS_Float m_primary,
+              m_tot;
+
+    string  particle_name;
+    /* Auxiliary input variables*/
+    bool    verbose,
+            score_spe,
+            score_primaries;
 };
 
 /*! \brief Ausgab object for scoring fluence at circular or rectangular fields
 
   \ingroup AusgabObjects
 
-  A linear track-length estimator in the zero-thickness limit is used to 
-  compute fluence for either a circular field or a rectangular screen of 
-  arbitrary resolution (pixels). Rectangular fields are by default at Z = 0 
+  A linear track-length estimator in the zero-thickness limit is used to
+  compute fluence for either a circular field or a rectangular screen of
+  arbitrary resolution (pixels). Rectangular fields are by default at Z = 0
   directed along the positive z-axis. An affine transofrmation can be included
-  to place a rectangular field anywhere in space. User can request to score primary 
-  fluence as well as differential fluence. If fluence for more than one particle type 
-  is desired, multiple AOs are required. 
-  
-  For charged particle fluence scoring this method can be inefficient as 
+  to place a rectangular field anywhere in space. User can request to score primary
+  fluence as well as differential fluence. If fluence for more than one particle type
+  is desired, multiple AOs are required.
+
+  For charged particle fluence scoring this method can be inefficient as
   it checks at every single step whether a charged particle is aimed at scoring field.
-  To improve the efficieny for charged particles, one has the option to define contributing regions 
+  To improve the efficieny for charged particles, one has the option to define contributing regions
   from where to score. However, users must be careful to select all regions from where
-  charged particles can cross the scoring field. This option has the added benefit of 
+  charged particles can cross the scoring field. This option has the added benefit of
   allowing to estimate the contribution to the fluence from specific regions in the geometry.
 
   To define an EGS_PlanarFluence AO use the syntax below:
@@ -257,10 +261,10 @@ protected:
     library = egs_fluence_scoring  # Library name
     type    = planar               # Score on circular or square field
     scoring particle = photon, or electron, or positron
-    source particle  = photon, or electron, or positron 
+    source particle  = photon, or electron, or positron
                                    # Optional. Only required to score primary fluence.
                                    # Defaults to source particles if all the same.
-                                   # In the case of multiple particles, 
+                                   # In the case of multiple particles,
                                    # defaults to scoring particle. Useful for
                                    # bremsstrahlung targets and radioactive sources.
     score primaries = yes or no    # Defaults to `no`.
@@ -313,146 +317,153 @@ protected:
 class EGS_FLUENCE_SCORING_EXPORT EGS_PlanarFluence : public EGS_FluenceScoring {
 
 public:
-   /*! Constructors */
-   EGS_PlanarFluence(const string &Name="", EGS_ObjectFactory *f = 0);
-   /*! Destructor.  */
-  ~EGS_PlanarFluence();
-   EGS_Float area(){return Area;};
-   bool needsCall(EGS_Application::AusgabCall iarg) const {
-       if (iarg == EGS_Application::BeforeTransport ||
-           iarg == EGS_Application::AfterTransport ){
-           return true;
-       }
-       else if ( score_primaries && 
-              (iarg == EGS_Application::AfterPair        || 
-               iarg == EGS_Application::AfterCompton     || 
-               iarg == EGS_Application::AfterPhoto       || 
-               iarg == EGS_Application::AfterRayleigh    ||
-               iarg == EGS_Application::AfterBrems       || 
-               iarg == EGS_Application::AfterMoller      ||
-               iarg == EGS_Application::AfterBhabha      || 
-               iarg == EGS_Application::AfterAnnihFlight || 
-               iarg == EGS_Application::AfterAnnihRest   ))
-       {
-             return true;
-       }
-       else {
-           return false;
-       }
-   };
+    /*! Constructors */
+    EGS_PlanarFluence(const string &Name="", EGS_ObjectFactory *f = 0);
+    /*! Destructor.  */
+    ~EGS_PlanarFluence();
+    EGS_Float area() {
+        return Area;
+    };
+    bool needsCall(EGS_Application::AusgabCall iarg) const {
+        if (iarg == EGS_Application::BeforeTransport ||
+                iarg == EGS_Application::AfterTransport) {
+            return true;
+        }
+        else if (score_primaries &&
+                 (iarg == EGS_Application::AfterPair        ||
+                  iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterPhoto       ||
+                  iarg == EGS_Application::AfterRayleigh    ||
+                  iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterMoller      ||
+                  iarg == EGS_Application::AfterBhabha      ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    };
 
-   inline int hitsField(const EGS_Particle& p, EGS_Float* dist);
-   inline void    score(const EGS_Particle& p, const int& ivoxel);
-   void describeMe();//!< Sets fluence scoring object \c description
-   void initScoring(EGS_Input *inp);
-   void setApplication(EGS_Application *App);
-   void ouputPlanarFluence( EGS_ScoringArray *fT, const double &norma );
-   void ouputResults();
-   void reportResults();
-   int processEvent(EGS_Application::AusgabCall iarg) {
+    inline int hitsField(const EGS_Particle &p, EGS_Float *dist);
+    inline void    score(const EGS_Particle &p, const int &ivoxel);
+    void describeMe();//!< Sets fluence scoring object \c description
+    void initScoring(EGS_Input *inp);
+    void setApplication(EGS_Application *App);
+    void ouputPlanarFluence(EGS_ScoringArray *fT, const double &norma);
+    void ouputResults();
+    void reportResults();
+    int processEvent(EGS_Application::AusgabCall iarg) {
 
-       int q = app->top_p.q,
-          ir = app->top_p.ir;
+        int q = app->top_p.q,
+            ir = app->top_p.ir;
 
-       if ( q == scoring_charge && ir >= 0 && is_sensitive[ir] )
-       {
+        if (q == scoring_charge && ir >= 0 && is_sensitive[ir]) {
 
-          /* Quantify contribution to scoring field */
-          if( iarg == EGS_Application::BeforeTransport ){
-              ixy = hitsField(app->top_p,&distance);
-              if (ixy >= 0){
-                 x0 = app->top_p.x; hits_field = true; 
-              }
-              else{hits_field = false; }
-          }
-   
-          if( iarg == EGS_Application::AfterTransport && hits_field ){
-              EGS_Vector xstep = app->top_p.x - x0;
-              if (xstep.length() >= distance){// crossed scoring field
-                 //if (!app->top_p.latch ) m_primary += app->top_p.wt;
-                 m_tot  += app->top_p.wt;
-                 score( app->top_p, ixy );
-              }
-              hits_field = false;
-          }
-       }
+            /* Quantify contribution to scoring field */
+            if (iarg == EGS_Application::BeforeTransport) {
+                ixy = hitsField(app->top_p,&distance);
+                if (ixy >= 0) {
+                    x0 = app->top_p.x;
+                    hits_field = true;
+                }
+                else {
+                    hits_field = false;
+                }
+            }
 
-       /******************************************************************** 
-        * Flag secondaries after interactions. Definition of secondaries
-        * matches FLURZnrc. One could fine tune it by using the is_source 
-        * flag to skip this block in certains regions such as brems targets,
-        * radioactive sources, etc.
-        * 
-        * BEWARE: Latch set to 1 (bit 0) to flag secondaries.
-        *         Other applications might use latch for other purposes!
-        *********************************************************************/
-       if ( score_primaries && ir >= 0 && !is_source[ir]){
-          flagSecondaries( iarg, q );
-       }
+            if (iarg == EGS_Application::AfterTransport && hits_field) {
+                EGS_Vector xstep = app->top_p.x - x0;
+                if (xstep.length() >= distance) { // crossed scoring field
+                    //if (!app->top_p.latch ) m_primary += app->top_p.wt;
+                    m_tot  += app->top_p.wt;
+                    score(app->top_p, ixy);
+                }
+                hits_field = false;
+            }
+        }
 
-       return 0;
+        /********************************************************************
+         * Flag secondaries after interactions. Definition of secondaries
+         * matches FLURZnrc. One could fine tune it by using the is_source
+         * flag to skip this block in certains regions such as brems targets,
+         * radioactive sources, etc.
+         *
+         * BEWARE: Latch set to 1 (bit 0) to flag secondaries.
+         *         Other applications might use latch for other purposes!
+         *********************************************************************/
+        if (score_primaries && ir >= 0 && !is_source[ir]) {
+            flagSecondaries(iarg, q);
+        }
 
-   };
-   
-   void setCurrentCase(EGS_I64 ncase) {
-        if( ncase != current_ncase ) {
+        return 0;
+
+    };
+
+    void setCurrentCase(EGS_I64 ncase) {
+        if (ncase != current_ncase) {
             current_ncase = ncase;
 
             fluT->setHistory(ncase);
 
-            if (score_spe){
-              for (int j = 0; j < Nx*Ny; j++)
-                   flu[j]->setHistory(ncase);
+            if (score_spe) {
+                for (int j = 0; j < Nx*Ny; j++) {
+                    flu[j]->setHistory(ncase);
+                }
             }
 
-            if ( score_primaries ){
-              fluT_p->setHistory(ncase);
-              if (score_spe){
-                 for (int j = 0; j < Nx*Ny; j++)
-                     flu_p[j]->setHistory(ncase);
-              }
+            if (score_primaries) {
+                fluT_p->setHistory(ncase);
+                if (score_spe) {
+                    for (int j = 0; j < Nx*Ny; j++) {
+                        flu_p[j]->setHistory(ncase);
+                    }
+                }
             }
         }
-   };
+    };
 
-   void resetCounter(){
-      current_ncase = 0; 
-      fluT->reset();
-      if (flu){
-        for (int j = 0; j < Nx*Ny; j++)
-             flu[j]->reset();
-      }
-      if ( score_primaries ){
-         fluT_p->reset();
-         if ( score_spe ){
-            for (int j = 0; j < Nx*Ny; j++)
-                flu_p[j]->reset();
-         }
-      }
-   }
-   bool storeState(ostream &data) const;
-   bool setState(istream &data);
-   bool addState(istream &data);
+    void resetCounter() {
+        current_ncase = 0;
+        fluT->reset();
+        if (flu) {
+            for (int j = 0; j < Nx*Ny; j++) {
+                flu[j]->reset();
+            }
+        }
+        if (score_primaries) {
+            fluT_p->reset();
+            if (score_spe) {
+                for (int j = 0; j < Nx*Ny; j++) {
+                    flu_p[j]->reset();
+                }
+            }
+        }
+    }
+    bool storeState(ostream &data) const;
+    bool setState(istream &data);
+    bool addState(istream &data);
 
-private:   
+private:
 
-  FieldType field_type;
+    FieldType field_type;
 
-  EGS_Float Area;
+    EGS_Float Area;
 
-  /* Circular scoring field parameters */  
-  EGS_Vector      m_normal,
-                  m_midpoint,
-                  ux, uy;
-  EGS_Vector      x0;
-  EGS_Float       m_R, m_R2; // scoring field
-  /* Rectangular field parameters */  
-  EGS_Float     ax, ay, vx, vy;
-  int           Nx, Ny, n_sensitive_regs, ixy;
-  
-  EGS_Float m_d;       // distance from origin to center of scoring field
-  EGS_Float distance; // distance to scoring field along particle's direction
-  bool      hits_field;
+    /* Circular scoring field parameters */
+    EGS_Vector      m_normal,
+                    m_midpoint,
+                    ux, uy;
+    EGS_Vector      x0;
+    EGS_Float       m_R, m_R2; // scoring field
+    /* Rectangular field parameters */
+    EGS_Float     ax, ay, vx, vy;
+    int           Nx, Ny, n_sensitive_regs, ixy;
+
+    EGS_Float m_d;       // distance from origin to center of scoring field
+    EGS_Float distance; // distance to scoring field along particle's direction
+    bool      hits_field;
 
 };
 
@@ -460,22 +471,22 @@ private:
 
   \ingroup AusgabObjects
 
-  A linear track-length estimator is used to compute fluence in specific 
-  geometrical regions. User can request to score primary fluence as well 
-  as differential fluence. If fluence for more than one particle type is 
+  A linear track-length estimator is used to compute fluence in specific
+  geometrical regions. User can request to score primary fluence as well
+  as differential fluence. If fluence for more than one particle type is
   desired, multiple AOs are required.
 
-  Differential fluence for charged particles is calculated accounting for 
+  Differential fluence for charged particles is calculated accounting for
   continuos energy losses along the path. As these particles slow down in medium,
   their contribution to fluence will spread over several energy bins. Two methods
-  to account for this are provided. One method follows the FLURZnrc implementation, 
-  whereby stopping power is assumed constant along the step and estimated as the 
-  ratio of the deposited energy EDEP to the total step length TVSTEP. The second 
-  method follows the approach used in the EGSnrc application \ref cavity "cavity", 
-  which accounts for stopping power changes within a scoring energy bin. It uses a 
-  series expansion of the integral of the inverse of the stopping power with respect 
-  to energy. Implementation details are provided in an upcoming publication.  
-  
+  to account for this are provided. One method follows the FLURZnrc implementation,
+  whereby stopping power is assumed constant along the step and estimated as the
+  ratio of the deposited energy EDEP to the total step length TVSTEP. The second
+  method follows the approach used in the EGSnrc application \ref cavity "cavity",
+  which accounts for stopping power changes within a scoring energy bin. It uses a
+  series expansion of the integral of the inverse of the stopping power with respect
+  to energy. Implementation details are provided in an upcoming publication.
+
   To define an EGS_VolumetricFluence AO use the syntax below:
   \verbatim
 :start ausgab object:
@@ -483,10 +494,10 @@ private:
     library = egs_fluence_scoring  # Library name
     type    = volumetric           # Score in a volume
     scoring particle = photon, or electron, or positron
-    source particle  = photon, or electron, or positron 
+    source particle  = photon, or electron, or positron
                                    # Optional. Only required to score primary fluence.
                                    # Defaults to source particles if all the same.
-                                   # In the case of multiple particles, 
+                                   # In the case of multiple particles,
                                    # defaults to scoring particle. Useful for
                                    # bremsstrahlung targets and radioactive sources.
     score primaries = yes or no    # Defaults to `no`.
@@ -508,31 +519,31 @@ private:
         #stop region  = irf_1, irf_2, ..., irf_n
         ###
         volumes = V1, V2, ..., VN # Enter as many as scoring regions. If same number
-                                  # of entries as group of regions, assumes groups of 
-                                  # equal volume regions. If only one entry, assumes 
+                                  # of entries as group of regions, assumes groups of
+                                  # equal volume regions. If only one entry, assumes
                                   # equal volumes in all regions. Defaults to 1.
         method  = flurz or stpwr or stpwrO5 # For charged particle scoring.
-                  # 
+                  #
                   # flurz   => FLURZnrc algorithm
-                  # 
+                  #
                   # Path length at each energy interval from energy
-                  # deposited EDEP and total particle step TVSTEP. 
+                  # deposited EDEP and total particle step TVSTEP.
                   # Assumes stopping power constancy along the particle's
                   # step. It might introduce artifacts if ESTEPE or the
                   # scoring bin width are too large.
-                  # 
-                  # stpwr   => Accounts for stopping power variation 
-                  #          along the particle's step. More accurate 
+                  #
+                  # stpwr   => Accounts for stopping power variation
+                  #          along the particle's step. More accurate
                   #          than method used in FLURZnrc albeit about
                   #          about 10% slower in electron beam cases.
                   #
                   # Uses an O(3) series expansion of the integral of the
-                  # inverse of the stopping power with respect to energy. 
-                  # Stopping power is represented as a linear interpolation 
+                  # inverse of the stopping power with respect to energy.
+                  # Stopping power is represented as a linear interpolation
                   # over a log energy grid.
-                  # 
+                  #
                   # stpwrO5 => Uses an O(5) series expansion. Slightly slower.
-                  # 
+                  #
                   # Defaults to `stpwr`.
     :stop volumetric scoring:
 :stop ausgab object:
@@ -541,371 +552,404 @@ private:
 class EGS_FLUENCE_SCORING_EXPORT EGS_VolumetricFluence : public EGS_FluenceScoring {
 
 public:
-   /*! Constructors */
-   EGS_VolumetricFluence(const string &Name="", EGS_ObjectFactory *f = 0);
+    /*! Constructors */
+    EGS_VolumetricFluence(const string &Name="", EGS_ObjectFactory *f = 0);
 
-   /*! Destructor.  */
-  ~EGS_VolumetricFluence();
+    /*! Destructor.  */
+    ~EGS_VolumetricFluence();
 
-   /*************************************************************** 
-     NOTE: Primary particles defined as particles that suffer any 
-           type of interaction, except for the slowing down of 
-           charged particles in a medium.  
-   ****************************************************************/
-   bool needsCall(EGS_Application::AusgabCall iarg) const {
-       if (iarg == EGS_Application::BeforeTransport ||
-           iarg == EGS_Application::UserDiscard ){
-           return true;
-       }
-       else if ( score_primaries && 
-              (iarg == EGS_Application::AfterPair        || 
-               iarg == EGS_Application::AfterCompton     || 
-               iarg == EGS_Application::AfterPhoto       || 
-               iarg == EGS_Application::AfterRayleigh    ||
-               iarg == EGS_Application::AfterBrems       || 
-               iarg == EGS_Application::AfterMoller      ||
-               iarg == EGS_Application::AfterBhabha      || 
-               iarg == EGS_Application::AfterAnnihFlight || 
-               iarg == EGS_Application::AfterAnnihRest   ))
-       {
-             return true;
-       }
-       else {
-           return false;
-       }
-   };
+    /***************************************************************
+      NOTE: Primary particles defined as particles that suffer any
+            type of interaction, except for the slowing down of
+            charged particles in a medium.
+    ****************************************************************/
+    bool needsCall(EGS_Application::AusgabCall iarg) const {
+        if (iarg == EGS_Application::BeforeTransport ||
+                iarg == EGS_Application::UserDiscard) {
+            return true;
+        }
+        else if (score_primaries &&
+                 (iarg == EGS_Application::AfterPair        ||
+                  iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterPhoto       ||
+                  iarg == EGS_Application::AfterRayleigh    ||
+                  iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterMoller      ||
+                  iarg == EGS_Application::AfterBhabha      ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest)) {
+            return true;
+        }
+        else {
+            return false;
+        }
+    };
 
-   void describeMe();//!< Sets fluence scoring object \c description
+    void describeMe();//!< Sets fluence scoring object \c description
 
-   void initScoring(EGS_Input *inp);
+    void initScoring(EGS_Input *inp);
 
-   void setApplication(EGS_Application *App);
+    void setApplication(EGS_Application *App);
 
-   void ouputVolumetricFluence( EGS_ScoringArray *fT, const double &norma );
-   
-   void ouputResults();
+    void ouputVolumetricFluence(EGS_ScoringArray *fT, const double &norma);
 
-   void reportResults();
+    void ouputResults();
 
-   int processEvent(EGS_Application::AusgabCall iarg) {
+    void reportResults();
 
-    int    q = app->top_p.q,
-          ir = app->top_p.ir, 
-       latch = app->top_p.latch;
+    int processEvent(EGS_Application::AusgabCall iarg) {
 
-    if ( q == scoring_charge && ir >= 0 && is_sensitive[ir] ) {
+        int    q = app->top_p.q,
+               ir = app->top_p.ir,
+               latch = app->top_p.latch;
 
-       if ( !q ){// It's a photon
-          /* Score photon fluence */
-          if (iarg == EGS_Application::BeforeTransport ) {
-             /* Linear track-Length scoring */
-             EGS_Float wtstep  = app->top_p.wt*app->getTVSTEP();
-             /* Score total fluence */
-             fluT->score(ir,wtstep);
-             if (score_primaries && !latch){
-                fluT_p->score(ir,wtstep);
-             }
-             /* Score differential fluence */
-             if ( score_spe ) {
-                EGS_Float e = app->top_p.E;
-                if (flu_s) {
-                     e = log(e);
-                }
-                EGS_Float ae; int je;
-                /* Score differential fluence */
-                if ( e > flu_xmin && e <= flu_xmax ) {
-                    ae = flu_a*e + flu_b;
-                    je = min((int)ae,flu_nbin-1);
-                    EGS_ScoringArray *aux = flu[ir];
-                    aux->score(je,wtstep);
-                    if (score_primaries && !latch){
-                       flu_p[ir]->score(je,wtstep);
+        if (q == scoring_charge && ir >= 0 && is_sensitive[ir]) {
+
+            if (!q) { // It's a photon
+                /* Score photon fluence */
+                if (iarg == EGS_Application::BeforeTransport) {
+                    /* Linear track-Length scoring */
+                    EGS_Float wtstep  = app->top_p.wt*app->getTVSTEP();
+                    /* Score total fluence */
+                    fluT->score(ir,wtstep);
+                    if (score_primaries && !latch) {
+                        fluT_p->score(ir,wtstep);
+                    }
+                    /* Score differential fluence */
+                    if (score_spe) {
+                        EGS_Float e = app->top_p.E;
+                        if (flu_s) {
+                            e = log(e);
+                        }
+                        EGS_Float ae;
+                        int je;
+                        /* Score differential fluence */
+                        if (e > flu_xmin && e <= flu_xmax) {
+                            ae = flu_a*e + flu_b;
+                            je = min((int)ae,flu_nbin-1);
+                            EGS_ScoringArray *aux = flu[ir];
+                            aux->score(je,wtstep);
+                            if (score_primaries && !latch) {
+                                flu_p[ir]->score(je,wtstep);
+                            }
+                        }
                     }
                 }
-             }
-          }
-       }
-       else {// It's a charged particle
+            }
+            else {// It's a charged particle
 
-          EGS_Float edep = app->getEdep();
-   
-          /* Score charged particle fluence */
-          if ( edep &&
-             ( iarg == EGS_Application::BeforeTransport || 
-               iarg == EGS_Application::UserDiscard )   ){
+                EGS_Float edep = app->getEdep();
 
-             /**************************/
-             /***** Initialization *****/
-             /**************************/
-             EGS_Float weight = app->top_p.wt;
-             bool score_p = score_primaries && !latch;
-             /* Integral fluence scoring arrays */
-             EGS_ScoringArray *auxT = fluT, *auxT_p;
-             if ( score_p ){
-                 auxT_p = fluT_p;
-             }
+                /* Score charged particle fluence */
+                if (edep &&
+                        (iarg == EGS_Application::BeforeTransport ||
+                         iarg == EGS_Application::UserDiscard)) {
 
-             /***************************************/
-             /* Score integral fluence using TVSTEP */
-             /***************************************/
-             EGS_Float a_step = weight*app->getTVSTEP();
-             auxT->score(ir,a_step);
-             if (score_p) 
-                auxT_p->score(ir,a_step);
-             /***************************************/
+                    /**************************/
+                    /***** Initialization *****/
+                    /**************************/
+                    EGS_Float weight = app->top_p.wt;
+                    bool score_p = score_primaries && !latch;
+                    /* Integral fluence scoring arrays */
+                    EGS_ScoringArray *auxT = fluT, *auxT_p;
+                    if (score_p) {
+                        auxT_p = fluT_p;
+                    }
 
-             if ( score_spe ){
+                    /***************************************/
+                    /* Score integral fluence using TVSTEP */
+                    /***************************************/
+                    EGS_Float a_step = weight*app->getTVSTEP();
+                    auxT->score(ir,a_step);
+                    if (score_p) {
+                        auxT_p->score(ir,a_step);
+                    }
+                    /***************************************/
 
-                 EGS_ScoringArray *aux, *aux_p;
-                 aux = flu[ir];
-                 if ( score_p ){
-                    aux_p = flu_p[ir];
-                 }
+                    if (score_spe) {
 
-                 EGS_Float Eb = app->top_p.E - app->getRM(),
-                           Ee = Eb - edep;
-    
-                 EGS_Float xb, xe;
-                 if( flu_s ) {
-                     xb = log(Eb);
-                     if( Ee > 0 )
-                         xe = log(Ee);
-                     else xe = -15;
-                 }
-                 else{
-                   xb = Eb; xe = Ee;
-                 }
-                 /**********************************************************/
-                 /* If not out of bounds, proceed with rest of calculation */
-                 /**********************************************************/
-                 if( xb > flu_xmin && xe < flu_xmax ) {
-                     EGS_Float ab, ae; int jb, je;
-                     /* Fraction of the initial bin covered */
-                     if( xb < flu_xmax ) {
-                         ab = flu_a*xb + flu_b; jb = (int) ab;
-                         /* Variable bin-width for log scale*/
-                         if (flu_s){
-                            ab = (Eb*a_const[jb]-1)*r_const;
-                         }
-                         else{ ab -= jb;}
-                     }
-                     else { // particle's energy above Emax
-                         xb = flu_xmax; ab = 1; jb = flu_nbin - 1; 
-                     }
-                     /* Fraction of the final bin covered */
-                     if( xe > flu_xmin ) {
-                         ae = flu_a*xe + flu_b; je = (int) ae;
-                         /* Variable bin-width for log scale*/
-                         if (flu_s){
-                            ae = (Ee*a_const[je]-1)*r_const;
-                         }
-                         else{ ae -= je; }
-                     }
-                     else { xe = flu_xmin; ae = 0; je = 0; }// extends below Emin
-       
-#ifdef DEBUG 
-                     if (jb == je) 
-                       one_bin++;
-                     else{          
-                       multi_bin++;
-                     }
-    
-                     binDist->score(jb-je,weight);
-    
-                     EGS_Float totStep = 0, the_step = app->getTVSTEP();
-#endif                            
-     
-                     /************************************************
-                      * Approach A:
-                      * -----------
-                      * Uses either an O(3) or O(5) series expansion of the
-                      * integral of the inverse of the stopping power with
-                      * respect to energy. The stopping power is represented
-                      * as a linear interpolation over a log energy grid. It
-                      * accounts for stopping power variation along the particle's
-                      * step within the resolution of the scoring array. This
-                      * is more accurate than the method used in FLURZnrc albeit
-                      * about 10% slower in electron beam cases.
-                      *
-                      * BEWARE: For this approach to work, no range rejection
-                      * ------  nor Russian Roulette should be used.
-                      *
-                      ************************************************/
-                     if ( flu_stpwr ){
-                        int imed = app->getMedium(ir);
-                        // Initial and final energies in same bin
-                        EGS_Float step;
-                        if( jb == je ){
-                            step = weight*(ab-ae)*getStepPerEnergyLoss(imed,xb,xe);
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                            /* Differential fluence */
-                            if ( score_spe ){
-                               aux->score(jb,step);
-                               if (score_p)
-                                  aux_p->score(jb,step);
+                        EGS_ScoringArray *aux, *aux_p;
+                        aux = flu[ir];
+                        if (score_p) {
+                            aux_p = flu_p[ir];
+                        }
+
+                        EGS_Float Eb = app->top_p.E - app->getRM(),
+                                  Ee = Eb - edep;
+
+                        EGS_Float xb, xe;
+                        if (flu_s) {
+                            xb = log(Eb);
+                            if (Ee > 0) {
+                                xe = log(Ee);
+                            }
+                            else {
+                                xe = -15;
                             }
                         }
                         else {
-    
-                            // First bin
-    
-                            Ee = flu_xmin + jb*flu_a_i; Eb=xb;
-                            step = weight*ab*getStepPerEnergyLoss(imed,Eb,Ee);
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                            /* Differential fluence */
-                            if ( score_spe ){
-                               aux->score(jb,step);
-                               if (score_p) 
-                                  aux_p->score(jb,step);
-                            }
-    
-                            // Last bin
-    
-                            Ee = xe; Eb = flu_xmin+(je+1)*flu_a_i;
-                            step = weight*(1-ae)*getStepPerEnergyLoss(imed,Eb,Ee);
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                            /* Differential fluence */
-                            if ( score_spe ){
-                               aux->score(je,step);
-                               if (score_p)
-                                  aux_p->score(je,step);
-                            }
-    
-                            // intermediate bins
-    
-                            for(int j=je+1; j<jb; j++){
-                               if (flu_stpwr == stpwrO5){
-                                 Ee = Eb; Eb = flu_xmin + (j+1)*flu_a_i;
-                                /* O(eps^5) would require more pre-computed values
-                                 * than just 1/Lmid. One requires lnEmid[i] to get
-                                 * the b parameter and eps[i]=1-E[i]/E[i+1]. Not
-                                 * impossible, but seems unnecessary considering
-                                 * the excellent agreement with O(eps^3), which
-                                 * should be always used.
-                                 */
-                                 step = weight*getStepPerEnergyLoss(imed,Eb,Ee);
-                               }
-                               else{// use pre-computed values of 1/Lmid
-                                step = weight*Lmid_i[j + imed*flu_nbin];
-                               }
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                               /* Differential fluence */
-                               if ( score_spe ){
-                                  aux->score(j,step);
-                                  if (score_p) 
-                                     aux_p->score(j,step);
-                               }
-                            }
+                            xb = Eb;
+                            xe = Ee;
                         }
-                     }
-                     /***************************************************
-                      * -----------------------
-                      * Approach B (FLURZnrc):
-                      * ----------------------
-                      * Path length at each energy interval from energy
-                      * deposited edep and total particle step tvstep. It
-                      * assumes stopping power constancy along the particle's
-                      * step. It might introduce artifacts if ESTEPE or the
-                      * scoring bin width are too large.
-                      *
-                      * BEWARE: For this approach to work, no range rejection
-                      * ------  nor Russian Roulette should be used.
-                      **************************************************/
-                     else{
-                        EGS_Float step, wtstep = weight*app->getTVSTEP()/edep;
-                        // Initial and final energies in same bin
-                        if( jb == je ){
-                          step = wtstep*(ab-ae);
-#ifdef DEBUG
-                                totStep += step;
-#endif                
-                          /* Differential fluence */
-                          if ( score_spe ){
-                             aux->score(jb,step);
-                             if (score_p) 
-                                aux_p->score(jb,step);
-                          }
-                        }
-                        else {
-    
-                            // First bin
-    
-                            step = wtstep*ab;
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                            /* Differential fluence */
-                            if ( score_spe ){
-                               aux->score(jb,step);
-                               if (score_p)
-                                  aux_p->score(jb,step);
-                            }
-    
-                            // Last bin
-    
-                            step = wtstep*(1-ae);
-#ifdef DEBUG
-                                totStep += step;
-#endif                            
-                            /* Differential fluence */
-                            if ( score_spe ){
-                               aux->score(je,step);
-                               if (score_p)
-                                  aux_p->score(je,step);
-                            }
-                            // intermediate bins
-                            for(int j=je+1; j<jb; j++){
-#ifdef DEBUG
-                                totStep += wtstep;
-#endif                            
-                                /* Differential fluence */
-                                if ( score_spe ){
-                                   aux->score(j,wtstep);
-                                   if (score_p)
-                                      aux_p->score(j,wtstep);
+                        /**********************************************************/
+                        /* If not out of bounds, proceed with rest of calculation */
+                        /**********************************************************/
+                        if (xb > flu_xmin && xe < flu_xmax) {
+                            EGS_Float ab, ae;
+                            int jb, je;
+                            /* Fraction of the initial bin covered */
+                            if (xb < flu_xmax) {
+                                ab = flu_a*xb + flu_b;
+                                jb = (int) ab;
+                                /* Variable bin-width for log scale*/
+                                if (flu_s) {
+                                    ab = (Eb*a_const[jb]-1)*r_const;
+                                }
+                                else {
+                                    ab -= jb;
                                 }
                             }
-                        }
-                     }
-    
+                            else { // particle's energy above Emax
+                                xb = flu_xmax;
+                                ab = 1;
+                                jb = flu_nbin - 1;
+                            }
+                            /* Fraction of the final bin covered */
+                            if (xe > flu_xmin) {
+                                ae = flu_a*xe + flu_b;
+                                je = (int) ae;
+                                /* Variable bin-width for log scale*/
+                                if (flu_s) {
+                                    ae = (Ee*a_const[je]-1)*r_const;
+                                }
+                                else {
+                                    ae -= je;
+                                }
+                            }
+                            else {
+                                xe = flu_xmin;    // extends below Emin
+                                ae = 0;
+                                je = 0;
+                            }
+
 #ifdef DEBUG
-                     EGS_Float edep_step = totStep*flu_a_i, diff = edep_step/the_step;
-                     EGS_Float astep = step_a*the_step + step_b; int jstep = (int) astep;
-                     if (jstep < 0 || jstep > n_step_bins)
-                        egsFatal("\n**** EGS_VolumetricFluence::processEvent-> jstep = %d\n is out of bound!\n");
-                     stepDist->score(jstep,app->top_p.wt);
-                     relStepDiff->score(jstep,diff); eCases++;
-#endif                 
-                 }
-             }
-          }
-       }
-    }
+                            if (jb == je) {
+                                one_bin++;
+                            }
+                            else {
+                                multi_bin++;
+                            }
 
-    /******************************************************************** 
-     * Flag secondaries after interactions. Definition of secondaries
-     * matches FLURZnrc. One could fine tune it by using the is_source 
-     * flag to skip this block in certains regions such as brems targets,
-     * radioactive sources, etc.
-     * 
-     * BEWARE: Latch set to 1 (bit 0) to flag secondaries.
-     *         Other applications might use latch for other purposes!
-     *********************************************************************/
-    if ( score_primaries && ir >= 0 && !is_source[ir]){
-       flagSecondaries( iarg, q );
-    }
+                            binDist->score(jb-je,weight);
 
-    return 0;
+                            EGS_Float totStep = 0, the_step = app->getTVSTEP();
+#endif
 
-   };
+                            /************************************************
+                             * Approach A:
+                             * -----------
+                             * Uses either an O(3) or O(5) series expansion of the
+                             * integral of the inverse of the stopping power with
+                             * respect to energy. The stopping power is represented
+                             * as a linear interpolation over a log energy grid. It
+                             * accounts for stopping power variation along the particle's
+                             * step within the resolution of the scoring array. This
+                             * is more accurate than the method used in FLURZnrc albeit
+                             * about 10% slower in electron beam cases.
+                             *
+                             * BEWARE: For this approach to work, no range rejection
+                             * ------  nor Russian Roulette should be used.
+                             *
+                             ************************************************/
+                            if (flu_stpwr) {
+                                int imed = app->getMedium(ir);
+                                // Initial and final energies in same bin
+                                EGS_Float step;
+                                if (jb == je) {
+                                    step = weight*(ab-ae)*getStepPerEnergyLoss(imed,xb,xe);
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(jb,step);
+                                        if (score_p) {
+                                            aux_p->score(jb,step);
+                                        }
+                                    }
+                                }
+                                else {
+
+                                    // First bin
+
+                                    Ee = flu_xmin + jb*flu_a_i;
+                                    Eb=xb;
+                                    step = weight*ab*getStepPerEnergyLoss(imed,Eb,Ee);
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(jb,step);
+                                        if (score_p) {
+                                            aux_p->score(jb,step);
+                                        }
+                                    }
+
+                                    // Last bin
+
+                                    Ee = xe;
+                                    Eb = flu_xmin+(je+1)*flu_a_i;
+                                    step = weight*(1-ae)*getStepPerEnergyLoss(imed,Eb,Ee);
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(je,step);
+                                        if (score_p) {
+                                            aux_p->score(je,step);
+                                        }
+                                    }
+
+                                    // intermediate bins
+
+                                    for (int j=je+1; j<jb; j++) {
+                                        if (flu_stpwr == stpwrO5) {
+                                            Ee = Eb;
+                                            Eb = flu_xmin + (j+1)*flu_a_i;
+                                            /* O(eps^5) would require more pre-computed values
+                                             * than just 1/Lmid. One requires lnEmid[i] to get
+                                             * the b parameter and eps[i]=1-E[i]/E[i+1]. Not
+                                             * impossible, but seems unnecessary considering
+                                             * the excellent agreement with O(eps^3), which
+                                             * should be always used.
+                                             */
+                                            step = weight*getStepPerEnergyLoss(imed,Eb,Ee);
+                                        }
+                                        else { // use pre-computed values of 1/Lmid
+                                            step = weight*Lmid_i[j + imed*flu_nbin];
+                                        }
+#ifdef DEBUG
+                                        totStep += step;
+#endif
+                                        /* Differential fluence */
+                                        if (score_spe) {
+                                            aux->score(j,step);
+                                            if (score_p) {
+                                                aux_p->score(j,step);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                            /***************************************************
+                             * -----------------------
+                             * Approach B (FLURZnrc):
+                             * ----------------------
+                             * Path length at each energy interval from energy
+                             * deposited edep and total particle step tvstep. It
+                             * assumes stopping power constancy along the particle's
+                             * step. It might introduce artifacts if ESTEPE or the
+                             * scoring bin width are too large.
+                             *
+                             * BEWARE: For this approach to work, no range rejection
+                             * ------  nor Russian Roulette should be used.
+                             **************************************************/
+                            else {
+                                EGS_Float step, wtstep = weight*app->getTVSTEP()/edep;
+                                // Initial and final energies in same bin
+                                if (jb == je) {
+                                    step = wtstep*(ab-ae);
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(jb,step);
+                                        if (score_p) {
+                                            aux_p->score(jb,step);
+                                        }
+                                    }
+                                }
+                                else {
+
+                                    // First bin
+
+                                    step = wtstep*ab;
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(jb,step);
+                                        if (score_p) {
+                                            aux_p->score(jb,step);
+                                        }
+                                    }
+
+                                    // Last bin
+
+                                    step = wtstep*(1-ae);
+#ifdef DEBUG
+                                    totStep += step;
+#endif
+                                    /* Differential fluence */
+                                    if (score_spe) {
+                                        aux->score(je,step);
+                                        if (score_p) {
+                                            aux_p->score(je,step);
+                                        }
+                                    }
+                                    // intermediate bins
+                                    for (int j=je+1; j<jb; j++) {
+#ifdef DEBUG
+                                        totStep += wtstep;
+#endif
+                                        /* Differential fluence */
+                                        if (score_spe) {
+                                            aux->score(j,wtstep);
+                                            if (score_p) {
+                                                aux_p->score(j,wtstep);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+#ifdef DEBUG
+                            EGS_Float edep_step = totStep*flu_a_i, diff = edep_step/the_step;
+                            EGS_Float astep = step_a*the_step + step_b;
+                            int jstep = (int) astep;
+                            if (jstep < 0 || jstep > n_step_bins) {
+                                egsFatal("\n**** EGS_VolumetricFluence::processEvent-> jstep = %d\n is out of bound!\n");
+                            }
+                            stepDist->score(jstep,app->top_p.wt);
+                            relStepDiff->score(jstep,diff);
+                            eCases++;
+#endif
+                        }
+                    }
+                }
+            }
+        }
+
+        /********************************************************************
+         * Flag secondaries after interactions. Definition of secondaries
+         * matches FLURZnrc. One could fine tune it by using the is_source
+         * flag to skip this block in certains regions such as brems targets,
+         * radioactive sources, etc.
+         *
+         * BEWARE: Latch set to 1 (bit 0) to flag secondaries.
+         *         Other applications might use latch for other purposes!
+         *********************************************************************/
+        if (score_primaries && ir >= 0 && !is_source[ir]) {
+            flagSecondaries(iarg, q);
+        }
+
+        return 0;
+
+    };
 
     /*! Computes path per energy loss traveled by a charged particle when
      *  slowing down from Eb to Ee.
@@ -921,44 +965,50 @@ public:
      * function that is the result of the integration of the inverse of the stopping
      * power with respect to energy.
      */
-    EGS_Float getStepPerEnergyLoss( const int & imed,
-                                      const EGS_Float & Eb,
-                                      const EGS_Float & Ee){
+    EGS_Float getStepPerEnergyLoss(const int &imed,
+                                   const EGS_Float &Eb,
+                                   const EGS_Float &Ee) {
         EGS_Float stpFrac, eps, lnEmid;
-        if (flu_s){//Using log(E)
-          eps     = 1 - exp(Ee-Eb);
-          /* 4th order series expansion of log([Eb+Ee]/2) */
-          lnEmid  = 0.5*(Eb+Ee+0.25*eps*eps*(1+eps*(1+0.875*eps)));
+        if (flu_s) { //Using log(E)
+            eps     = 1 - exp(Ee-Eb);
+            /* 4th order series expansion of log([Eb+Ee]/2) */
+            lnEmid  = 0.5*(Eb+Ee+0.25*eps*eps*(1+eps*(1+0.875*eps)));
         }
-        else{//Using E
-          if (flu_stpwr == stpwrO5)
-             eps  = 1 - Ee/Eb;
-          lnEmid  = log(0.5*(Eb+Ee));
+        else { //Using E
+            if (flu_stpwr == stpwrO5) {
+                eps  = 1 - Ee/Eb;
+            }
+            lnEmid  = log(0.5*(Eb+Ee));
         }
 
         EGS_Float dedxmid_i = dedx_i[imed].interpolate(lnEmid);
         // Used in cavity:
         // EGS_Float dedxmid_i = 1./i_dedx[imed].interpolate(lnEmid);
 #ifdef DEBUG
-if (!isfinite(dedxmid_i)){
-  if (isnan(dedxmid_i))
-    egsInformation("\n Is NaN? dedxmid_i = %g",dedxmid_i);
-  else    
-    egsInformation("\n Is infinite? dedxmid_i = %g",dedxmid_i);
-}
-else{
-  if (dedxmid_i<0){
-    egsInformation("\n Is negative? dedxmid_i = %g Emid = %g lnEmid = %g index = %d",
-    dedxmid_i,exp(lnEmid),lnEmid, dedx_i[imed].getIndex(lnEmid) );
-  }
-  if (dedxmid_i > 1.E10)
-    egsInformation("\n Is very large? dedxmid_i = %g Emid = %g lnEmid = %g",dedxmid_i,exp(lnEmid),lnEmid);
-      
-}
-#endif        
+        if (!isfinite(dedxmid_i)) {
+            if (isnan(dedxmid_i)) {
+                egsInformation("\n Is NaN? dedxmid_i = %g",dedxmid_i);
+            }
+            else {
+                egsInformation("\n Is infinite? dedxmid_i = %g",dedxmid_i);
+            }
+        }
+        else {
+            if (dedxmid_i<0) {
+                egsInformation("\n Is negative? dedxmid_i = %g Emid = %g lnEmid = %g index = %d",
+                               dedxmid_i,exp(lnEmid),lnEmid, dedx_i[imed].getIndex(lnEmid));
+            }
+            if (dedxmid_i > 1.E10) {
+                egsInformation("\n Is very large? dedxmid_i = %g Emid = %g lnEmid = %g",dedxmid_i,exp(lnEmid),lnEmid);
+            }
+
+        }
+#endif
         /* O(eps^3) approach */
-        if (flu_stpwr == stpwr) return dedxmid_i;
-        
+        if (flu_stpwr == stpwr) {
+            return dedxmid_i;
+        }
+
         /* O(eps^5) approach */
         EGS_Float b = i_dedx[imed].get_b(i_dedx[imed].getIndexFast(lnEmid));
         EGS_Float aux = b*dedxmid_i;
@@ -969,104 +1019,110 @@ else{
     }
 
 
-   void setCurrentCase(EGS_I64 ncase) {
-        if( ncase != current_ncase ) {
+    void setCurrentCase(EGS_I64 ncase) {
+        if (ncase != current_ncase) {
             current_ncase = ncase;
             fluT->setHistory(ncase);
-            if ( score_primaries )
-               fluT_p->setHistory(ncase);
-            if (score_spe){
-              for (int j = 0; j < nreg; j++){
-                  if ( is_sensitive[j] ) 
-                     flu[j]->setHistory(ncase);
-              }
-              if ( score_primaries ){
-                 for (int j = 0; j < nreg; j++){
-                     if ( is_sensitive[j] ) 
-                        flu_p[j]->setHistory(ncase);
-                 }
-              }
+            if (score_primaries) {
+                fluT_p->setHistory(ncase);
+            }
+            if (score_spe) {
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        flu[j]->setHistory(ncase);
+                    }
+                }
+                if (score_primaries) {
+                    for (int j = 0; j < nreg; j++) {
+                        if (is_sensitive[j]) {
+                            flu_p[j]->setHistory(ncase);
+                        }
+                    }
+                }
             }
         }
 #ifdef DEBUG
         binDist->setHistory(ncase);
-        if ( scoring_charge ){
-           stepDist->setHistory(ncase);
-           relStepDiff->setHistory(ncase);
+        if (scoring_charge) {
+            stepDist->setHistory(ncase);
+            relStepDiff->setHistory(ncase);
         }
-#endif        
-
-   };
-   void resetCounter(){
-      current_ncase = 0; 
-      fluT->reset();
-      if ( score_primaries ) 
-         fluT_p->reset();
-      if ( score_spe ){
-        for (int j = 0; j < nreg; j++){
-            if ( is_sensitive[j] ) 
-               flu[j]->reset();
-        }
-        
-        if ( score_primaries ){
-           for (int j = 0; j < nreg; j++){
-               if ( is_sensitive[j] ) 
-                  flu_p[j]->reset();
-           }
-        }
-      }
-#ifdef DEBUG
-      binDist->reset();
-      if ( scoring_charge ){
-         stepDist->reset();
-         relStepDiff->reset();
-      }
 #endif
-   }
 
-   bool storeState(ostream &data) const;
-   
-   bool setState(istream &data);
-   
-   bool addState(istream &data);
+    };
+    void resetCounter() {
+        current_ncase = 0;
+        fluT->reset();
+        if (score_primaries) {
+            fluT_p->reset();
+        }
+        if (score_spe) {
+            for (int j = 0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    flu[j]->reset();
+                }
+            }
 
-private:   
+            if (score_primaries) {
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        flu_p[j]->reset();
+                    }
+                }
+            }
+        }
+#ifdef DEBUG
+        binDist->reset();
+        if (scoring_charge) {
+            stepDist->reset();
+            relStepDiff->reset();
+        }
+#endif
+    }
 
-  /*******************************************/
-  /* Charged particle fluence: Required data */
-  /*******************************************/
-  EGS_Interpolator* i_dedx; // stopping power for each medium
-  EGS_Interpolator* dedx_i; // inverse stopping power for each medium
-  EGS_Float*        Lmid_i; // pre-computed inverse of bin midpoint stpwr
-  eFluType       flu_stpwr; // flurz   => ave. stpwr = edep/tvstep,
-                            // stpwr   => 3rd order in edep/Eb,
-                            // stpwrO5 => 5th order in edep/Eb
-  /**************************************************************
-   * Parameters required for calculations on a log-scale
-   * The main issue here is that the bin width is not constant
-   *************************************************************/
-   EGS_Float       r_const;    // inverse of (Emax/Emin)**1/flu_nbin - 1 = exp(binwidth)-1
-   EGS_Float      *a_const;    // constant needed to determine bin fractions on log scale
-   EGS_Float      *DE;         // bin width of logarithmic scale
-  /*****************************************************************/
+    bool storeState(ostream &data) const;
 
-  EGS_I64 eCases;
+    bool setState(istream &data);
 
-  vector<EGS_Float> volume;    // volume of each scoring region
-  /* Energy grid inputs */
-  //EGS_Float flu_a_i;
-  /* Auxiliary input variables*/
-  vector <EGS_Float> vol_list;       // Input list of region volumes
+    bool addState(istream &data);
+
+private:
+
+    /*******************************************/
+    /* Charged particle fluence: Required data */
+    /*******************************************/
+    EGS_Interpolator *i_dedx; // stopping power for each medium
+    EGS_Interpolator *dedx_i; // inverse stopping power for each medium
+    EGS_Float        *Lmid_i; // pre-computed inverse of bin midpoint stpwr
+    eFluType       flu_stpwr; // flurz   => ave. stpwr = edep/tvstep,
+    // stpwr   => 3rd order in edep/Eb,
+    // stpwrO5 => 5th order in edep/Eb
+    /**************************************************************
+     * Parameters required for calculations on a log-scale
+     * The main issue here is that the bin width is not constant
+     *************************************************************/
+    EGS_Float       r_const;    // inverse of (Emax/Emin)**1/flu_nbin - 1 = exp(binwidth)-1
+    EGS_Float      *a_const;    // constant needed to determine bin fractions on log scale
+    EGS_Float      *DE;         // bin width of logarithmic scale
+    /*****************************************************************/
+
+    EGS_I64 eCases;
+
+    vector<EGS_Float> volume;    // volume of each scoring region
+    /* Energy grid inputs */
+    //EGS_Float flu_a_i;
+    /* Auxiliary input variables*/
+    vector <EGS_Float> vol_list;       // Input list of region volumes
 
 #ifdef DEBUG
-  /* Debugging information */
-  int one_bin, multi_bin;
-  EGS_ScoringArray *binDist;  
-  EGS_ScoringArray *stepDist;  
-  EGS_ScoringArray *relStepDiff; // Relative difference between tvstep and edep-derived step
-  EGS_Float max_step;
-  EGS_Float step_a, step_b;
-  EGS_I32 n_step_bins;
+    /* Debugging information */
+    int one_bin, multi_bin;
+    EGS_ScoringArray *binDist;
+    EGS_ScoringArray *stepDist;
+    EGS_ScoringArray *relStepDiff; // Relative difference between tvstep and edep-derived step
+    EGS_Float max_step;
+    EGS_Float step_a, step_b;
+    EGS_I32 n_step_bins;
 #endif
 
 };

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -36,8 +36,6 @@ in FLURZnrc for IPRIMARY = 2 (primaries) and IPRIMARY = 4 (secondaries).
 
 The basic definition of a fluence scoring AO is
 
-This ausgab object is specified via
-
     :start ausgab object:
         name    = a_name
         library = egs_fluence_scoring
@@ -153,7 +151,6 @@ A basic fluence scoring ausgab object is specified via
   \todo Total kerma scoring
   \todo Account for multiple app geometries
   \todo Fluence for any particle type?
-
 */
 class EGS_FLUENCE_SCORING_EXPORT EGS_FluenceScoring : public EGS_AusgabObject {
 
@@ -164,6 +161,8 @@ public:
   ~EGS_FluenceScoring();
 
    void initScoring(EGS_Input *inp);
+
+   void getSensitiveRegions(EGS_Input *inp);
 
    void getNumberRegions( const string &str, vector<int> &regs );
 
@@ -194,8 +193,8 @@ public:
 
            OPTIONAL:
            FLURZnrc IPRIMARY = 1 (e- from brems as primaries)
-               Set source_particle to 'photon' in the input file to not flag
-               brems photons so that when scoring charged partcle fluence in 
+               Set `source particle` to 'photon' in the input file to not flag
+               brems photons so that when scoring charged particle fluence in 
                photon beams, first generation e- are primaries. This is
                implicit for photon interactions when scoring charged particle 
                fluence. But one must explicitly account for that during brems events.

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1221,6 +1221,7 @@ void EGS_AdvancedApplication::setRadiativeSplitting(const EGS_Float &nsplit) {
 //************************************************************
 // Utility functions for use with ausgab fluence scoring objects
 //************************************************************
+
 EGS_Float EGS_AdvancedApplication::getTVSTEP() {
     return the_epcont->tvstep;
 };

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1219,6 +1219,13 @@ void EGS_AdvancedApplication::setRadiativeSplitting(const EGS_Float &nsplit) {
 }
 
 //************************************************************
+// Utility functions for use with ausgab fluence scoring objects
+//************************************************************
+EGS_Float EGS_AdvancedApplication::getTVSTEP() {
+    return the_epcont->tvstep;
+};
+
+//************************************************************
 // Utility function for ausgab phase space scoring objects
 //************************************************************
 void EGS_AdvancedApplication::setLatch(int latch) {

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1225,29 +1225,32 @@ EGS_Float EGS_AdvancedApplication::getTVSTEP() {
     return the_epcont->tvstep;
 }
 
-EGS_Interpolator* EGS_AdvancedApplication::getDEDX( const int &imed, const int &iq ) {
-    if (iq == -1)
-       return &i_ededx[imed];
-    else if (iq == 1)           
-       return &i_pdedx[imed];
-    else 
-       return 0;
+EGS_Interpolator *EGS_AdvancedApplication::getDEDX(const int &imed, const int &iq) {
+    if (iq == -1) {
+        return &i_ededx[imed];
+    }
+    else if (iq == 1) {
+        return &i_pdedx[imed];
+    }
+    else {
+        return 0;
+    }
 }
 
-void EGS_AdvancedApplication::setLatch( const int &ip, const int &latch ) {
-  the_stack->latch[ip] = latch;
+void EGS_AdvancedApplication::setLatch(const int &ip, const int &latch) {
+    the_stack->latch[ip] = latch;
 }
 
-void EGS_AdvancedApplication::incLatch( const int &ip, const int &increment ){
-  the_stack->latch[ip] += increment;
+void EGS_AdvancedApplication::incLatch(const int &ip, const int &increment) {
+    the_stack->latch[ip] += increment;
 }
 
 int EGS_AdvancedApplication::getNp() {
-  return the_stack->np-1;;
+    return the_stack->np-1;;
 }
 
 int EGS_AdvancedApplication::getNpOld() {
-  return the_stack->npold-1;
+    return the_stack->npold-1;
 }
 
 //************************************************************

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1219,12 +1219,36 @@ void EGS_AdvancedApplication::setRadiativeSplitting(const EGS_Float &nsplit) {
 }
 
 //************************************************************
-// Utility functions for use with ausgab fluence scoring objects
+// Utility functions for fluence scoring objects
 //************************************************************
-
 EGS_Float EGS_AdvancedApplication::getTVSTEP() {
     return the_epcont->tvstep;
-};
+}
+
+EGS_Interpolator* EGS_AdvancedApplication::getDEDX( const int &imed, const int &iq ) {
+    if (iq == -1)
+       return &i_ededx[imed];
+    else if (iq == 1)           
+       return &i_pdedx[imed];
+    else 
+       return 0;
+}
+
+void EGS_AdvancedApplication::setLatch( const int &ip, const int &latch ) {
+  the_stack->latch[ip] = latch;
+}
+
+void EGS_AdvancedApplication::incLatch( const int &ip, const int &increment ){
+  the_stack->latch[ip] += increment;
+}
+
+int EGS_AdvancedApplication::getNp() {
+  return the_stack->np-1;;
+}
+
+int EGS_AdvancedApplication::getNpOld() {
+  return the_stack->npold-1;
+}
 
 //************************************************************
 // Utility function for ausgab phase space scoring objects

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -221,12 +221,12 @@ public:
     // Utility functions for fluence scoring objects
     //************************************************************
     EGS_Float getTVSTEP();
-    EGS_Interpolator* getDEDX( const int &imed, const int &iq );
-    void setLatch( const int &ip, const int &latch );
-    void incLatch( const int &ip, const int &increment );
+    EGS_Interpolator *getDEDX(const int &imed, const int &iq);
+    void setLatch(const int &ip, const int &latch);
+    void incLatch(const int &ip, const int &increment);
     int getNp();
     int getNpOld();
-    
+
     /* Needed by some sources */
     EGS_Float getRM();
     /* Turn ON/OFF radiative splitting */

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -221,8 +221,13 @@ public:
     // Utility functions for fluence scoring objects
     //************************************************************
     EGS_Float getTVSTEP();
-    EGS_Interpolator* eDEDX( int imed ) {
-        return &i_ededx[imed];
+    EGS_Interpolator* getDEDX( const int &imed, const int &iq ) {
+        if (iq == -1)
+           return &i_ededx[imed];
+        else if (iq == 1)           
+           return &i_pdedx[imed];
+        else 
+           return 0;
     };
     
     /* Needed by some sources */

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -221,14 +221,11 @@ public:
     // Utility functions for fluence scoring objects
     //************************************************************
     EGS_Float getTVSTEP();
-    EGS_Interpolator* getDEDX( const int &imed, const int &iq ) {
-        if (iq == -1)
-           return &i_ededx[imed];
-        else if (iq == 1)           
-           return &i_pdedx[imed];
-        else 
-           return 0;
-    };
+    EGS_Interpolator* getDEDX( const int &imed, const int &iq );
+    void setLatch( const int &ip, const int &latch );
+    void incLatch( const int &ip, const int &increment );
+    int getNp();
+    int getNpOld();
     
     /* Needed by some sources */
     EGS_Float getRM();

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -217,6 +217,11 @@ public:
     //************************************************************
     void setLatch(int latch);
 
+    //************************************************************
+    // Utility functions for fluence scoring objects
+    //************************************************************
+    EGS_Float getTVSTEP();
+
     /* Needed by some sources */
     EGS_Float getRM();
     /* Turn ON/OFF radiative splitting */

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -221,7 +221,10 @@ public:
     // Utility functions for fluence scoring objects
     //************************************************************
     EGS_Float getTVSTEP();
-
+    EGS_Interpolator* eDEDX( int imed ) {
+        return &i_ededx[imed];
+    };
+    
     /* Needed by some sources */
     EGS_Float getRM();
     /* Turn ON/OFF radiative splitting */

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1149,6 +1149,13 @@ public:
     virtual void setRadiativeSplitting(const EGS_Float &nsplit) {};
 
     //************************************************************
+    // Utility functions for use with ausgab fluence scoring objects
+    //************************************************************
+    virtual EGS_Float getTVSTEP() {
+        return 0.0;
+    };
+
+    //************************************************************
     // Utility function for ausgab phase space scoring objects
     //************************************************************
     virtual void setLatch(int latch) {};

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1165,7 +1165,12 @@ public:
         return source->getObjectType();
     }
 
+    int sourceCharge() {
+        return source->getCharge();
+    }
+
     virtual void setLatch( const int &ip, const int &latch ){};
+
     virtual void incLatch( const int &ip, const int &increment ){};
 
     virtual int getNp() {

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1169,6 +1169,10 @@ public:
         return source->getCharge();
     }
 
+    int sourceEmax() {
+        return source->getEmax();
+    }
+
     virtual void setLatch( const int &ip, const int &latch ){};
 
     virtual void incLatch( const int &ip, const int &increment ){};

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1157,7 +1157,7 @@ public:
         return 0.0;
     };
 
-    virtual EGS_Interpolator* eDEDX( int imed ) {
+    virtual EGS_Interpolator* getDEDX( const int &imed, const int &iq ) {
         return 0;
     };
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -43,6 +43,7 @@
 #include "egs_base_geometry.h"
 #include "egs_base_source.h"
 #include "egs_simple_container.h"
+#include "egs_interpolator.h"
 
 #include <string>
 #include <iostream>
@@ -54,6 +55,7 @@ class EGS_RandomGenerator;
 class EGS_RunControl;
 class EGS_GeometryHistory;
 class EGS_AusgabObject;
+class EGS_Interpolator;
 //template <class T> class EGS_SimpleContainer;
 
 /*! \brief A structure holding the information of one particle
@@ -1154,6 +1156,14 @@ public:
     virtual EGS_Float getTVSTEP() {
         return 0.0;
     };
+
+    virtual EGS_Interpolator* eDEDX( int imed ) {
+        return 0;
+    };
+
+    string sourceType() {
+        return source->getObjectType();
+    }
 
     //************************************************************
     // Utility function for ausgab phase space scoring objects

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1157,7 +1157,7 @@ public:
         return 0.0;
     };
 
-    virtual EGS_Interpolator* getDEDX( const int &imed, const int &iq ) {
+    virtual EGS_Interpolator *getDEDX(const int &imed, const int &iq) {
         return 0;
     };
 
@@ -1173,16 +1173,16 @@ public:
         return source->getEmax();
     }
 
-    virtual void setLatch( const int &ip, const int &latch ){};
+    virtual void setLatch(const int &ip, const int &latch) {};
 
-    virtual void incLatch( const int &ip, const int &increment ){};
+    virtual void incLatch(const int &ip, const int &increment) {};
 
     virtual int getNp() {
-      return 0;
+        return 0;
     };
 
     virtual int getNpOld() {
-      return 0;
+        return 0;
     };
 
     //************************************************************

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1165,6 +1165,17 @@ public:
         return source->getObjectType();
     }
 
+    virtual void setLatch( const int &ip, const int &latch ){};
+    virtual void incLatch( const int &ip, const int &increment ){};
+
+    virtual int getNp() {
+      return 0;
+    };
+
+    virtual int getNpOld() {
+      return 0;
+    };
+
     //************************************************************
     // Utility function for ausgab phase space scoring objects
     //************************************************************

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -146,7 +146,7 @@ public:
      *
      *  This virtual function must be re-implemented in derived classes
      *  that return the source particles' charge. Multi-particle sources
-     *  will return a value of -99. This value corresponds to an unknown 
+     *  will return a value of -99. This value corresponds to an unknown
      *  particle type in the fluence scoring AOs.
      */
     virtual int getCharge() const  {

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -142,6 +142,16 @@ public:
     */
     virtual void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) { };
 
+    /*! \brief Get the charge of the source.
+     *
+     *  This virtual function must be re-implemented in derived classes
+     *  that return the source particles' charge. Multi-particle sources
+     *  will return a value of -99. This value corresponds to an unknown 
+     *  particle type in the fluence scoring AOs.
+     */
+    virtual int getCharge() const  {
+        return -99;
+    };
     /*! \brief Return the maximum energy of this source.
      *
      *  This pure virtual function must be implemented in derived classes
@@ -640,7 +650,7 @@ public:
      *
      * Simply returns the value of the (protected) attribute q.
      */
-    virtual int getCharge() const {
+    int getCharge() const {
         return q;
     };
 

--- a/HEN_HOUSE/egs++/egs_interpolator.cpp
+++ b/HEN_HOUSE/egs++/egs_interpolator.cpp
@@ -99,8 +99,8 @@ void EGS_Interpolator::initialize(int nbin, EGS_Float Xmin, EGS_Float Xmax,
         b[j] = (values[j+1]-values[j])*bx;
         a[j] = values[j] - b[j]*(xmin + dx*j);
     }
-    /**************************************************** 
-       Extra subinterval at top of interval, taking care 
+    /****************************************************
+       Extra subinterval at top of interval, taking care
        of round-off errors via extrapolation.
        Mimics PEGS4 PWLF QFIT approach.
     *****************************************************/

--- a/HEN_HOUSE/egs++/egs_interpolator.cpp
+++ b/HEN_HOUSE/egs++/egs_interpolator.cpp
@@ -87,7 +87,7 @@ void EGS_Interpolator::initialize(int nbin, EGS_Float Xmin, EGS_Float Xmax,
     clear();
     own_data = true;
     n = nbin - 1;
-    a = new EGS_Float [n], b = new EGS_Float [n];
+    a = new EGS_Float [nbin], b = new EGS_Float [nbin];
     xmin = Xmin;
     xmax = Xmax;
     fmin = values[0];
@@ -99,6 +99,13 @@ void EGS_Interpolator::initialize(int nbin, EGS_Float Xmin, EGS_Float Xmax,
         b[j] = (values[j+1]-values[j])*bx;
         a[j] = values[j] - b[j]*(xmin + dx*j);
     }
+    /**************************************************** 
+       Extra subinterval at top of interval, taking care 
+       of round-off errors via extrapolation.
+       Mimics PEGS4 PWLF QFIT approach.
+    *****************************************************/
+    a[n] = a[n-1];
+    b[n] = b[n-1];
 }
 
 void EGS_Interpolator::initialize(int nbin, EGS_Float Xmin, EGS_Float Xmax,


### PR DESCRIPTION
Scores fluence in _user-defined_ regions (`volumetric`) or at a circular or rectangular field (`planar`) located in an arbitrary position in space. Scoring can be done for either photons, electrons or positrons. Scoring for multiple particle types, can be accomplished by defining as many fluence scoring AOs as required.