### PR TITLE
Fix buffer overflow from scoring bin rounding

### DIFF
--- a/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
+++ b/HEN_HOUSE/user_codes/tutor7pp/tutor7pp.cpp
@@ -462,8 +462,8 @@ int Tutor7_Application::ausgab(int iarg) {
         if (ir == nreg+1) {
             EGS_ScoringArray *flu = the_stack->iq[np] ? eflu : gflu;
             EGS_Float r2 = the_stack->x[np]*the_stack->x[np] + the_stack->y[np]*the_stack->y[np];
-            if (r2 < 400) {
-                int bin = (int)(sqrt(r2)*10.);
+            int bin = (int)(sqrt(r2)*10.);
+            if (bin < 200) {
 
                 aux = the_stack->wt[np]/the_stack->w[np];
                 if (aux > 0) {


### PR DESCRIPTION
Before this change, there was a small risk of buffer overflow in the
tutor7pp fluence scoring arrays. The value r2 was checked to be less
than 400, and then the scoring bin number (from 0 to 199) is calculated
using the expression `(int)(sqrt(r2)*10.)`. The problem with this check
is that certain double precision values less than 400 can nevertheless
have a square root equal to exactly 20.0 due to floating-point rounding.

For example, taking the square root of the double 399.99999999999994
results in 20.0 under certain conditions, not a value slightly less than
20.0 as would be expected. The default g++ rounding mode is
round-to-nearest, so even with the square root's true value being under
20.0, the resulting double can be rounded upwards to 20.0 if the true
value is closer to 20.0 than the previous representable float. Then,
scoring in bin 200 results in buffer overflow in the scoring array.

This change ensures the resulting scoring array bin integer is in bounds
(< 200), eliminating the potential for buffer overflow.

Fixes #863.