### PR TITLE
Fix serious bug in MCDF-XCOM PE routine

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -5247,7 +5247,7 @@ IF( iedgfl(irl) ~= 0 ) [" User requested atomic relaxations "
       $RANDOMSET br; logE = log(peig);
       "DO k=1,nne(medium) ["
       DO k=nne(medium),1,-1 [
-          iZ = int( zelem(medium,k) + 0.5 );zpos = pe_zpos(iZ);
+          iz = int(pe_zsorted(k,medium)+0.5); zpos = pe_zpos(iZ);
           IF( iZ < 1 | iZ > $MXELEMENT ) [
               $egs_info(*,' Error in egs_shellwise_photo: ');
               $egs_fatal(*,'   Atomic number of element ',k,


### PR DESCRIPTION
**Unexpected behavior:** Results depend on the order in which the material
composition is defined. This is clearly a bug as  elements can be entered in 
an arbitrary order to define compounds and mixtures.

**Reported by:** Iymad Mansour (issue #844) who observed that `egs_brachy` simulations of
an irradiation with an isotropic 35 keV photon point source embedded
in a steel applicator, produced 5% differences in the surface dose of
a water phantom when the order of the steel components was changed.

Confirmed with `egs_kerma` for a 35 keV photon point source surrounded by
a 1 mm steel encapsulation embedded in a spherical water phantom. Kerma
at the spherical water shell next to the encapsulation differs by 4%.

**BUG:** Sampling element and atomic shell for photo-electric interaction
     with MCDF-XCOM shell-wise cross sections using unsorted array `zelem` rather than
     `pe_zsorted.` The use of a sorted array was introduced with the MCDF-XCOM option 
     for efficiency purposes when sampling the interacting element, by checking from heaviest 
     to lightest element.

Using `pe_zsorted` array fixes the problem.