### PR TITLE
Fix buffer overflow from scoring vacuum media dose

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -361,6 +361,10 @@ void EGS_DoseScoring::reportResults() {
         for (int ir=0; ir<nreg; ir++) {
             if (app->isRealRegion(ir)) {
                 imed = app->getMedium(ir);
+                // skip vacuum regions
+                if (imed == -1) {
+                    continue;
+                }
                 EGS_Float volume = vol.size() > 1 ? vol[ir]:vol[0];
                 massM[imed] += app->getMediumRho(imed)*volume;
             }


### PR DESCRIPTION
Vacuum has a special medium number -1, while all other media get offsets
from 0 to nmedia. Before this change, there was a buffer overflow if
media dose scoring was used with a geometry that had vacuum as one of
the media. The vector massM is indexed by medium number, but for any
vacuum regions, it would read and write memory at the memory location
one before the buffer bounds: massM[-1].

Skipping the vacuum region masses shouldn't matter, as vacuum dose is
always zero. massM is only used later on with non-vacuum media, so
skipping vacuum regions is the right choice instead of an alternative
like appending the vacuum mass to massM.

Fixes #860.