### PR TITLE
Add egs_view egsinp editor with autocompletion

### DIFF
--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -42,7 +42,7 @@ egspp_files = egs_input egs_base_geometry egs_library egs_transformations \
              egs_base_source egs_functions egs_application egs_run_control \
              egs_scoring egs_interpolator egs_atomic_relaxations \
              egs_ausgab_object egs_particle_track egs_fortran_geometry \
-             egs_ensdf
+             egs_ensdf egs_input_struct
 
 egspp_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(egspp_files)))
 config1h = $(IEGS1)$(DSEP)egs_config1.h egs_libconfig.h egs_functions.h
@@ -72,7 +72,7 @@ lib_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(all_libs)))
 
 #******************************************************************************
 
-all: $(EGS_BINDIR)egspp$(EXE) $(ABS_DSO)$(libpre)egspp$(libext) glibs slibs shapes aobjects gtest
+all: $(EGS_BINDIR)egspp$(EXE) $(ABS_DSO)$(libpre)egspp$(libext) $(ABS_DSO)$(libpre)egs_input_struct$(libext) glibs slibs shapes aobjects gtest
 
 $(EGS_BINDIR)egspp$(EXE): $(dso) $(DSO1)egspp.$(obje) $(ABS_DSO)$(libpre)egspp$(libext)
 	$(CXX) $(INC1) $(DEF1) $(opt) $(EOUT)$@ $(DSO1)egspp.$(obje) $(lib_link1) $(link2_prefix)egspp$(link2_suffix)
@@ -83,6 +83,9 @@ $(ABS_DSO)$(libpre)egspp$(libext): $(dso) $(egspp_objects)
 $(DSO1)egspp.$(obje): egspp.cpp egs_application.h egs_base_geometry.h egs_vector.h \
 	               egs_math.h egs_library.h $(config1h)
 	$(CXX) $(INC1) $(DEF1) $(opt) -c $(COUT)$@ $(notdir $(basename $@)).cpp
+
+$(ABS_DSO)$(libpre)egs_input_struct$(libext): $(dso) $(DSO1)egs_input_struct.$(obje)
+	$(CXX) $(INC1) $(DEFS) $(opt) $(shared) $(DSO1)egs_input_struct.$(obje) $(extra)
 
 $(DSO1)egs_interpolator.$(obje): egs_interpolator.cpp egs_interpolator.h \
                                  $(config1h)
@@ -129,6 +132,9 @@ $(DSO1)egs_base_source.$(obje): egs_base_source.cpp egs_base_source.h \
 
 $(DSO1)egs_ensdf.$(obje): egs_ensdf.cpp egs_ensdf.h \
     $(config1h) egs_functions.h egs_math.h egs_alias_table.h egs_atomic_relaxations.h
+
+$(DSO1)egs_input_struct.$(obje): egs_input_struct.cpp egs_input_struct.h \
+    $(config1h)
 
 $(DSO1)egs_geometry_tester.$(obje): egs_geometry_tester.cpp \
     egs_geometry_tester.h egs_input.h egs_vector.h egs_base_geometry.h \

--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -72,7 +72,8 @@ lib_objects = $(addprefix $(DSO1), $(addsuffix .$(obje), $(all_libs)))
 
 #******************************************************************************
 
-all: $(EGS_BINDIR)egspp$(EXE) $(ABS_DSO)$(libpre)egspp$(libext) $(ABS_DSO)$(libpre)egs_input_struct$(libext) glibs slibs shapes aobjects gtest
+#all: $(EGS_BINDIR)egspp$(EXE) $(ABS_DSO)$(libpre)egspp$(libext) $(ABS_DSO)$(libpre)egs_input_struct$(libext) glibs slibs shapes aobjects gtest
+all: $(EGS_BINDIR)egspp$(EXE) $(ABS_DSO)$(libpre)egspp$(libext) glibs slibs shapes aobjects gtest
 
 $(EGS_BINDIR)egspp$(EXE): $(dso) $(DSO1)egspp.$(obje) $(ABS_DSO)$(libpre)egspp$(libext)
 	$(CXX) $(INC1) $(DEF1) $(opt) $(EOUT)$@ $(DSO1)egspp.$(obje) $(lib_link1) $(link2_prefix)egspp$(link2_suffix)
@@ -84,8 +85,8 @@ $(DSO1)egspp.$(obje): egspp.cpp egs_application.h egs_base_geometry.h egs_vector
 	               egs_math.h egs_library.h $(config1h)
 	$(CXX) $(INC1) $(DEF1) $(opt) -c $(COUT)$@ $(notdir $(basename $@)).cpp
 
-$(ABS_DSO)$(libpre)egs_input_struct$(libext): $(dso) $(DSO1)egs_input_struct.$(obje)
-	$(CXX) $(INC1) $(DEFS) $(opt) $(shared) $(DSO1)egs_input_struct.$(obje) $(extra)
+#$(ABS_DSO)$(libpre)egs_input_struct$(libext): $(dso) $(DSO1)egs_input_struct.$(obje) $(egspp_objects)
+#	$(CXX) $(INC1) $(DEFS) $(opt) $(shared) $(DSO1)egs_input_struct.$(obje) $(egspp_objects) $(extra)
 
 $(DSO1)egs_interpolator.$(obje): egs_interpolator.cpp egs_interpolator.h \
                                  $(config1h)
@@ -131,7 +132,7 @@ $(DSO1)egs_base_source.$(obje): egs_base_source.cpp egs_base_source.h \
     egs_vector.h $(config1h) egs_object_factory.h egs_input.h
 
 $(DSO1)egs_ensdf.$(obje): egs_ensdf.cpp egs_ensdf.h \
-    $(config1h) egs_functions.h egs_math.h egs_alias_table.h egs_atomic_relaxations.h
+    $(config1h) egs_math.h egs_alias_table.h egs_atomic_relaxations.h
 
 $(DSO1)egs_input_struct.$(obje): egs_input_struct.cpp egs_input_struct.h \
     $(config1h)

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -27,6 +27,7 @@
 #                   Reid Townson
 #                   Hubert Ho
 #                   Blake Walters
+#                   Hannah Gallop
 #
 ###############################################################################
 #
@@ -95,6 +96,8 @@
 #include "egs_dose_scoring.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_DOSE_SCORING_LOCAL inputSet = false;
 
 EGS_DoseScoring::EGS_DoseScoring(const string &Name,
                                  EGS_ObjectFactory *f) :
@@ -588,6 +591,39 @@ void EGS_DoseScoring::resetCounter() {
 //
 //**********************************************************************
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseAusgabObjectInputs();
+
+        ausBlockInput->getSingleInput("library")->setValues({"EGS_Dose_Scoring"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        ausBlockInput->addSingleInput("medium dose", false, "Requests the dose deposited in each medium to be scored, default is no", {"yes", "no"});
+        ausBlockInput->addSingleInput("region dose", false, "Requests the dose deposited in each region to be scored, default is yes", {"yes", "no"});
+        ausBlockInput->addSingleInput("volume", false, "Either a unique volume, which will be the same for all regions or a list of individual volumes for each region, default is 1g/cm3");
+        auto dosePtr = ausBlockInput->addSingleInput("dose regions", false, "A list of individual regions");
+        auto startPtr = ausBlockInput->addSingleInput("dose start region", false, "A list of starts for regions");
+        auto stopPtr = ausBlockInput->addSingleInput("dose stop region", false, "A list of stops for regions");
+
+        dosePtr->addDependency(startPtr, "", true);
+        dosePtr->addDependency(stopPtr, "", true);
+        startPtr->addDependency(dosePtr, "", true);
+        stopPtr->addDependency(dosePtr, "", true);
+
+        // This can only be used if one of the geometries is an EGS_XYZGeometry
+        auto blockPtr = ausBlockInput->addBlockInput("output dose file");
+        blockPtr->addSingleInput("geometry name", true, "The name of a predefined EGS_XYZGeometry");
+        blockPtr->addSingleInput("file type", true, "The type of file", {"3ddose"});
+    }
+
+    EGS_DOSE_SCORING_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return ausBlockInput;
+    }
 
     EGS_DOSE_SCORING_EXPORT EGS_AusgabObject *createAusgabObject(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -619,7 +619,7 @@ extern "C" {
     }
 
     EGS_DOSE_SCORING_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
-        if(!inputSet) {
+        if (!inputSet) {
             setInputs();
         }
         return ausBlockInput;

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Ernesto Mainegra-Hing, 2018
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 #
@@ -49,6 +49,8 @@
 #include "egs_radiative_splitting.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_RADIATIVE_SPLITTING_LOCAL inputSet = false;
 
 EGS_RadiativeSplitting::EGS_RadiativeSplitting(const string &Name,
         EGS_ObjectFactory *f) :
@@ -94,6 +96,24 @@ void EGS_RadiativeSplitting::setApplication(EGS_Application *App) {
 //
 //**********************************************************************
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseAusgabObjectInputs();
+
+        ausBlockInput->getSingleInput("library")->setValues({"EGS_Radiative_Splitting"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        ausBlockInput->addSingleInput("splitting", false, "N-split");
+    }
+
+    EGS_RADIATIVE_SPLITTING_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return ausBlockInput;
+    }
 
     EGS_RADIATIVE_SPLITTING_EXPORT EGS_AusgabObject *createAusgabObject(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
@@ -109,7 +109,7 @@ extern "C" {
     }
 
     EGS_RADIATIVE_SPLITTING_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
-        if(!inputSet) {
+        if (!inputSet) {
             setInputs();
         }
         return ausBlockInput;

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
@@ -139,8 +139,8 @@ extern "C" {
 
     EGS_TRACK_SCORING_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_track_scoring
     #:start ausgab object:
         library = egs_track_scoring
@@ -165,36 +165,36 @@ extern "C" {
     EGS_TRACK_SCORING_EXPORT EGS_AusgabObject *createAusgabObject(EGS_Input *input,
             EGS_ObjectFactory *f) {
         const static char *func = "createAusgabObject(track_scoring)";
-        if (!input) {
-            egsWarning("%s: null input?\n",func);
-            return 0;
+            if (!input) {
+                egsWarning("%s: null input?\n",func);
+                return 0;
+            }
+            vector<string> sc_options;
+            sc_options.push_back("no");
+            sc_options.push_back("yes");
+            bool scph = input->getInput("score photons",sc_options,true);
+            bool scel = input->getInput("score electrons",sc_options,true);
+            bool scpo = input->getInput("score positrons",sc_options,true);
+            if (!scph && !scel && !scpo) {
+                return 0;
+            }
+            EGS_I64 first = 0, last = 1024;
+            input->getInput("start scoring",first);
+            input->getInput("stop scoring",last);
+            int bufSize = 1024;
+            input->getInput("buffer size",bufSize);
+            string fnExtra;
+            input->getInput("file name addition",fnExtra);
+            EGS_TrackScoring *result = new EGS_TrackScoring("",f);
+            result->setScorePhotons(scph);
+            result->setScoreElectrons(scel);
+            result->setScorePositrons(scpo);
+            result->setFirstEvent(first);
+            result->setLastEvent(last);
+            result->setBufferSize(bufSize);
+            result->setFileNameExtra(fnExtra);
+            result->setName(input);
+            return result;
         }
-        vector<string> sc_options;
-        sc_options.push_back("no");
-        sc_options.push_back("yes");
-        bool scph = input->getInput("score photons",sc_options,true);
-        bool scel = input->getInput("score electrons",sc_options,true);
-        bool scpo = input->getInput("score positrons",sc_options,true);
-        if (!scph && !scel && !scpo) {
-            return 0;
-        }
-        EGS_I64 first = 0, last = 1024;
-        input->getInput("start scoring",first);
-        input->getInput("stop scoring",last);
-        int bufSize = 1024;
-        input->getInput("buffer size",bufSize);
-        string fnExtra;
-        input->getInput("file name addition",fnExtra);
-        EGS_TrackScoring *result = new EGS_TrackScoring("",f);
-        result->setScorePhotons(scph);
-        result->setScoreElectrons(scel);
-        result->setScorePositrons(scpo);
-        result->setFirstEvent(first);
-        result->setLastEvent(last);
-        result->setBufferSize(bufSize);
-        result->setFileNameExtra(fnExtra);
-        result->setName(input);
-        return result;
-    }
 
-}
+    }

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2009
 #
 #  Contributors:    Georgi Gerganov
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,6 +38,8 @@
 #include "egs_track_scoring.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_TRACK_SCORING_LOCAL inputSet = false;
 
 EGS_TrackScoring::EGS_TrackScoring(const string &Name, EGS_ObjectFactory *f) :
     EGS_AusgabObject(Name,f), m_pts(0), m_start(0), m_stop(1024), m_lastCase(-1),
@@ -116,6 +119,48 @@ void EGS_TrackScoring::reportResults() {
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseAusgabObjectInputs();
+
+        ausBlockInput->getSingleInput("library")->setValues({"EGS_Track_Scoring"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        ausBlockInput->addSingleInput("score photons", false, "Score photons? Default is yes.", {"yes", "no"});
+        ausBlockInput->addSingleInput("score electrons", false, "Score the elctrons? Default is yes.", {"yes", "no"});
+        ausBlockInput->addSingleInput("score positrons", false, "Score positrons? Default is yes.", {"yes", "no"});
+        ausBlockInput->addSingleInput("start scoring", false, "Event_number, default is 0.");
+        ausBlockInput->addSingleInput("stop scoring", false, "Event_number, default is 1024.");
+        ausBlockInput->addSingleInput("buffer size", false, "Size, default is 1024.");
+        ausBlockInput->addSingleInput("file name addition", false, "A string that constructs the output file name");
+    }
+
+    EGS_TRACK_SCORING_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_track_scoring
+    #:start ausgab object:
+        library = egs_track_scoring
+        name = my_score
+        score photons = yes
+        score electrons = yes
+        score positrons = yes
+        start scoring = 0
+        stop scoring = 1024
+    :stop ausgab object:
+)"};
+        return example;
+    }
+
+    EGS_TRACK_SCORING_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return ausBlockInput;
+    }
 
     EGS_TRACK_SCORING_EXPORT EGS_AusgabObject *createAusgabObject(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -43,7 +43,6 @@
 #include "egs_input.h"
 #include "egs_base_source.h"
 #include "egs_rndm.h"
-#include "egs_run_control.h"
 #include "egs_base_source.h"
 #include "egs_simple_container.h"
 #include "egs_ausgab_object.h"

--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -100,6 +100,8 @@ static EGS_LOCAL EGS_Application *active_egs_application = 0;
 
 int EGS_Application::n_apps = 0;
 
+unique_ptr<EGS_InputStruct> EGS_Application::inputStructure = unique_ptr<EGS_InputStruct>();
+
 EGS_EXPORT EGS_Application *EGS_Application::activeApplication() {
     return active_egs_application;
 }

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -44,6 +44,7 @@
 #include "egs_base_source.h"
 #include "egs_simple_container.h"
 #include "egs_input_struct.h"
+#include "egs_run_control.h"
 
 #include <memory>
 #include <string>
@@ -1182,6 +1183,11 @@ public:
     extern "C" {\
         APP_EXPORT EGS_Application* createApplication(int argc, char **argv) {\
             return new app_name(argc,argv);\
+        }\
+        APP_EXPORT shared_ptr<EGS_BlockInput> getAppInputs() {\
+            shared_ptr<EGS_BlockInput> inpPtr;\
+            addRunControlBlock(inpPtr);\ 
+            return inpPtr;\
         }\
     }
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -43,7 +43,9 @@
 #include "egs_base_geometry.h"
 #include "egs_base_source.h"
 #include "egs_simple_container.h"
+#include "egs_input_struct.h"
 
+#include <memory>
 #include <string>
 #include <iostream>
 using namespace std;
@@ -1152,6 +1154,8 @@ public:
     // Utility function for ausgab phase space scoring objects
     //************************************************************
     virtual void setLatch(int latch) {};
+
+    static unique_ptr<EGS_InputStruct> inputStructure;
 
 };
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -27,6 +27,7 @@
 #                   Ernesto Mainegra-Hing
 #                   Blake Walters
 #                   Reid Townson
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -45,6 +46,7 @@
 #include "egs_simple_container.h"
 #include "egs_input_struct.h"
 #include "egs_run_control.h"
+#include "egs_scoring.h"
 
 #include <memory>
 #include <string>
@@ -58,6 +60,47 @@ class EGS_RunControl;
 class EGS_GeometryHistory;
 class EGS_AusgabObject;
 //template <class T> class EGS_SimpleContainer;
+
+static void addmcBlock(shared_ptr<EGS_InputStruct> blockPtr) {
+    shared_ptr<EGS_BlockInput> mcBlock = blockPtr->addBlockInput("MC transport parameter");
+    mcBlock->addSingleInput("Global ECUT", false, "Global electron transport cutoff");
+    mcBlock->addSingleInput("Global PCUT", false, "Global photon transport cutoff");
+    mcBlock->addSingleInput("Global SMAX", false, "Global maximum step-size restriction for e-transport");
+    mcBlock->addSingleInput("ESTEPE", false, "Default is 0.25");
+    mcBlock->addSingleInput("XIMAX", false, "Default is 0.5, maximum value is 1.");
+    mcBlock->addSingleInput("Boundary crossing algorithm", false, "exact is default", {"exact", "PRESTA-I"});
+    mcBlock->addSingleInput("Skin depth for BCA", false, "Default value is 3 for exact boundary crossing");
+    mcBlock->addSingleInput("Electron-step algorithm", false, "Default is PRESTA-II", {"PRESTA_II", "PRESTA_I"});
+    mcBlock->addSingleInput("Spin effects", false, "Default is On", {"On", "Off"});
+    mcBlock->addSingleInput("Brems angular sampling", false, "Default is KM", {"KM", "Simple"});
+    mcBlock->addSingleInput("Brems cross sections", false, "Default is BH", {"BH", "NIST"});
+    mcBlock->addSingleInput("Pair angular crossing", false, "Default is Simple", {"Simple", "Off", "KM"});
+    mcBlock->addSingleInput("Triplet production", false, "Default is On", {"On", "Off"});
+    mcBlock->addSingleInput("Electron Impact Ionization", false, "Default is Off", {"On", "Off", "casnati", "kolbenstvedt", "gryzinski"});
+    mcBlock->addSingleInput("Bound Compton scattering", false, "Default is norej", {"On", "Off", "Simple", "norej"});
+    mcBlock->addSingleInput("Radiative Compton corrections", false, "Default is Off", {"On", "Off"});
+    mcBlock->addSingleInput("Rayleigh scattering", false, "Default is off", {"On", "Off", "custom"});
+    mcBlock->addSingleInput("Photoelectron angular sampling", false, "Default is on", {"On", "Off"});
+    mcBlock->addSingleInput("Atomic relaxations", false, "Default is on", {"On", "Off"});
+    mcBlock->addSingleInput("Photon cross sections", false, "Default is xcom, can also be user-supplied", {"si", "epdl", "xcom"});
+    mcBlock->addSingleInput("Photon cross-sections output", false, "Default is off", {"On", "Off"});
+    mcBlock->addSingleInput("Compton cross sections", false, "User-supplied, default is comp-xsections");
+    mcBlock->addSingleInput("Photonuclear attenuation", false, "Default is off", {"On", "Off"});
+    mcBlock->addSingleInput("Photonuclear cross sections", false, "Default is default, or is user-supplied", {"default"});
+}
+
+static void addvrBlock(shared_ptr<EGS_InputStruct> blockPtr) {
+    shared_ptr<EGS_BlockInput> vrBlock = blockPtr->addBlockInput("variance reduction");
+    vrBlock->addSingleInput("photon splitting", false, "N_split");
+    vrBlock->addSingleInput("TmpPhsp", false, "Score phase space, use once in each geometry");
+    vrBlock->addSingleInput("cs enhancement", false, "0 (XCSE off) or >0 (XCSE on)");
+
+    shared_ptr<EGS_BlockInput> rangePtr = vrBlock->addBlockInput("range rejection");
+    rangePtr->addSingleInput("rejection", false, "N_r");
+    rangePtr->addSingleInput("Esave", false, "E_save");
+    rangePtr->addSingleInput("cavity geometry", false, "The name of a previously defined geometry");
+    rangePtr->addSingleInput("rejection range medium", false, "index of the medium to calculate electron ranges");
+}
 
 /*! \brief A structure holding the information of one particle
   \ingroup egspp_main
@@ -1157,9 +1200,7 @@ public:
     virtual void setLatch(int latch) {};
 
     static unique_ptr<EGS_InputStruct> inputStructure;
-
 };
-
 #define APP_MAIN(app_name) \
     int main(int argc, char **argv) { \
         app_name app(argc,argv); \
@@ -1186,9 +1227,9 @@ public:
         }\
         APP_EXPORT void getAppInputs(shared_ptr<EGS_InputStruct> inpPtr) {\
             addRunControlBlock(inpPtr);\
+            addmcBlock(inpPtr);\
+            addvrBlock(inpPtr);\
+            addScoringBlock(inpPtr);\
         }\
-    }
-
 
 #endif
-

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1184,12 +1184,11 @@ public:
         APP_EXPORT EGS_Application* createApplication(int argc, char **argv) {\
             return new app_name(argc,argv);\
         }\
-        APP_EXPORT shared_ptr<EGS_BlockInput> getAppInputs() {\
-            shared_ptr<EGS_BlockInput> inpPtr;\
-            addRunControlBlock(inpPtr);\ 
-            return inpPtr;\
+        APP_EXPORT void getAppInputs(shared_ptr<EGS_InputStruct> inpPtr) {\
+            addRunControlBlock(inpPtr);\
         }\
     }
 
 
 #endif
+

--- a/HEN_HOUSE/egs++/egs_ausgab_object.h
+++ b/HEN_HOUSE/egs++/egs_ausgab_object.h
@@ -39,6 +39,7 @@
 
 #include "egs_application.h"
 #include "egs_object_factory.h"
+#include "egs_input_struct.h"
 
 #include <string>
 #include <iostream>
@@ -60,6 +61,12 @@ using namespace std;
 
 class EGS_Input;
 class EGS_Application;
+
+static shared_ptr<EGS_BlockInput> ausBlockInput = make_shared<EGS_BlockInput>("ausgab object");
+static void setBaseAusgabObjectInputs() {
+    ausBlockInput->addSingleInput("library", true, "The type of ausgab object, loaded by shared library in egs++/dso.");
+    ausBlockInput->addSingleInput("name", true, "The user-declared unique name of this ausgab object. This is the name you may refer to elsewhere in the input file.");
+}
 
 class EGS_EXPORT EGS_AusgabObject : public EGS_Object {
 

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -1170,3 +1170,5 @@ int EGS_BaseGeometry::setLabels(const string &inp) {
 
     return 1;
 }
+
+

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -43,10 +43,12 @@
 #define EGS_BASE_GEOMETRY_
 
 #include "egs_vector.h"
+#include "egs_input_struct.h"
 
 #include <string>
 #include <vector>
 #include <iostream>
+#include <memory>
 
 using std::string;
 using std::vector;
@@ -70,6 +72,14 @@ public:
     string      name;
     vector<int> regions;
 };
+
+static shared_ptr<EGS_BlockInput> blockInput = make_shared<EGS_BlockInput>("geometry");
+static void setBaseGeometryInputs() {
+    blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry.");
+    shared_ptr<EGS_BlockInput> mediaBlock = blockInput->addBlockInput("media input");
+    mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry.");
+    mediaBlock->addSingleInput("set medium", false, "TODO");
+}
 
 /*! \brief Base geometry class. Every geometry class must be derived from
   EGS_BaseGeometry.

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -73,13 +73,13 @@ public:
     vector<int> regions;
 };
 
-static shared_ptr<EGS_BlockInput> blockInput = make_shared<EGS_BlockInput>("geometry");
+static shared_ptr<EGS_BlockInput> geomBlockInput = make_shared<EGS_BlockInput>("geometry");
 static void setBaseGeometryInputs(bool includeMediaBlock = true) {
-    blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.");
-    blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
+    geomBlockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.");
+    geomBlockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
 
     if(includeMediaBlock) {
-        shared_ptr<EGS_BlockInput> mediaBlock = blockInput->addBlockInput("media input");
+        shared_ptr<EGS_BlockInput> mediaBlock = geomBlockInput->addBlockInput("media input");
         mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
         mediaBlock->addSingleInput("set medium", false, "TODO");
     }

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -74,11 +74,14 @@ public:
 };
 
 static shared_ptr<EGS_BlockInput> blockInput = make_shared<EGS_BlockInput>("geometry");
-static void setBaseGeometryInputs() {
+static void setBaseGeometryInputs(bool includeMediaBlock = true) {
     blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
-    shared_ptr<EGS_BlockInput> mediaBlock = blockInput->addBlockInput("media input");
-    mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
-    mediaBlock->addSingleInput("set medium", false, "TODO");
+
+    if(includeMediaBlock) {
+        shared_ptr<EGS_BlockInput> mediaBlock = blockInput->addBlockInput("media input");
+        mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
+        mediaBlock->addSingleInput("set medium", false, "TODO");
+    }
 }
 
 /*! \brief Base geometry class. Every geometry class must be derived from

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -75,6 +75,7 @@ public:
 
 static shared_ptr<EGS_BlockInput> blockInput = make_shared<EGS_BlockInput>("geometry");
 static void setBaseGeometryInputs(bool includeMediaBlock = true) {
+    blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.");
     blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
 
     if(includeMediaBlock) {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -75,9 +75,9 @@ public:
 
 static shared_ptr<EGS_BlockInput> blockInput = make_shared<EGS_BlockInput>("geometry");
 static void setBaseGeometryInputs() {
-    blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry.");
+    blockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
     shared_ptr<EGS_BlockInput> mediaBlock = blockInput->addBlockInput("media input");
-    mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry.");
+    mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
     mediaBlock->addSingleInput("set medium", false, "TODO");
 }
 

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -78,7 +78,7 @@ static void setBaseGeometryInputs(bool includeMediaBlock = true) {
     geomBlockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.");
     geomBlockInput->addSingleInput("name", true, "The user-declared unique name of this geometry. This is the name you may refer to elsewhere in the input file");
 
-    if(includeMediaBlock) {
+    if (includeMediaBlock) {
         shared_ptr<EGS_BlockInput> mediaBlock = geomBlockInput->addBlockInput("media input");
         mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
         mediaBlock->addSingleInput("set medium", false, "2, 3 or 4 integers defining the medium for a region or range of regions.\nFor 2: region #, medium index from the media list for this geometry (starts at 0). For 3: start region, stop region, medium index. For 4: Same as 3, plus a step size for the region range.\nNeglect this input for a homogeneous geometry of the first medium in the media list. Repeat this input to specify each medium.");

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -81,7 +81,7 @@ static void setBaseGeometryInputs(bool includeMediaBlock = true) {
     if(includeMediaBlock) {
         shared_ptr<EGS_BlockInput> mediaBlock = geomBlockInput->addBlockInput("media input");
         mediaBlock->addSingleInput("media", true, "A list of media that are used in this geometry");
-        mediaBlock->addSingleInput("set medium", false, "TODO");
+        mediaBlock->addSingleInput("set medium", false, "2, 3 or 4 integers defining the medium for a region or range of regions.\nFor 2: region #, medium index from the media list for this geometry (starts at 0). For 3: start region, stop region, medium index. For 4: Same as 3, plus a step size for the region range.\nNeglect this input for a homogeneous geometry of the first medium in the media list. Repeat this input to specify each medium.");
     }
 }
 

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -59,11 +59,11 @@ static void setBaseSourceInputs(bool isSimpleSource = true, bool includeSpectrum
     srcBlockInput->addSingleInput("library", true, "The type of source, loaded by shared library in egs++/dso.");
     srcBlockInput->addSingleInput("name", true, "The user-declared unique name of this source. This is the name you may refer to elsewhere in the input file");
 
-    if(isSimpleSource) {
+    if (isSimpleSource) {
         includeSpectrumBlock = true;
         srcBlockInput->addSingleInput("charge", true, "The type of particle to emit from the source, as defined by the charge. Use 0 for photons, -1 for electrons and 1 for positrons.", {"0", "1", "-1"});
     }
-    if(includeSpectrumBlock) {
+    if (includeSpectrumBlock) {
         shared_ptr<EGS_BlockInput> specBlock = srcBlockInput->addBlockInput("spectrum");
         auto typePtr = specBlock->addSingleInput("type", true, "The type of energy distribution for the spectrum.", {"monoenergetic", "Gaussian", "Double Gaussian", "uniform", "tabulated spectrum", "radionuclide"});
 
@@ -92,7 +92,7 @@ static void setBaseSourceInputs(bool isSimpleSource = true, bool includeSpectrum
         maxEPtr->addDependency(rangePtr, "", true);
         rangePtr->addDependency(minEPtr, "", true);
         rangePtr->addDependency(maxEPtr, "", true);
-        
+
         // Tabulated
         auto specFilePtr = specBlock->addSingleInput("spectrum file", false, "The full file path to the spectrum file. See documentation for the format of the file.");
         specFilePtr->addDependency(typePtr, "tabulated spectrum");

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -43,6 +43,7 @@
 #include "egs_vector.h"
 #include "egs_object_factory.h"
 #include "egs_functions.h"
+#include "egs_input_struct.h"
 
 #include <string>
 #include <iostream>
@@ -52,6 +53,69 @@ using namespace std;
 
 class EGS_Input;
 class EGS_RandomGenerator;
+
+static shared_ptr<EGS_BlockInput> srcBlockInput = make_shared<EGS_BlockInput>("source");
+static void setBaseSourceInputs(bool isSimpleSource = true, bool includeSpectrumBlock = true) {
+    srcBlockInput->addSingleInput("library", true, "The type of source, loaded by shared library in egs++/dso.");
+    srcBlockInput->addSingleInput("name", true, "The user-declared unique name of this source. This is the name you may refer to elsewhere in the input file");
+
+    if(isSimpleSource) {
+        includeSpectrumBlock = true;
+        srcBlockInput->addSingleInput("charge", true, "The type of particle to emit from the source, as defined by the charge. Use 0 for photons, -1 for electrons and 1 for positrons.");
+    }
+    if(includeSpectrumBlock) {
+        shared_ptr<EGS_BlockInput> specBlock = srcBlockInput->addBlockInput("spectrum");
+        auto typePtr = specBlock->addSingleInput("type", true, "The type of energy distribution for the spectrum.", {"monoenergetic", "Gaussian", "Double Gaussian", "uniform", "tabulated spectrum", "radionuclide"});
+
+        // Monoenergetic
+        specBlock->addSingleInput("energy", false, "The kinetic energy of the source particles in MeV.")->addDependency(typePtr, "monoenergetic");
+
+        // Gaussian & double Gaussian
+        specBlock->addSingleInput("mean energy", false, "The mean kinetic energy of the source particles in MeV.")->addDependency(typePtr, "Gaussian");
+        auto sigmaPtr = specBlock->addSingleInput("sigma", false, "The sigma of the spectrum. For a double Gaussian, input two values.");
+        sigmaPtr->addDependency(typePtr, "Gaussian");
+        sigmaPtr->addDependency(typePtr, "Double Gaussian");
+        auto fwhmPtr = specBlock->addSingleInput("fwhm", false, "The full-width-at-half-maximum of the spectrum. For a double Gaussian, input two values.");
+        fwhmPtr->addDependency(typePtr, "Gaussian");
+        fwhmPtr->addDependency(typePtr, "Double Gaussian");
+        fwhmPtr->addDependency(sigmaPtr, "", true);
+        sigmaPtr->addDependency(fwhmPtr, "", true);
+
+        // Uniform
+        auto rangePtr = specBlock->addSingleInput("range", false, "The minimum and maximum energy for the spectrum, in MeV.");
+        rangePtr->addDependency(typePtr, "uniform");
+        auto minEPtr = specBlock->addSingleInput("minimum energy", false, "The minimum energy for the spectrum, in MeV.");
+        minEPtr->addDependency(typePtr, "uniform");
+        auto maxEPtr = specBlock->addSingleInput("maximum energy", false, "The maximum energy for the spectrum, in MeV.");
+        maxEPtr->addDependency(typePtr, "uniform");
+        minEPtr->addDependency(rangePtr, "", true);
+        maxEPtr->addDependency(rangePtr, "", true);
+        rangePtr->addDependency(minEPtr, "", true);
+        rangePtr->addDependency(maxEPtr, "", true);
+        
+        // Tabulated
+        auto specFilePtr = specBlock->addSingleInput("spectrum file", false, "The full file path to the spectrum file. See documentation for the format of the file.");
+        specFilePtr->addDependency(typePtr, "tabulated spectrum");
+        auto modePtr = specBlock->addSingleInput("spectrum mode", false, "The mode number that denotes how to create the spectrum. Use 0 for histogram counts/bin, 1 for counts/MeV, 2 for a line spectrum and 3 for an interpolated spectrum.");
+        modePtr->addDependency(typePtr, "tabulated spectrum");
+        auto energiesPtr = specBlock->addSingleInput("energies", false, "A list of energies for the spectrum, in MeV. When applicable, this is the upper edge of the bin.");
+        energiesPtr->addDependency(typePtr, "tabulated spectrum");
+        auto probsPtr = specBlock->addSingleInput("probabilities", false, "A list of probabilities for the spectrum. Does not need to be normalized.");
+        probsPtr->addDependency(typePtr, "tabulated spectrum");
+        modePtr->addDependency(specFilePtr, "", true);
+        energiesPtr->addDependency(specFilePtr, "", true);
+        probsPtr->addDependency(specFilePtr, "", true);
+
+        // Radionuclide
+        specBlock->addSingleInput("nuclide", true, "The name of the nuclide to model, e.g. Co-60 or Tc-99m. If the 'ensdf file' input is not specified, then the ENSDF file will be searched for as $HEN_HOUSE/spectra/lnhb/ensdf/nuclide.txt, where nuclide is the text you input. Note that a radionuclide spectrum is ONLY compatible with a radionuclide source.")->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("ensdf file", false, "The full path to the ENSDF file to use.")->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("relative activity", false, "If multiple radionuclide spectra are specified for a single radionuclide source, this is the relative weight of this spectrum. Defaults to 1.")->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("atomic relaxations", false, "The model to use for atomic relaxations resulting from radionuclide decay. Defaults to EADL.", {"eadl", "ensdf", "off"})->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("output beta spectra", false, "Whether or not to output as files the beta spectra that are used for sampling beta decay energies. Defaults to No.", {"yes", "no"})->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("alpha scoring", false, "The model to use for scoring alpha particles during radionuclide decay. Defaults to Discard.", {"local", "discard"})->addDependency(typePtr, "radionuclide");
+        specBlock->addSingleInput("extra transition approximation", false, "Whether or not to use the option that automatically balances transition intensities. Defaults to Off.", {"on","off"})->addDependency(typePtr, "radionuclide");
+    }
+}
 
 /*! \brief Base source class. All particle sources must be derived from
   this class.

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -61,7 +61,7 @@ static void setBaseSourceInputs(bool isSimpleSource = true, bool includeSpectrum
 
     if(isSimpleSource) {
         includeSpectrumBlock = true;
-        srcBlockInput->addSingleInput("charge", true, "The type of particle to emit from the source, as defined by the charge. Use 0 for photons, -1 for electrons and 1 for positrons.");
+        srcBlockInput->addSingleInput("charge", true, "The type of particle to emit from the source, as defined by the charge. Use 0 for photons, -1 for electrons and 1 for positrons.", {"0", "1", "-1"});
     }
     if(includeSpectrumBlock) {
         shared_ptr<EGS_BlockInput> specBlock = srcBlockInput->addBlockInput("spectrum");

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -42,7 +42,13 @@ EGS_InputStruct::EGS_InputStruct() {}
 
 EGS_InputStruct::~EGS_InputStruct() {}
 
-void EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
+shared_ptr<EGS_BlockInput> EGS_InputStruct::addBlockInput(string blockTit, bool isReq) {
+    blockInputs.push_back(make_shared<EGS_BlockInput>(blockTit, isReq, nullptr));
+
+    return blockInputs.back();
+}
+
+shared_ptr<EGS_BlockInput> EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
     blockInputs.push_back(block);
 }
 
@@ -52,6 +58,16 @@ void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) 
 
 vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
     return blockInputs;
+}
+
+shared_ptr<EGS_BlockInput> EGS_InputStruct::getBlockInput(string title) {
+    for(auto &block: blockInputs) {
+        if(egsEquivStr(block->getTitle(), title)) {
+            return block;
+        }
+    }
+
+    return nullptr;
 }
 
 shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, string libraryName) {
@@ -108,6 +124,13 @@ shared_ptr<EGS_SingleInput> EGS_BlockInput::addSingleInput(string inputTag, bool
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::addBlockInput(string blockTit, bool isReq) {
     blockInputs.push_back(make_shared<EGS_BlockInput>(blockTit, isReq, shared_from_this()));
+
+    return blockInputs.back();
+}
+
+shared_ptr<EGS_BlockInput> EGS_BlockInput::addBlockInput(shared_ptr<EGS_BlockInput> block) {
+    block->setParent(shared_from_this());
+    blockInputs.push_back(block);
 
     return blockInputs.back();
 }
@@ -297,6 +320,10 @@ bool EGS_SingleInput::getRequired() {
 
 const vector<string> EGS_SingleInput::getValues() {
     return values;
+}
+
+void EGS_SingleInput::setValues(const vector<string> vals) {
+    values = vals;
 }
 
 string EGS_SingleInput::getDescription() {

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -42,6 +42,30 @@ EGS_InputStruct::EGS_InputStruct() {}
 
 EGS_InputStruct::~EGS_InputStruct() {}
 
+void EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
+    blockInputs.push_back(block);
+}
+
+void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) {
+    egsInformation("testA EGS_InputStruct::addBlockInputs\n");
+    blockInputs.insert(blockInputs.end(), blocks.begin(), blocks.end());
+}
+
+shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, string libraryName) {
+    // Loop through each input block in the structure to find the library with
+    // the matching name
+    egsInformation("testA EGS_InputStruct::getLibraryBlock\n");
+    shared_ptr<EGS_BlockInput> libraryBlock;
+    for(auto& block : blockInputs) {
+        libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
+        egsInformation("testB EGS_InputStruct::getLibraryBlock\n");
+        if(libraryBlock) {
+            break;
+        }
+    }
+    return libraryBlock;
+}
+
 EGS_BlockInput::EGS_BlockInput() {}
 
 EGS_BlockInput::EGS_BlockInput(string blockTit, bool isReq, shared_ptr<EGS_BlockInput> par) {
@@ -97,6 +121,32 @@ void EGS_BlockInput::setParent(shared_ptr<EGS_BlockInput> par) {
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
     return parent;
+}
+
+shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
+    shared_ptr<EGS_BlockInput> libraryBlock(new EGS_BlockInput);
+    egsInformation("test EGS_BlockInput::getLibraryBlock\n");
+
+    // First search the singleInputs for the library name
+    // only if the block title matches (e.g. it's a geometry, or a source)
+    if(this->getTitle() == blockTitle) {
+        egsInformation("test2 EGS_BlockInput::getLibraryBlock\n");
+        for(auto& inp : singleInputs) {
+            if(inp.getAttribute() == libraryName) {
+                egsInformation("test3 EGS_BlockInput::getLibraryBlock\n");
+                return shared_ptr<EGS_BlockInput>(this);
+            }
+        }
+    }
+
+    // If not found, go through input blocks
+    for(auto& block : blockInputs) {
+        libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
+        if(libraryBlock) {
+            egsInformation("test4 EGS_BlockInput::getLibraryBlock\n");
+            return libraryBlock;
+        }
+    }
 }
 
 EGS_SingleInput::EGS_SingleInput() {}

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -135,6 +135,20 @@ vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs() {
     return blockInputs;
 }
 
+vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs(string title) {
+    if(egsEquivStr(this->getTitle(), title)) {
+        return blockInputs;
+    } else {
+        for(auto &block: blockInputs) {
+            if(egsEquivStr(block->getTitle(), title)) {
+                return block->getBlockInputs();
+            }
+        }
+    }
+
+    return {};
+}
+
 shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string inputTag) {
     for(auto& inp : singleInputs) {
         // TODO: this assumes unique inputTag
@@ -255,9 +269,10 @@ EGS_SingleInput::EGS_SingleInput(string inputTag, bool isReq, const string desc,
 
 EGS_SingleInput::~EGS_SingleInput() {}
 
-void EGS_SingleInput::addDependency(shared_ptr<EGS_SingleInput> inp, string val) {
+void EGS_SingleInput::addDependency(shared_ptr<EGS_SingleInput> inp, string val, bool isAntiDependency) {
     dependencyInp.push_back(inp);
     dependencyVal.push_back(val);
+    dependencyAnti.push_back(isAntiDependency);
 }
 
 vector<shared_ptr<EGS_SingleInput>> EGS_SingleInput::getDependencyInp() {
@@ -266,6 +281,10 @@ vector<shared_ptr<EGS_SingleInput>> EGS_SingleInput::getDependencyInp() {
 
 vector<string> EGS_SingleInput::getDependencyVal() {
     return dependencyVal;
+}
+
+vector<bool> EGS_SingleInput::getDependencyAnti() {
+    return dependencyAnti;
 }
 
 string EGS_SingleInput::getTag() {

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -63,8 +63,8 @@ vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
 }
 
 shared_ptr<EGS_BlockInput> EGS_InputStruct::getBlockInput(string title) {
-    for(auto &block: blockInputs) {
-        if(egsEquivStr(block->getTitle(), title)) {
+    for (auto &block: blockInputs) {
+        if (egsEquivStr(block->getTitle(), title)) {
             return block;
         }
     }
@@ -76,9 +76,9 @@ shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, s
     // Loop through each input block in the structure to find the library with
     // the matching name
     auto libraryBlock = make_shared<EGS_BlockInput>();
-    for(auto& block : blockInputs) {
+    for (auto &block : blockInputs) {
         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
-        if(libraryBlock) {
+        if (libraryBlock) {
             break;
         }
     }
@@ -90,15 +90,15 @@ vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
     // library options that match the input block type
     // E.g. find all the geometry libraries
     vector<string> libOptions;
-    for(auto& block : blockInputs) {
+    for (auto &block : blockInputs) {
 
         // We only search the 2nd-level blocks
         // i.e. don't look at the geometry definition block, look at the geometries
-        for(auto& block2 : block->getBlockInputs()) {
-            if(block2 && (block2->getTitle() == blockTitle)) {
+        for (auto &block2 : block->getBlockInputs()) {
+            if (block2 && (block2->getTitle() == blockTitle)) {
                 vector<string> libAr = block2->getSingleInput("library")->getValues();
-                for(auto& lib : libAr) {
-                    if(lib.size() > 0) {
+                for (auto &lib : libAr) {
+                    if (lib.size() > 0) {
                         libOptions.push_back(lib);
                     }
                 }
@@ -108,15 +108,15 @@ vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
 
     // If nothing was found on the 2nd level blocks, search the top level ones
     // This is the case for shapes
-    if(libOptions.size() < 1) {
-        for(auto& block : blockInputs) {
+    if (libOptions.size() < 1) {
+        for (auto &block : blockInputs) {
 
-            if(block && (block->getTitle() == blockTitle ||
-                // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
-        (egsEquivStr(block->getTitle(), "shape") && (egsEquivStr(blockTitle, "target shape") || egsEquivStr(blockTitle, "source shape"))))) {
+            if (block && (block->getTitle() == blockTitle ||
+                          // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
+                          (egsEquivStr(block->getTitle(), "shape") && (egsEquivStr(blockTitle, "target shape") || egsEquivStr(blockTitle, "source shape"))))) {
                 vector<string> libAr = block->getSingleInput("library")->getValues();
-                for(auto& lib : libAr) {
-                    if(lib.size() > 0) {
+                for (auto &lib : libAr) {
+                    if (lib.size() > 0) {
                         libOptions.push_back(lib);
                     }
                 }
@@ -169,14 +169,15 @@ vector<shared_ptr<EGS_SingleInput>> EGS_BlockInput::getSingleInputs() {
 }
 
 vector<shared_ptr<EGS_SingleInput>> EGS_BlockInput::getSingleInputs(string title) {
-    if(egsEquivStr(blockTitle, title) ||
-        // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
-        (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
+    if (egsEquivStr(blockTitle, title) ||
+            // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
+            (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
         return singleInputs;
-    } else {
-        for(auto &block: blockInputs) {
+    }
+    else {
+        for (auto &block: blockInputs) {
             auto inp = block->getSingleInputs(title);
-            if(inp.size() > 0) {
+            if (inp.size() > 0) {
                 return inp;
             }
         }
@@ -190,13 +191,14 @@ vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs() {
 }
 
 vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs(string title) {
-    if(egsEquivStr(this->getTitle(), title) ||
-        // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
-        (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
+    if (egsEquivStr(this->getTitle(), title) ||
+            // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
+            (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
         return blockInputs;
-    } else {
-        for(auto &block: blockInputs) {
-            if(egsEquivStr(block->getTitle(), title)) {
+    }
+    else {
+        for (auto &block: blockInputs) {
+            if (egsEquivStr(block->getTitle(), title)) {
                 return block->getBlockInputs();
             }
         }
@@ -206,17 +208,17 @@ vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs(string title) 
 }
 
 shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string inputTag) {
-    for(auto& inp : singleInputs) {
+    for (auto &inp : singleInputs) {
         // TODO: this assumes unique inputTag
-        if(inp && egsEquivStr(inp->getTag(), inputTag)) {
+        if (inp && egsEquivStr(inp->getTag(), inputTag)) {
             return inp;
         }
     }
 
     // If not found in the top level, search recursively
-    for(auto &block: blockInputs) {
+    for (auto &block: blockInputs) {
         auto inp = block->getSingleInput(inputTag);
-        if(inp) {
+        if (inp) {
             return inp;
         }
     }
@@ -226,22 +228,22 @@ shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string inputTag) {
 
 shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string inputTag, string title) {
     // First search the top-level input block
-    if(egsEquivStr(blockTitle, title) ||
-        // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
-        (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
-        for(auto &inp: singleInputs) {
+    if (egsEquivStr(blockTitle, title) ||
+            // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
+            (egsEquivStr(blockTitle, "shape") && (egsEquivStr(title, "target shape") || egsEquivStr(title, "source shape")))) {
+        for (auto &inp: singleInputs) {
             // TODO: this assumes unique inputTag
-            if(inp && egsEquivStr(inp->getTag(), inputTag)) {
+            if (inp && egsEquivStr(inp->getTag(), inputTag)) {
                 return inp;
             }
         }
     }
 
     // If not found, go through input lower level blocks
-    for(auto &block: blockInputs) {
-        if(egsEquivStr(block->getTitle(), title)) {
+    for (auto &block: blockInputs) {
+        if (egsEquivStr(block->getTitle(), title)) {
             auto inp = block->getSingleInput(inputTag, title);
-            if(inp) {
+            if (inp) {
                 return inp;
             }
         }
@@ -251,19 +253,22 @@ shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string inputTag, stri
 }
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getBlockInput(string title) {
-    if(egsEquivStr(blockTitle, title)) {
+    if (egsEquivStr(blockTitle, title)) {
         return shared_from_this();
-    } else {
-        for(auto &block: blockInputs) {
-            if(egsEquivStr(block->getTitle(), title)) {
+    }
+    else {
+        for (auto &block: blockInputs) {
+            if (egsEquivStr(block->getTitle(), title)) {
                 return block;
-            // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
-            } else if(egsEquivStr(block->getTitle(), "shape") && (egsEquivStr(title, "source shape") || egsEquivStr(title, "target shape"))) {
+                // Handle the special case where "target shape" and "source shape" for egs_collimated_source need to match just "shape".
+            }
+            else if (egsEquivStr(block->getTitle(), "shape") && (egsEquivStr(title, "source shape") || egsEquivStr(title, "target shape"))) {
                 return block;
-            } else {
+            }
+            else {
                 // Do a recursive search
                 auto foundBlock = block->getBlockInput(title);
-                if(foundBlock) {
+                if (foundBlock) {
                     return foundBlock;
                 }
             }
@@ -283,23 +288,24 @@ shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
     // First search the singleInputs for the library name
-    for(auto &inp: singleInputs) {
-        if(!inp) {
+    for (auto &inp: singleInputs) {
+        if (!inp) {
             continue;
         }
-        if(egsEquivStr(inp->getTag(), "library")) {
-            if(inp->getValues().size() && egsEquivStr(inp->getValues().front(), libraryName)) {
+        if (egsEquivStr(inp->getTag(), "library")) {
+            if (inp->getValues().size() && egsEquivStr(inp->getValues().front(), libraryName)) {
                 return shared_from_this();
-            } else {
+            }
+            else {
                 break;
             }
         }
     }
 
     // If not found, go through input blocks
-    for(auto &block: blockInputs) {
+    for (auto &block: blockInputs) {
         auto libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
-        if(libraryBlock) {
+        if (libraryBlock) {
             return libraryBlock;
         }
     }
@@ -307,11 +313,11 @@ shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, st
 }
 
 bool EGS_BlockInput::contains(string inputTag) {
-    for(auto &inp: singleInputs) {
-        if(!inp) {
+    for (auto &inp: singleInputs) {
+        if (!inp) {
             continue;
         }
-        if(egsEquivStr(inp->getTag(), inputTag)) {
+        if (egsEquivStr(inp->getTag(), inputTag)) {
             return true;
         }
     }

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -1,0 +1,136 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ input struct
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2019
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+
+/*! \file egs_input_struct.cpp
+ *  \brief The input struct cpp file
+ *  \RT
+ *
+ */
+
+#include "egs_functions.h"
+#include "egs_input_struct.h"
+
+EGS_InputStruct::EGS_InputStruct() {}
+
+EGS_InputStruct::~EGS_InputStruct() {}
+
+EGS_BlockInput::EGS_BlockInput() {}
+
+EGS_BlockInput::EGS_BlockInput(string blockTit, bool isReq, shared_ptr<EGS_BlockInput> par) {
+    blockTitle = blockTit;
+    isRequired = isReq;
+    parent = par;
+}
+
+EGS_BlockInput::~EGS_BlockInput() {}
+
+void EGS_BlockInput::setTitle(string blockTit) {
+    blockTitle = blockTit;
+}
+
+string EGS_BlockInput::getTitle() {
+    return blockTitle;
+}
+
+void EGS_BlockInput::addSingleInput(string attr, bool isReq, const string desc, const vector<string> vals) {
+    singleInputs.push_back(EGS_SingleInput(attr, isReq, desc, vals));
+}
+
+shared_ptr<EGS_BlockInput> EGS_BlockInput::addBlockInput(string blockTit, bool isReq) {
+    egsInformation("addBlockInput\n");
+    blockInputs.push_back(make_shared<EGS_BlockInput>(blockTit, isReq, shared_from_this()));
+    egsInformation("addBlockInput2\n");
+
+    return blockInputs.back();
+}
+
+vector<EGS_SingleInput> EGS_BlockInput::getSingleInputs() {
+    return singleInputs;
+}
+
+vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs() {
+    return blockInputs;
+}
+
+EGS_SingleInput EGS_BlockInput::getSingleInput(string attr) {
+    for(auto& inp : singleInputs) {
+        // TODO: this assumes unique attr
+        if(inp.getAttribute() == attr) {
+            return inp;
+        }
+    }
+
+    return EGS_SingleInput();
+}
+
+void EGS_BlockInput::setParent(shared_ptr<EGS_BlockInput> par) {
+    parent = par;
+}
+
+shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
+    return parent;
+}
+
+EGS_SingleInput::EGS_SingleInput() {}
+
+EGS_SingleInput::EGS_SingleInput(string attr, bool isReq, const string desc, const vector<string> vals) {
+    attribute = attr;
+    isRequired = isReq;
+    description = desc;
+    values = vals;
+}
+
+EGS_SingleInput::~EGS_SingleInput() {}
+
+void EGS_SingleInput::addRequirement(string attr, string val) {
+
+}
+
+vector<EGS_SingleInput> EGS_SingleInput::getDependents() {
+
+}
+
+string EGS_SingleInput::getAttribute() {
+    return attribute;
+}
+
+bool EGS_SingleInput::getRequired() {
+    return isRequired;
+}
+
+const vector<string> EGS_SingleInput::getValues() {
+    return values;
+}
+
+
+
+
+

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -51,19 +51,37 @@ void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) 
     blockInputs.insert(blockInputs.end(), blocks.begin(), blocks.end());
 }
 
+vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
+    return blockInputs;
+}
+
 shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, string libraryName) {
     // Loop through each input block in the structure to find the library with
     // the matching name
-    egsInformation("testA EGS_InputStruct::getLibraryBlock\n");
-    shared_ptr<EGS_BlockInput> libraryBlock;
+    auto libraryBlock = make_shared<EGS_BlockInput>();
     for(auto& block : blockInputs) {
         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
-        egsInformation("testB EGS_InputStruct::getLibraryBlock\n");
         if(libraryBlock) {
             break;
         }
     }
     return libraryBlock;
+}
+
+vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
+    // Loop through each input block in the structure to find all the possible
+    // library options that match the input block type
+    // E.g. find all the geometry libraries
+    vector<string> libOptions;
+    for(auto& block : blockInputs) {
+        if(block && block->getTitle() == blockTitle) {
+            string lib = block->getSingleInput("library")->getValues().front();
+            if(lib.size() > 0) {
+                libOptions.push_back(lib);
+            }
+        }
+    }
+    return libOptions;
 }
 
 EGS_BlockInput::EGS_BlockInput() {}
@@ -85,18 +103,17 @@ string EGS_BlockInput::getTitle() {
 }
 
 void EGS_BlockInput::addSingleInput(string attr, bool isReq, const string desc, const vector<string> vals) {
-    singleInputs.push_back(EGS_SingleInput(attr, isReq, desc, vals));
+    singleInputs.push_back(make_shared<EGS_SingleInput>(attr, isReq, desc, vals));
 }
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::addBlockInput(string blockTit, bool isReq) {
     egsInformation("addBlockInput\n");
     blockInputs.push_back(make_shared<EGS_BlockInput>(blockTit, isReq, shared_from_this()));
-    egsInformation("addBlockInput2\n");
 
     return blockInputs.back();
 }
 
-vector<EGS_SingleInput> EGS_BlockInput::getSingleInputs() {
+vector<shared_ptr<EGS_SingleInput>> EGS_BlockInput::getSingleInputs() {
     return singleInputs;
 }
 
@@ -104,15 +121,15 @@ vector<shared_ptr<EGS_BlockInput>> EGS_BlockInput::getBlockInputs() {
     return blockInputs;
 }
 
-EGS_SingleInput EGS_BlockInput::getSingleInput(string attr) {
+shared_ptr<EGS_SingleInput> EGS_BlockInput::getSingleInput(string attr) {
     for(auto& inp : singleInputs) {
         // TODO: this assumes unique attr
-        if(inp.getAttribute() == attr) {
+        if(inp && inp->getAttribute() == attr) {
             return inp;
         }
     }
 
-    return EGS_SingleInput();
+    return nullptr;
 }
 
 void EGS_BlockInput::setParent(shared_ptr<EGS_BlockInput> par) {
@@ -124,29 +141,44 @@ shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
 }
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
-    shared_ptr<EGS_BlockInput> libraryBlock(new EGS_BlockInput);
-    egsInformation("test EGS_BlockInput::getLibraryBlock\n");
 
     // First search the singleInputs for the library name
     // only if the block title matches (e.g. it's a geometry, or a source)
     if(this->getTitle() == blockTitle) {
-        egsInformation("test2 EGS_BlockInput::getLibraryBlock\n");
-        for(auto& inp : singleInputs) {
-            if(inp.getAttribute() == libraryName) {
-                egsInformation("test3 EGS_BlockInput::getLibraryBlock\n");
-                return shared_ptr<EGS_BlockInput>(this);
+        for(auto &inp: singleInputs) {
+            if(!inp) {
+                continue;
+            }
+            if(egsEquivStr(inp->getAttribute(), "library")) {
+                if(inp->getValues().size() && egsEquivStr(inp->getValues().front(), libraryName)) {
+                    return shared_from_this();
+                } else {
+                    break;
+                }
             }
         }
     }
 
     // If not found, go through input blocks
-    for(auto& block : blockInputs) {
-        libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
+    for(auto &block: blockInputs) {
+        auto libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
         if(libraryBlock) {
-            egsInformation("test4 EGS_BlockInput::getLibraryBlock\n");
             return libraryBlock;
         }
     }
+    return nullptr;
+}
+
+bool EGS_BlockInput::contains(string inputTag) {
+    for(auto &inp: singleInputs) {
+        if(!inp) {
+            continue;
+        }
+        if(egsEquivStr(inp->getAttribute(), inputTag)) {
+            return true;
+        }
+    }
+    return false;
 }
 
 EGS_SingleInput::EGS_SingleInput() {}
@@ -178,6 +210,10 @@ bool EGS_SingleInput::getRequired() {
 
 const vector<string> EGS_SingleInput::getValues() {
     return values;
+}
+
+string EGS_SingleInput::getDescription() {
+    return description;
 }
 
 

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -64,7 +64,6 @@ vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
 
 shared_ptr<EGS_BlockInput> EGS_InputStruct::getBlockInput(string title) {
     for(auto &block: blockInputs) {
-        egsInformation("test struct getBlockInput %s\n", block->getTitle().c_str());
         if(egsEquivStr(block->getTitle(), title)) {
             return block;
         }
@@ -92,7 +91,7 @@ vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
     // E.g. find all the geometry libraries
     vector<string> libOptions;
     for(auto& block : blockInputs) {
-        egsInformation("test getLibOpt %s %s\n",block->getTitle().c_str(),blockTitle.c_str() );
+
         // We only search the 2nd-level blocks
         // i.e. don't look at the geometry definition block, look at the geometries
         for(auto& block2 : block->getBlockInputs()) {
@@ -111,7 +110,7 @@ vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
     // This is the case for shapes
     if(libOptions.size() < 1) {
         for(auto& block : blockInputs) {
-            egsInformation("test getLibOpt2 %s %s\n",block->getTitle().c_str(),blockTitle.c_str() );
+
             if(block && block->getTitle() == blockTitle) {
                 vector<string> libAr = block->getSingleInput("library")->getValues();
                 for(auto& lib : libAr) {

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -42,32 +42,6 @@ EGS_InputStruct::EGS_InputStruct() {}
 
 EGS_InputStruct::~EGS_InputStruct() {}
 
-void EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
-    blockInputs.push_back(block);
-}
-
-void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) {
-    egsInformation("testA EGS_InputStruct::addBlockInputs\n");
-    blockInputs.insert(blockInputs.end(), blocks.begin(), blocks.end());
-}
-
-shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, string libraryName) {
-    // Loop through each input block in the structure to find the library with
-    // the matching name
-    egsInformation("testA EGS_InputStruct::getLibraryBlock\n");
-    //shared_ptr<EGS_BlockInput> libraryBlock;
-    //shared_ptr<EGS_BlockInput> libraryBlock = make_shared<EGS_BlockInput>("geometry");
-    //auto libraryBlock = make_shared<EGS_BlockInput>();
-//     for(auto& block : blockInputs) {
-//         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
-//         egsInformation("testB EGS_InputStruct::getLibraryBlock\n");
-//         if(libraryBlock) {
-//             break;
-//         }
-//     }
-    return nullptr;
-}
-
 EGS_BlockInput::EGS_BlockInput() {}
 
 EGS_BlockInput::EGS_BlockInput(string blockTit, bool isReq, shared_ptr<EGS_BlockInput> par) {
@@ -123,35 +97,6 @@ void EGS_BlockInput::setParent(shared_ptr<EGS_BlockInput> par) {
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
     return parent;
-}
-
-shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
-    egsInformation("test EGS_BlockInput::getLibraryBlock\n");
-    //shared_ptr<EGS_BlockInput> libraryBlock(new EGS_BlockInput);
-    auto libraryBlock = make_shared<EGS_BlockInput>();
-
-
-//     // First search the singleInputs for the library name
-//     // only if the block title matches (e.g. it's a geometry, or a source)
-//     if(this->getTitle() == blockTitle) {
-//         egsInformation("test2 EGS_BlockInput::getLibraryBlock\n");
-//         for(auto& inp : singleInputs) {
-//             if(inp.getAttribute() == libraryName) {
-//                 egsInformation("test3 EGS_BlockInput::getLibraryBlock\n");
-//                 return shared_ptr<EGS_BlockInput>(this);
-//             }
-//         }
-//     }
-//
-//     // If not found, go through input blocks
-//     for(auto& block : blockInputs) {
-//         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
-//         if(libraryBlock) {
-//             egsInformation("test4 EGS_BlockInput::getLibraryBlock\n");
-//             return libraryBlock;
-//         }
-//     }
-    return libraryBlock;
 }
 
 EGS_SingleInput::EGS_SingleInput() {}

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -42,6 +42,32 @@ EGS_InputStruct::EGS_InputStruct() {}
 
 EGS_InputStruct::~EGS_InputStruct() {}
 
+void EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
+    blockInputs.push_back(block);
+}
+
+void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) {
+    egsInformation("testA EGS_InputStruct::addBlockInputs\n");
+    blockInputs.insert(blockInputs.end(), blocks.begin(), blocks.end());
+}
+
+shared_ptr<EGS_BlockInput> EGS_InputStruct::getLibraryBlock(string blockTitle, string libraryName) {
+    // Loop through each input block in the structure to find the library with
+    // the matching name
+    egsInformation("testA EGS_InputStruct::getLibraryBlock\n");
+    //shared_ptr<EGS_BlockInput> libraryBlock;
+    //shared_ptr<EGS_BlockInput> libraryBlock = make_shared<EGS_BlockInput>("geometry");
+    //auto libraryBlock = make_shared<EGS_BlockInput>();
+//     for(auto& block : blockInputs) {
+//         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
+//         egsInformation("testB EGS_InputStruct::getLibraryBlock\n");
+//         if(libraryBlock) {
+//             break;
+//         }
+//     }
+    return nullptr;
+}
+
 EGS_BlockInput::EGS_BlockInput() {}
 
 EGS_BlockInput::EGS_BlockInput(string blockTit, bool isReq, shared_ptr<EGS_BlockInput> par) {
@@ -97,6 +123,35 @@ void EGS_BlockInput::setParent(shared_ptr<EGS_BlockInput> par) {
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
     return parent;
+}
+
+shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
+    egsInformation("test EGS_BlockInput::getLibraryBlock\n");
+    //shared_ptr<EGS_BlockInput> libraryBlock(new EGS_BlockInput);
+    auto libraryBlock = make_shared<EGS_BlockInput>();
+
+
+//     // First search the singleInputs for the library name
+//     // only if the block title matches (e.g. it's a geometry, or a source)
+//     if(this->getTitle() == blockTitle) {
+//         egsInformation("test2 EGS_BlockInput::getLibraryBlock\n");
+//         for(auto& inp : singleInputs) {
+//             if(inp.getAttribute() == libraryName) {
+//                 egsInformation("test3 EGS_BlockInput::getLibraryBlock\n");
+//                 return shared_ptr<EGS_BlockInput>(this);
+//             }
+//         }
+//     }
+//
+//     // If not found, go through input blocks
+//     for(auto& block : blockInputs) {
+//         libraryBlock = block->getLibraryBlock(blockTitle, libraryName);
+//         if(libraryBlock) {
+//             egsInformation("test4 EGS_BlockInput::getLibraryBlock\n");
+//             return libraryBlock;
+//         }
+//     }
+    return libraryBlock;
 }
 
 EGS_SingleInput::EGS_SingleInput() {}

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -64,6 +64,7 @@ vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
 
 shared_ptr<EGS_BlockInput> EGS_InputStruct::getBlockInput(string title) {
     for(auto &block: blockInputs) {
+        egsInformation("test struct getBlockInput %s\n", block->getTitle().c_str());
         if(egsEquivStr(block->getTitle(), title)) {
             return block;
         }

--- a/HEN_HOUSE/egs++/egs_input_struct.cpp
+++ b/HEN_HOUSE/egs++/egs_input_struct.cpp
@@ -50,10 +50,18 @@ shared_ptr<EGS_BlockInput> EGS_InputStruct::addBlockInput(string blockTit, bool 
 
 shared_ptr<EGS_BlockInput> EGS_InputStruct::addBlockInput(shared_ptr<EGS_BlockInput> block) {
     blockInputs.push_back(block);
+
+    return blockInputs.back();
 }
 
 void EGS_InputStruct::addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks) {
     blockInputs.insert(blockInputs.end(), blocks.begin(), blocks.end());
+}
+
+shared_ptr<EGS_BlockInput> EGS_InputStruct::addFloatingBlock(shared_ptr<EGS_BlockInput> block) {
+    floatingBlocks.push_back(block);
+
+    return floatingBlocks.back();
 }
 
 vector<shared_ptr<EGS_BlockInput>> EGS_InputStruct::getBlockInputs() {
@@ -94,9 +102,11 @@ vector<string> EGS_InputStruct::getLibraryOptions(string blockTitle) {
         // i.e. don't look at the geometry definition block, look at the geometries
         for(auto& block2 : block->getBlockInputs()) {
             if(block2 && block2->getTitle() == blockTitle) {
-                string lib = block2->getSingleInput("library")->getValues().front();
-                if(lib.size() > 0) {
-                    libOptions.push_back(lib);
+                vector<string> libAr = block2->getSingleInput("library")->getValues();
+                for(auto& lib : libAr) {
+                    if(lib.size() > 0) {
+                        libOptions.push_back(lib);
+                    }
                 }
             }
         }
@@ -243,22 +253,18 @@ shared_ptr<EGS_BlockInput> EGS_BlockInput::getParent() {
 
 shared_ptr<EGS_BlockInput> EGS_BlockInput::getLibraryBlock(string blockTitle, string libraryName) {
     // First search the singleInputs for the library name
-    // only if the block title matches (e.g. it's a geometry, or a source)
-    // TODO: remove blockTitle from input params??
-    //if(this->getTitle() == blockTitle) {
-        for(auto &inp: singleInputs) {
-            if(!inp) {
-                continue;
-            }
-            if(egsEquivStr(inp->getTag(), "library")) {
-                if(inp->getValues().size() && egsEquivStr(inp->getValues().front(), libraryName)) {
-                    return shared_from_this();
-                } else {
-                    break;
-                }
+    for(auto &inp: singleInputs) {
+        if(!inp) {
+            continue;
+        }
+        if(egsEquivStr(inp->getTag(), "library")) {
+            if(inp->getValues().size() && egsEquivStr(inp->getValues().front(), libraryName)) {
+                return shared_from_this();
+            } else {
+                break;
             }
         }
-    //}
+    }
 
     // If not found, go through input blocks
     for(auto &block: blockInputs) {

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -53,26 +53,26 @@ class EGS_EXPORT EGS_SingleInput {
 
 public:
     EGS_SingleInput();
-    EGS_SingleInput(string attr, bool isReq, const string desc, const vector<string> vals);
-    string getAttribute();
-    bool getRequired();
+    EGS_SingleInput(string inputTag, bool isReq, const string desc, const vector<string> vals);
     ~EGS_SingleInput();
+
+    string getTag();
+    bool getRequired();
     const vector<string> getValues();
     string getDescription();
-
-protected:
-
-    void addRequirement(string attr, string value="");
-    vector<EGS_SingleInput> getDependents();
+    void addDependency(shared_ptr<EGS_SingleInput> inp, string val="");
+    vector<shared_ptr<EGS_SingleInput>> getDependencyInp();
+    vector<string> getDependencyVal();
 
 private:
 
-    vector<EGS_SingleInput> dependents;
     vector<string> requirements;
-    string attribute;
+    string tag;
     bool isRequired;
     string description;
     vector<string> values;
+    vector<shared_ptr<EGS_SingleInput>> dependencyInp;
+    vector<string> dependencyVal;
 };
 
 class EGS_EXPORT EGS_BlockInput
@@ -84,15 +84,21 @@ public:
 
     void setTitle(string blockTit);
     string getTitle();
-    void addSingleInput(string attr, bool isReq, const string desc, const vector<string> vals = vector<string>());
+    shared_ptr<EGS_SingleInput> addSingleInput(string inputTag, bool isReq, const string desc, const vector<string> vals = vector<string>());
     shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
     vector<shared_ptr<EGS_SingleInput>> getSingleInputs();
+    vector<shared_ptr<EGS_SingleInput>> getSingleInputs(string title);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
-    shared_ptr<EGS_SingleInput> getSingleInput(string attr);
+    shared_ptr<EGS_SingleInput> getSingleInput(string inputTag);
+    shared_ptr<EGS_SingleInput> getSingleInput(string inputTag, string title);
+    shared_ptr<EGS_BlockInput> getBlockInput(string title);
     void setParent(shared_ptr<EGS_BlockInput> par);
     shared_ptr<EGS_BlockInput> getParent();
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
     bool contains(string inputTag);
+    void addDependency(shared_ptr<EGS_SingleInput> inp, string val="");
+    shared_ptr<EGS_SingleInput> getDependencyInp();
+    string getDependencyVal();
 
 
 private:
@@ -103,6 +109,8 @@ private:
     string blockTitle;
     bool isRequired;
     const string desc;
+    shared_ptr<EGS_SingleInput> dependencyInp;
+    string dependencyVal;
 };
 
 class EGS_EXPORT EGS_InputStruct {

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -1,0 +1,116 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ input struct headers
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2019
+#
+#  Contributors:
+#
+#  An application has one global scope input struct object. Input blocks are
+#  then added to contain geometries or sources. Input blocks may contain single
+#  inputs.
+#
+###############################################################################
+*/
+
+
+/*! \file egs_input_struct.h
+ *  \brief The input struct header file
+ *  \RT
+ *
+ */
+
+#ifndef EGS_INPUT_STRUCT_
+#define EGS_INPUT_STRUCT_
+
+#include <vector>
+#include <string>
+#include "egs_libconfig.h"
+#include <memory>
+
+using namespace std;
+
+class EGS_EXPORT EGS_SingleInput {
+
+public:
+    EGS_SingleInput();
+    EGS_SingleInput(string attr, bool isReq, const string desc, const vector<string> vals);
+    string getAttribute();
+    bool getRequired();
+    ~EGS_SingleInput();
+    const vector<string> getValues();
+
+protected:
+
+    void addRequirement(string attr, string value="");
+    vector<EGS_SingleInput> getDependents();
+
+private:
+
+    vector<EGS_SingleInput> dependents;
+    vector<string> requirements;
+    string attribute;
+    bool isRequired;
+    string description;
+    vector<string> values;
+};
+
+class EGS_EXPORT EGS_BlockInput
+    : public std::enable_shared_from_this<EGS_BlockInput> {
+public:
+    EGS_BlockInput();
+    EGS_BlockInput(string blockTit, bool isReq = false, shared_ptr<EGS_BlockInput> par = nullptr);
+    ~EGS_BlockInput();
+
+    void setTitle(string blockTit);
+    string getTitle();
+    void addSingleInput(string attr, bool isReq, const string desc, const vector<string> vals = vector<string>());
+    shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
+    vector<EGS_SingleInput> getSingleInputs();
+    vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
+    EGS_SingleInput getSingleInput(string attr);
+    void setParent(shared_ptr<EGS_BlockInput> par);
+    shared_ptr<EGS_BlockInput> getParent();
+
+
+private:
+
+    vector<EGS_SingleInput> singleInputs;
+    vector<shared_ptr<EGS_BlockInput>> blockInputs;
+    shared_ptr<EGS_BlockInput> parent;
+    string blockTitle;
+    bool isRequired;
+    const string desc;
+};
+
+class EGS_EXPORT EGS_InputStruct {
+public:
+    EGS_InputStruct();
+    ~EGS_InputStruct();
+
+    void addBlockInput(EGS_InputStruct *parent, string blockTit, bool isReq);
+};
+
+
+#endif
+
+

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -58,6 +58,7 @@ public:
     bool getRequired();
     ~EGS_SingleInput();
     const vector<string> getValues();
+    string getDescription();
 
 protected:
 
@@ -85,17 +86,18 @@ public:
     string getTitle();
     void addSingleInput(string attr, bool isReq, const string desc, const vector<string> vals = vector<string>());
     shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
-    vector<EGS_SingleInput> getSingleInputs();
+    vector<shared_ptr<EGS_SingleInput>> getSingleInputs();
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
-    EGS_SingleInput getSingleInput(string attr);
+    shared_ptr<EGS_SingleInput> getSingleInput(string attr);
     void setParent(shared_ptr<EGS_BlockInput> par);
     shared_ptr<EGS_BlockInput> getParent();
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
+    bool contains(string inputTag);
 
 
 private:
 
-    vector<EGS_SingleInput> singleInputs;
+    vector<shared_ptr<EGS_SingleInput>> singleInputs;
     vector<shared_ptr<EGS_BlockInput>> blockInputs;
     shared_ptr<EGS_BlockInput> parent;
     string blockTitle;
@@ -111,7 +113,9 @@ public:
     void addBlockInput(shared_ptr<EGS_BlockInput> block);
     //void addBlockInput(string blockTit, bool isReq);
     void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
+    vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
+    vector<string> getLibraryOptions(string blockTitle);
 
 private:
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -90,6 +90,7 @@ public:
     EGS_SingleInput getSingleInput(string attr);
     void setParent(shared_ptr<EGS_BlockInput> par);
     shared_ptr<EGS_BlockInput> getParent();
+    shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
 
 
 private:
@@ -107,7 +108,14 @@ public:
     EGS_InputStruct();
     ~EGS_InputStruct();
 
-    void addBlockInput(EGS_InputStruct *parent, string blockTit, bool isReq);
+    void addBlockInput(shared_ptr<EGS_BlockInput> block);
+    //void addBlockInput(string blockTit, bool isReq);
+    void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
+    shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
+
+private:
+
+    vector<shared_ptr<EGS_BlockInput>> blockInputs;
 };
 
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -90,7 +90,6 @@ public:
     EGS_SingleInput getSingleInput(string attr);
     void setParent(shared_ptr<EGS_BlockInput> par);
     shared_ptr<EGS_BlockInput> getParent();
-    shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
 
 
 private:
@@ -108,14 +107,7 @@ public:
     EGS_InputStruct();
     ~EGS_InputStruct();
 
-    void addBlockInput(shared_ptr<EGS_BlockInput> block);
-    //void addBlockInput(string blockTit, bool isReq);
-    void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
-    shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
-
-private:
-
-    vector<shared_ptr<EGS_BlockInput>> blockInputs;
+    void addBlockInput(EGS_InputStruct *parent, string blockTit, bool isReq);
 };
 
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -133,7 +133,6 @@ public:
     shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
     shared_ptr<EGS_BlockInput> addBlockInput(shared_ptr<EGS_BlockInput> block);
     void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
-    shared_ptr<EGS_BlockInput> addFloatingBlock(shared_ptr<EGS_BlockInput> block);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
     shared_ptr<EGS_BlockInput> getBlockInput(string title);
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
@@ -142,7 +141,7 @@ public:
 private:
 
     vector<shared_ptr<EGS_BlockInput>> blockInputs;
-    vector<shared_ptr<EGS_BlockInput>> floatingBlocks;
+    vector<shared_ptr<EGS_BlockInput>> generalBlocks;
 };
 
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -60,7 +60,7 @@ public:
 
     string getTag();
     bool getRequired();
-    void addDependency(shared_ptr<EGS_SingleInput> inp, string val="", bool isAntiDependency = false);
+    void addDependency(shared_ptr<EGS_SingleInput> inp, string val = "", bool isAntiDependency = false);
     void addDependency(shared_ptr<EGS_BlockInput> block, bool isAntiDependency = false);
     vector<shared_ptr<EGS_SingleInput>> getDependencyInp();
     vector<string> getDependencyVal();
@@ -133,6 +133,7 @@ public:
     shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
     shared_ptr<EGS_BlockInput> addBlockInput(shared_ptr<EGS_BlockInput> block);
     void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
+    shared_ptr<EGS_BlockInput> addFloatingBlock(shared_ptr<EGS_BlockInput> block);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
     shared_ptr<EGS_BlockInput> getBlockInput(string title);
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
@@ -141,6 +142,7 @@ public:
 private:
 
     vector<shared_ptr<EGS_BlockInput>> blockInputs;
+    vector<shared_ptr<EGS_BlockInput>> floatingBlocks;
 };
 
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -60,9 +60,10 @@ public:
     bool getRequired();
     const vector<string> getValues();
     string getDescription();
-    void addDependency(shared_ptr<EGS_SingleInput> inp, string val="");
+    void addDependency(shared_ptr<EGS_SingleInput> inp, string val="", bool isAntiDependency = false);
     vector<shared_ptr<EGS_SingleInput>> getDependencyInp();
     vector<string> getDependencyVal();
+    vector<bool> getDependencyAnti();
 
 private:
 
@@ -73,6 +74,7 @@ private:
     vector<string> values;
     vector<shared_ptr<EGS_SingleInput>> dependencyInp;
     vector<string> dependencyVal;
+    vector<bool> dependencyAnti;
 };
 
 class EGS_EXPORT EGS_BlockInput
@@ -89,6 +91,7 @@ public:
     vector<shared_ptr<EGS_SingleInput>> getSingleInputs();
     vector<shared_ptr<EGS_SingleInput>> getSingleInputs(string title);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
+    vector<shared_ptr<EGS_BlockInput>> getBlockInputs(string title);
     shared_ptr<EGS_SingleInput> getSingleInput(string inputTag);
     shared_ptr<EGS_SingleInput> getSingleInput(string inputTag, string title);
     shared_ptr<EGS_BlockInput> getBlockInput(string title);

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -58,12 +58,13 @@ public:
 
     string getTag();
     bool getRequired();
-    const vector<string> getValues();
-    string getDescription();
     void addDependency(shared_ptr<EGS_SingleInput> inp, string val="", bool isAntiDependency = false);
     vector<shared_ptr<EGS_SingleInput>> getDependencyInp();
     vector<string> getDependencyVal();
     vector<bool> getDependencyAnti();
+    const vector<string> getValues();
+    void setValues(const vector<string> vals);
+    string getDescription();
 
 private:
 
@@ -88,6 +89,7 @@ public:
     string getTitle();
     shared_ptr<EGS_SingleInput> addSingleInput(string inputTag, bool isReq, const string desc, const vector<string> vals = vector<string>());
     shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
+    shared_ptr<EGS_BlockInput> addBlockInput(shared_ptr<EGS_BlockInput> block);
     vector<shared_ptr<EGS_SingleInput>> getSingleInputs();
     vector<shared_ptr<EGS_SingleInput>> getSingleInputs(string title);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
@@ -121,10 +123,11 @@ public:
     EGS_InputStruct();
     ~EGS_InputStruct();
 
-    void addBlockInput(shared_ptr<EGS_BlockInput> block);
-    //void addBlockInput(string blockTit, bool isReq);
+    shared_ptr<EGS_BlockInput> addBlockInput(string blockTit, bool isReq = false);
+    shared_ptr<EGS_BlockInput> addBlockInput(shared_ptr<EGS_BlockInput> block);
     void addBlockInputs(vector<shared_ptr<EGS_BlockInput>> blocks);
     vector<shared_ptr<EGS_BlockInput>> getBlockInputs();
+    shared_ptr<EGS_BlockInput> getBlockInput(string title);
     shared_ptr<EGS_BlockInput> getLibraryBlock(string blockTitle, string libraryName);
     vector<string> getLibraryOptions(string blockTitle);
 

--- a/HEN_HOUSE/egs++/egs_input_struct.h
+++ b/HEN_HOUSE/egs++/egs_input_struct.h
@@ -49,6 +49,8 @@
 
 using namespace std;
 
+class EGS_BlockInput;
+
 class EGS_EXPORT EGS_SingleInput {
 
 public:
@@ -59,9 +61,12 @@ public:
     string getTag();
     bool getRequired();
     void addDependency(shared_ptr<EGS_SingleInput> inp, string val="", bool isAntiDependency = false);
+    void addDependency(shared_ptr<EGS_BlockInput> block, bool isAntiDependency = false);
     vector<shared_ptr<EGS_SingleInput>> getDependencyInp();
     vector<string> getDependencyVal();
     vector<bool> getDependencyAnti();
+    shared_ptr<EGS_BlockInput> getDependencyBlock();
+    bool getDependencyBlockAnti();
     const vector<string> getValues();
     void setValues(const vector<string> vals);
     string getDescription();
@@ -76,6 +81,8 @@ private:
     vector<shared_ptr<EGS_SingleInput>> dependencyInp;
     vector<string> dependencyVal;
     vector<bool> dependencyAnti;
+    shared_ptr<EGS_BlockInput> dependencyBlock;
+    bool dependencyBlockAnti;
 };
 
 class EGS_EXPORT EGS_BlockInput

--- a/HEN_HOUSE/egs++/egs_run_control.h
+++ b/HEN_HOUSE/egs++/egs_run_control.h
@@ -40,12 +40,23 @@
 
 #include "egs_libconfig.h"
 #include "egs_timer.h"
+#include "egs_input_struct.h"
 
 #include <iostream>
 using namespace std;
 
 class EGS_Application;
 class EGS_Input;
+
+static void addRunControlBlock(shared_ptr<EGS_BlockInput> blockPtr) {
+    shared_ptr<EGS_BlockInput> runBlock = blockPtr->addBlockInput("run control");
+    runBlock->addSingleInput("ncase", true, "The number of histories to simulate.");
+    runBlock->addSingleInput("nbatch", false, "The number of batches to divide the simulation into. After each batch, a checkpoint is created to allow for simulation restarts. Defaults to 10.");
+    runBlock->addSingleInput("max cpu hours allowed", false, "The number hours after which the simulation will be haulted. Defaults to -1, which is no limit.");
+    runBlock->addSingleInput("statistical accuracy sought", false, "The statistical uncertainty for a particular quantity of interest, below which the simulation will be haulted. Note that the quantity must be defined by the application (e.g. the cavity dose in egs_chamber), and in general is undefined.");
+    runBlock->addSingleInput("geometry error limit", false, "The number of geometry errors that will be allowed to occur, before haulting the simulation. Defaults to 0.");
+    runBlock->addSingleInput("calculation", false, "The calculation type: first (default, runs a new simulation), restart (resumes a terminated simulation), analyze (prints results), combine (combines results from a parallel run). Defaults to 'first'.", {"first", "restart", "analyze", "combine"});
+}
 
 /*! \brief A simple run control object for advanced EGSnrc C++ applications.
 

--- a/HEN_HOUSE/egs++/egs_run_control.h
+++ b/HEN_HOUSE/egs++/egs_run_control.h
@@ -48,7 +48,7 @@ using namespace std;
 class EGS_Application;
 class EGS_Input;
 
-static void addRunControlBlock(shared_ptr<EGS_BlockInput> blockPtr) {
+static void addRunControlBlock(shared_ptr<EGS_InputStruct> blockPtr) {
     shared_ptr<EGS_BlockInput> runBlock = blockPtr->addBlockInput("run control");
     runBlock->addSingleInput("ncase", true, "The number of histories to simulate.");
     runBlock->addSingleInput("nbatch", false, "The number of batches to divide the simulation into. After each batch, a checkpoint is created to allow for simulation restarts. Defaults to 10.");

--- a/HEN_HOUSE/egs++/egs_run_control.h
+++ b/HEN_HOUSE/egs++/egs_run_control.h
@@ -64,7 +64,7 @@ static void addRunControlBlock(shared_ptr<EGS_InputStruct> blockPtr) {
 
   In EGSnrc applications derived from EGS_AdvancedApplication the program
   execution is controlled by a 'run control object' (RCO). The purpose of
-  the RCO is to tell shower loop into how many 'chunks' the simulation
+  the RCO is to tell the shower loop into how many 'chunks' the simulation
   should be split, how many particles to run per simulation chunk, into how
   many batches to split a simulation chunk, etc. In this way it is easy
   for EGSnrc C++ application developers to either use one of the RCO's

--- a/HEN_HOUSE/egs++/egs_run_control.h
+++ b/HEN_HOUSE/egs++/egs_run_control.h
@@ -64,7 +64,7 @@ static void addRunControlBlock(shared_ptr<EGS_InputStruct> blockPtr) {
 
   In EGSnrc applications derived from EGS_AdvancedApplication the program
   execution is controlled by a 'run control object' (RCO). The purpose of
-  the RCO is to tell the shower loop into how many 'chunks' the simulation
+  the RCO is to tell shower loop into how many 'chunks' the simulation
   should be split, how many particles to run per simulation chunk, into how
   many batches to split a simulation chunk, etc. In this way it is easy
   for EGSnrc C++ application developers to either use one of the RCO's

--- a/HEN_HOUSE/egs++/egs_scoring.h
+++ b/HEN_HOUSE/egs++/egs_scoring.h
@@ -40,9 +40,50 @@
 #include "egs_libconfig.h"
 #include "egs_functions.h"
 #include "egs_math.h"
+#include "egs_input_struct.h"
 
 #include <iostream>
 using namespace std;
+
+static void addScoringBlock(shared_ptr<EGS_InputStruct> blockPtr) {
+    shared_ptr<EGS_BlockInput> scoreBlock = blockPtr->addBlockInput("scoring options");
+    scoreBlock->addSingleInput("pulse height regions", false, "A list of regions to score pulse height distributions");
+    scoreBlock->addSingleInput("pulse height bins", false, "How many bins to use for each pulse height distribution. This must be either a single input, in which case all pulse height distributions will use this number of bins, or the same number of inputs as pulse height regions.");
+    scoreBlock->addSingleInput("silent", false, "0 (verbose output) or greater than 0 (short output)");
+    scoreBlock->addSingleInput("calculation type", false, "Default is dose", {"Dose", "Awall", "Fano", "FAC", "HVL"});
+
+    shared_ptr<EGS_BlockInput> calGeomPtr = scoreBlock->addBlockInput("calculation geometry");
+    calGeomPtr->addSingleInput("geometry name", false, "The name of the base geometry");
+    calGeomPtr->addSingleInput("cavity regions", true, "A list of cavity region indices");
+    calGeomPtr->addSingleInput("cavity mass", true, "The total cavity mass in grams");
+    calGeomPtr->addSingleInput("cavity geometry", true, "The name of geometry for range rejection");
+    calGeomPtr->addSingleInput("enhance regions", false, "A list of enhancement region indicies");
+    calGeomPtr->addSingleInput("enhancement", false, "A list of enhancement factors");
+
+    auto transPtr = calGeomPtr->addBlockInput("transformation");
+    transPtr->addSingleInput("translation", false, "The translation for the geometry (x, y ,z)");
+
+    scoreBlock->addSingleInput("correlated geometries", false, "A list of geometries");
+
+    // input loops can also be used so avoid retyping things
+    auto inpPtr = scoreBlock->addBlockInput("input loop");
+    inpPtr->addSingleInput("loop count", true, "The number of times the loop repeats");
+    inpPtr->addSingleInput("loop variable", true, "The type (0 for integer, 1 for real, 2 for string), the variable name, then a list of the variable inputs");
+    inpPtr->addSingleInput("correlated geometries", false, "A list of geometries");
+
+    auto geominpPtr = inpPtr->addBlockInput("calculation geometry");
+    geominpPtr->addSingleInput("geometry name", false, "The name of the base geometry");
+    geominpPtr->addSingleInput("cavity regions", true, "A list of cavity region indices");
+    geominpPtr->addSingleInput("cavity mass", true, "The total cavity mass in grams");
+    geominpPtr->addSingleInput("cavity geometry", true, "The name of geometry for range rejection");
+    geominpPtr->addSingleInput("enhance regions", false, "A list of enhancement region indicies");
+    geominpPtr->addSingleInput("enhancement", false, "A list of enhancement factors");
+    geominpPtr->addSingleInput("subgeometries", false, "A list of identical geometries with material differences");
+    geominpPtr->addSingleInput("sub geom regions", false, "A list of regions where composition changes");
+
+    auto transinpPtr = geominpPtr->addBlockInput("transformation");
+    transinpPtr->addSingleInput("translation", false, "The translation for the geometry (x, y ,z)");
+}
 
 /*! \brief A class for scoring a single quantity of interest in a
   Monte Carlo simulation.

--- a/HEN_HOUSE/egs++/egs_shapes.h
+++ b/HEN_HOUSE/egs++/egs_shapes.h
@@ -74,6 +74,8 @@ static void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
     shapePtr->addSingleInput("height", false, "The height of the cylinder, in cm.")->addDependency(typePtr, "cylinder");
     shapePtr->addSingleInput("phi range", false, "The minimum and maximum phi values, in degrees. This allows you restrict the cylinder to a shape like a slice of pie!")->addDependency(typePtr, "cylinder");
     shapePtr->addSingleInput("axis", false, "A unit vector that defines the axis of the cylinder.")->addDependency(typePtr, "cylinder");
+
+    addTransformationBlock(shapePtr);
 }
 
 /*! \defgroup Shapes Shapes

--- a/HEN_HOUSE/egs++/egs_shapes.h
+++ b/HEN_HOUSE/egs++/egs_shapes.h
@@ -57,13 +57,13 @@ static void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
     typePtr->addDependency(libPtr, "", true);
 
     // Point
-    shapePtr->addSingleInput("position", false, "The x, y, z position that the source will emit particles from.")->addDependency(typePtr, "point");
+    shapePtr->addSingleInput("position", true, "The x, y, z position that the source will emit particles from.")->addDependency(typePtr, "point");
 
     // Box
-    shapePtr->addSingleInput("box size", false, "The side lengths of the box, in cm. Enter 1 number for a cube, or 3 numbers to denote the x, y, and z side lengths.")->addDependency(typePtr, "box");
+    shapePtr->addSingleInput("box size", true, "The side lengths of the box, in cm. Enter 1 number for a cube, or 3 numbers to denote the x, y, and z side lengths.")->addDependency(typePtr, "box");
 
     // Sphere
-    auto radiusPtr = shapePtr->addSingleInput("radius", false, "The radius of the sphere or cylinder, in cm.");
+    auto radiusPtr = shapePtr->addSingleInput("radius", true, "The radius of the sphere or cylinder, in cm.");
     radiusPtr->addDependency(typePtr, "sphere");
     auto midPtr = shapePtr->addSingleInput("midpoint", false, "The x, y and z coordinates of the midpoint of the sphere or cylinder, in cm. Defaults to 0, 0, 0.");
     midPtr->addDependency(typePtr, "sphere");
@@ -71,9 +71,9 @@ static void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
     // Cylinder
     radiusPtr->addDependency(typePtr, "cylinder");
     midPtr->addDependency(typePtr, "cylinder");
-    shapePtr->addSingleInput("height", false, "The height of the cylinder, in cm.")->addDependency(typePtr, "cylinder");
+    shapePtr->addSingleInput("height", true, "The height of the cylinder, in cm.")->addDependency(typePtr, "cylinder");
     shapePtr->addSingleInput("phi range", false, "The minimum and maximum phi values, in degrees. This allows you restrict the cylinder to a shape like a slice of pie!")->addDependency(typePtr, "cylinder");
-    shapePtr->addSingleInput("axis", false, "A unit vector that defines the axis of the cylinder.")->addDependency(typePtr, "cylinder");
+    shapePtr->addSingleInput("axis", true, "A unit vector that defines the axis of the cylinder.")->addDependency(typePtr, "cylinder");
 
     addTransformationBlock(shapePtr);
 }

--- a/HEN_HOUSE/egs++/egs_shapes.h
+++ b/HEN_HOUSE/egs++/egs_shapes.h
@@ -49,7 +49,12 @@ using std::string;
 class EGS_Input;
 
 static void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
-    auto typePtr = shapePtr->addSingleInput("type", true, "The type of shape - this input includes only a small set of simple shapes. For more options, use the 'library' input instead.", {"point", "box", "sphere", "cylinder"});
+    auto libPtr = shapePtr->addSingleInput("library", false, "The type of shape, loaded by shared library in egs++/dso.");
+    auto typePtr = shapePtr->addSingleInput("type", false, "The type of shape - this input includes only a small set of simple shapes. For more options, use the 'library' input instead.", {"point", "box", "sphere", "cylinder"});
+
+    // Only one of "library" or "type" are allowed
+    libPtr->addDependency(typePtr, "", true);
+    typePtr->addDependency(libPtr, "", true);
 
     // Point
     shapePtr->addSingleInput("position", false, "The x, y, z position that the source will emit particles from.")->addDependency(typePtr, "point");

--- a/HEN_HOUSE/egs++/egs_shapes.h
+++ b/HEN_HOUSE/egs++/egs_shapes.h
@@ -41,11 +41,35 @@
 #include "egs_transformations.h"
 #include "egs_rndm.h"
 #include "egs_object_factory.h"
+#include "egs_input_struct.h"
 
 #include <string>
 using std::string;
 
 class EGS_Input;
+
+static void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
+    auto typePtr = shapePtr->addSingleInput("type", true, "The type of shape - this input includes only a small set of simple shapes. For more options, use the 'library' input instead.", {"point", "box", "sphere", "cylinder"});
+
+    // Point
+    shapePtr->addSingleInput("position", false, "The x, y, z position that the source will emit particles from.")->addDependency(typePtr, "point");
+
+    // Box
+    shapePtr->addSingleInput("box size", false, "The side lengths of the box, in cm. Enter 1 number for a cube, or 3 numbers to denote the x, y, and z side lengths.")->addDependency(typePtr, "box");
+
+    // Sphere
+    auto radiusPtr = shapePtr->addSingleInput("radius", false, "The radius of the sphere or cylinder, in cm.");
+    radiusPtr->addDependency(typePtr, "sphere");
+    auto midPtr = shapePtr->addSingleInput("midpoint", false, "The x, y and z coordinates of the midpoint of the sphere or cylinder, in cm. Defaults to 0, 0, 0.");
+    midPtr->addDependency(typePtr, "sphere");
+
+    // Cylinder
+    radiusPtr->addDependency(typePtr, "cylinder");
+    midPtr->addDependency(typePtr, "cylinder");
+    shapePtr->addSingleInput("height", false, "The height of the cylinder, in cm.")->addDependency(typePtr, "cylinder");
+    shapePtr->addSingleInput("phi range", false, "The minimum and maximum phi values, in degrees. This allows you restrict the cylinder to a shape like a slice of pie!")->addDependency(typePtr, "cylinder");
+    shapePtr->addSingleInput("axis", false, "A unit vector that defines the axis of the cylinder.")->addDependency(typePtr, "cylinder");
+}
 
 /*! \defgroup Shapes Shapes
   \brief Shapes are objects that can pick random points within

--- a/HEN_HOUSE/egs++/egs_spectra.cpp
+++ b/HEN_HOUSE/egs++/egs_spectra.cpp
@@ -374,10 +374,10 @@ A spectrum is defined inline as follows:
     type = tabulated spectrum
     energies = list of discrete energies or bin edges
     probabilities = list of probabilities
-    spectrum type = 0 or 1 or 2 or 3
+    spectrum mode = 0 or 1 or 2 or 3
 :stop spectrum:
 \endverbatim
-where the meaning of the spectrum type is the same as the mode of a
+where the meaning of the spectrum mode is the same as the mode of a
 spectrum file.
  */
 class EGS_EXPORT EGS_TabulatedSpectrum : public EGS_BaseSpectrum {

--- a/HEN_HOUSE/egs++/egs_transformations.h
+++ b/HEN_HOUSE/egs++/egs_transformations.h
@@ -43,12 +43,22 @@
 #include "egs_libconfig.h"
 #include "egs_math.h"
 #include "egs_functions.h"
+#include "egs_input_struct.h"
 
 #include <iostream>
 
 using namespace std;
 
 class EGS_Input;
+
+static void addTransformationBlock(shared_ptr<EGS_BlockInput> blockPtr) {
+    shared_ptr<EGS_BlockInput> transBlock = blockPtr->addBlockInput("transformation");
+    transBlock->addSingleInput("translation", false, "The x, y, z translation offsets in cm.");
+    auto vecPtr = transBlock->addSingleInput("rotation vector", false, "Defines a rotation which, when applied to the 3D vector defined by this input, transforms it into a vector along the positive z-axis.");
+    auto rotPtr = transBlock->addSingleInput("rotation", false, "2, 3 or 9 floating point numbers define a rotation. See the documentation for details.");
+    vecPtr->addDependency(rotPtr, "", true);
+    rotPtr->addDependency(vecPtr, "", true);
+}
 
 /*! \brief A class for vector rotations.
 

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
@@ -27,6 +27,7 @@
 #  Contributors:    Marc Chamberland
 #                   Rowan Thomson
 #                   Dave Rogers
+#                   Hannah Gallop
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
@@ -70,6 +70,7 @@ static char EGS_AENVELOPE_LOCAL transformations_keyword[] = "transformations";
 static char EGS_AENVELOPE_LOCAL type_keyword[] = "type";
 static char EGS_AENVELOPE_LOCAL transformation_keyword[] = "transformation";
 
+static bool EGS_AENVELOPE_LOCAL inputSet = false;
 
 EGS_AEnvelope::EGS_AEnvelope(EGS_BaseGeometry *base_geom,
                              const vector<AEnvelopeAux> inscribed, const string &Name, bool debug, string output_vc_file) :
@@ -815,7 +816,7 @@ EGS_ASwitchedEnvelope::EGS_ASwitchedEnvelope(EGS_BaseGeometry *base_geom,
 };
 
 
-//TODO: this gets called a lot and is probably quite slow.  Instead fo doing a
+//TODO: this gets called a lot and is probably quite slow.  Instead of doing a
 //set intersection on every call we can probably do it once when activated
 //geometries change and cache it
 vector<EGS_BaseGeometry *> EGS_ASwitchedEnvelope::getGeomsInRegion(int ireg) {
@@ -944,6 +945,32 @@ vector<EGS_AffineTransform *> EGS_AEnvelope::createTransforms(EGS_Input *input) 
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_AEnvelope"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("type", false, "The type of auto envelope", {"EGS_ASwitchedEnvelope"});
+
+        geomBlockInput->addSingleInput("incribed geometries", true, "A list of predefined geometries");
+        geomBlockInput->addSingleInput("base geometry", true, "The name of a predefined geometry");
+
+        auto blockPtr = geomBlockInput->addBlockInput("transformation");
+        blockPtr->addSingleInput("translation", false, "The translation for the geometry (x, y ,z)");
+        auto rotPtr = blockPtr->addSingleInput("rotation", false, "2, 3, or 9 floating point numbers");
+        auto vectPtr = blockPtr->addSingleInput("rotation vector", false, "3 floating point numbers");
+    }
+
+    EGS_AENVELOPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_AENVELOPE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_box/Makefile
+++ b/HEN_HOUSE/egs++/geometry/egs_box/Makefile
@@ -36,7 +36,7 @@ DEFS = $(DEF1) -DBUILD_BOX_DLL
 
 library = egs_box
 lib_files = egs_box
-my_deps = egs_transformations.h
+my_deps = egs_transformations.h egs_input_struct.h
 extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
 
 include $(SPEC_DIR)egspp_libs.spec

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Reid Townson
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -65,7 +65,7 @@ InputOptions inp;
 // Process inputs from the egsinp file
 EGS_BOX_LOCAL int processInputs(EGS_Input *input) {
     int err = input->getInput(ebox_key1,inp.boxSize);
-    if(err && blockInput->getSingleInput(ebox_key1)->getRequired()) {
+    if(err && geomBlockInput->getSingleInput(ebox_key1)->getRequired()) {
         egsWarning(ebox_message1,ebox_message3);
         return 0;
     }
@@ -80,10 +80,10 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        blockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
+        geomBlockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
 
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths.");
+        geomBlockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths.");
     }
 
     EGS_BOX_EXPORT string getExample() {
@@ -105,7 +105,7 @@ extern "C" {
         if(!inputSet) {
             setInputs();
         }
-        return blockInput;
+        return geomBlockInput;
     }
 
     EGS_BOX_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -36,6 +36,7 @@
 
 #include "egs_box.h"
 #include "egs_input.h"
+#include "egs_base_geometry.h"
 
 void EGS_Box::printInfo() const {
     EGS_BaseGeometry::printInfo();
@@ -43,7 +44,8 @@ void EGS_Box::printInfo() const {
     egsInformation("=======================================================\n");
 }
 
-string EGS_Box::type("EGS_Box");
+static string EGS_BOX_LOCAL typeStr("EGS_Box");
+string EGS_Box::type(typeStr);
 
 static char EGS_BOX_LOCAL ebox_message1[] = "createGeometry(box): %s\n";
 static char EGS_BOX_LOCAL ebox_message2[] = "null input?";
@@ -52,19 +54,56 @@ static char EGS_BOX_LOCAL ebox_message4[] =
     "expecting 1 or 3 float inputs for 'box size'";
 static char EGS_BOX_LOCAL ebox_key1[] = "box size";
 
+static bool inputSet = false;
+
+struct EGS_BOX_LOCAL BoxInputs {
+    vector<EGS_Float> boxSize;
+};
+BoxInputs inp;
+
+// TODO was going to add this function in addition to the blockinput stuff
+EGS_BOX_LOCAL int loadInputs(EGS_Input *input) {
+    int err = input->getInput(ebox_key1,inp.boxSize);
+    if(err && blockInput->getSingleInput(ebox_key1).getRequired()) {
+        egsWarning(ebox_message1,ebox_message3);
+        return 0;
+    }
+
+    return 1;
+}
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs();
+
+        blockInput->addSingleInput("library", true, "The type of geometry.", vector<string>(1, typeStr));
+        blockInput->addSingleInput("box size", true, "1 or 3 numbers defining the box size");
+    }
+
+    EGS_BOX_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return blockInput;
+    }
 
     EGS_BOX_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {
             egsWarning(ebox_message1,ebox_message2);
             return 0;
         }
-        vector<EGS_Float> s;
-        int err = input->getInput(ebox_key1,s);
-        if (err) {
-            egsWarning(ebox_message1,ebox_message3);
+
+        if(!loadInputs(input)) {
+            egsWarning("Failed to load the inputs for %s.\n", typeStr.c_str());
             return 0;
         }
+
+        vector<EGS_Float> s;
+        s = inp.boxSize;
+
         EGS_AffineTransform *t = EGS_AffineTransform::getTransformation(input);
         EGS_Box *result;
         if (s.size() == 1) {
@@ -89,5 +128,4 @@ extern "C" {
         result->setLabels(input);
         return result;
     }
-
 }

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -81,8 +81,8 @@ extern "C" {
         setBaseGeometryInputs();
 
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso", vector<string>(1, typeStr));
-        blockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths");
+        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", vector<string>(1, typeStr));
+        blockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths.");
     }
 
     EGS_BOX_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -54,17 +54,17 @@ static char EGS_BOX_LOCAL ebox_message4[] =
     "expecting 1 or 3 float inputs for 'box size'";
 static char EGS_BOX_LOCAL ebox_key1[] = "box size";
 
-static bool inputSet = false;
+static bool EGS_BOX_LOCAL inputSet = false;
 
-struct EGS_BOX_LOCAL BoxInputs {
+struct EGS_BOX_LOCAL InputOptions {
     vector<EGS_Float> boxSize;
 };
-BoxInputs inp;
+InputOptions inp;
 
-// TODO was going to add this function in addition to the blockinput stuff
-EGS_BOX_LOCAL int loadInputs(EGS_Input *input) {
+// Process inputs from the egsinp file
+EGS_BOX_LOCAL int processInputs(EGS_Input *input) {
     int err = input->getInput(ebox_key1,inp.boxSize);
-    if(err && blockInput->getSingleInput(ebox_key1).getRequired()) {
+    if(err && blockInput->getSingleInput(ebox_key1)->getRequired()) {
         egsWarning(ebox_message1,ebox_message3);
         return 0;
     }
@@ -79,8 +79,24 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        blockInput->addSingleInput("library", true, "The type of geometry.", vector<string>(1, typeStr));
-        blockInput->addSingleInput("box size", true, "1 or 3 numbers defining the box size");
+        // Format: name, isRequired, description, vector string of allowed values
+        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso", vector<string>(1, typeStr));
+        blockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths");
+    }
+
+    EGS_BOX_EXPORT string getExample() {
+        string example
+{R"(
+    :start geometry:
+        library     = EGS_Box
+        name        = my_box
+        box size    = 1 2 3
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
     }
 
     EGS_BOX_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
@@ -96,8 +112,8 @@ extern "C" {
             return 0;
         }
 
-        if(!loadInputs(input)) {
-            egsWarning("Failed to load the inputs for %s.\n", typeStr.c_str());
+        if(!processInputs(input)) {
+            egsWarning("Failed to process the inputs for %s.\n", typeStr.c_str());
             return 0;
         }
 

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -80,8 +80,9 @@ extern "C" {
 
         setBaseGeometryInputs();
 
+        blockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
+
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", vector<string>(1, typeStr));
         blockInput->addSingleInput("box size", true, "1 number defining the side-length of a cube, or 3 numbers defining the x, y, and z side-lengths.");
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -65,7 +65,7 @@ InputOptions inp;
 // Process inputs from the egsinp file
 EGS_BOX_LOCAL int processInputs(EGS_Input *input) {
     int err = input->getInput(ebox_key1,inp.boxSize);
-    if(err && geomBlockInput->getSingleInput(ebox_key1)->getRequired()) {
+    if (err && geomBlockInput->getSingleInput(ebox_key1)->getRequired()) {
         egsWarning(ebox_message1,ebox_message3);
         return 0;
     }
@@ -87,8 +87,8 @@ extern "C" {
     }
 
     EGS_BOX_EXPORT string getExample() {
-        string example
-{R"(
+        string example {
+            R"(
     :start geometry:
         library     = EGS_Box
         name        = my_box

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.h
@@ -109,6 +109,13 @@ class EGS_BOX_EXPORT EGS_Box : public EGS_BaseGeometry {
 
 public:
 
+//     EGS_Box() : EGS_BaseGeometry("empty") {
+//         inputBlock.addBlockInput("geometry", true);
+//         inputBlock.addSingleInput("library", true, {"egs_box"});
+//         inputBlock.addSingleInput("name", true);
+//     };
+    //static EGS_BlockInput getInputs();
+
     EGS_Box(EGS_Float a, const EGS_AffineTransform *t = 0,
             const string &Name = "") : EGS_BaseGeometry(Name),
         ax(a), ay(a), az(a), T(0)  {
@@ -133,6 +140,17 @@ public:
             delete T;
         }
     };
+
+    // Build the input structure that this class will adhere to
+    // Any new input parameters should be included here
+//     EGS_BlockInput getInputBlock() {
+//         //inputBlock = new EGS_BlockInput("geometry");
+//         /*inputBlock->addBlockInput("geometry", true);
+//         inputBlock->addSingleInput("library", true, {"egs_box"});
+//         inputBlock->addSingleInput("name", true);*/
+//
+//         return inputBlock;
+//     };
 
     bool isInside(const EGS_Vector &x) {
         EGS_Vector xp = T ? x*(*T) : x;

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -120,11 +120,11 @@ extern "C" {
         setBaseGeometryInputs(false);
 
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso", vector<string>(1, typeStr));
+        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", vector<string>(1, typeStr));
 
-        blockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry");
-        blockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size");
-        blockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style");
+        blockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry.");
+        blockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size.");
+        blockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style.");
     }
 
     EGS_CDGEOMETRY_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -119,9 +119,9 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", vector<string>(1, typeStr));
+        blockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
 
+        // Format: name, isRequired, description, vector string of allowed values
         blockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry.");
         blockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size.");
         blockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style.");

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -50,22 +51,6 @@ static string EGS_CDGEOMETRY_LOCAL typeStr("EGS_CDGeometry");
 string EGS_CDGeometry::type(typeStr);
 
 static bool EGS_CDGEOMETRY_LOCAL inputSet = false;
-
-struct EGS_CDGEOMETRY_LOCAL InputOptions {
-    string bg_name;
-};
-InputOptions inp;
-
-// Process inputs from the egsinp file
-EGS_CDGEOMETRY_LOCAL int processInputs(EGS_Input *input) {
-//     int err = input->getInput(ebox_key1,inp.boxSize);
-//     if(err && blockInput->getSingleInput(ebox_key1)->getRequired()) {
-//         egsWarning(ebox_message1,ebox_message3);
-//         return 0;
-//     }
-
-    return 1;
-}
 
 void EGS_CDGeometry::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_CDGeometry::setMedia: don't use this method. Use the\n"
@@ -132,11 +117,14 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
+        setBaseGeometryInputs(false);
+
         // Format: name, isRequired, description, vector string of allowed values
         blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso", vector<string>(1, typeStr));
 
         blockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry");
         blockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size");
+        blockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style");
     }
 
     EGS_CDGEOMETRY_EXPORT string getExample() {
@@ -173,20 +161,16 @@ extern "C" {
             delete ij;
         }
 
-        if(!processInputs(input)) {
-            egsWarning("Failed to process the inputs for %s.\n", typeStr.c_str());
-            return 0;
-        }
-
-        int err = input->getInput("base geometry",inp.bg_name);
+        string bg_name;
+        int err = input->getInput("base geometry", bg_name);
         if (err) {
             egsWarning("createGeometry(CD_Geometry): no 'base geometry' input\n");
             return 0;
         }
-        EGS_BaseGeometry *g = EGS_BaseGeometry::getGeometry(inp.bg_name);
+        EGS_BaseGeometry *g = EGS_BaseGeometry::getGeometry(bg_name);
         if (!g) {
             egsWarning("createGeometry(CD_Geometry): no geometry named %s is"
-                       " defined\n",inp.bg_name.c_str());
+                       " defined\n",bg_name.c_str());
             return 0;
         }
         int nreg = g->regions();

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -128,8 +128,8 @@ extern "C" {
     }
 
     EGS_CDGEOMETRY_EXPORT string getExample() {
-        string example
-{R"(
+        string example {
+            R"(
     :start geometry:
         library         = EGS_CDGeometry
         name            = my_cd

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -119,12 +119,12 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        blockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
+        geomBlockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
 
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry.");
-        blockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size.");
-        blockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style.");
+        geomBlockInput->addSingleInput("base geometry", true, "The name of the geometry that defines regions for this 'cutting device'. It is within these regions that other geometries will be placed to create a composite geometry.");
+        geomBlockInput->addSingleInput("set geometry", true, "The region number in the base geometry, followed by the name of the geometry to place in that region. If this geometry extends beyond the region boundaries, it will be cut to size.");
+        geomBlockInput->addSingleInput("new indexing style", false, "Set to 1 to use a new region numbering algorithm. Defaults to 0, to use the original indexing style.");
     }
 
     EGS_CDGEOMETRY_EXPORT string getExample() {
@@ -147,7 +147,7 @@ extern "C" {
         if(!inputSet) {
             setInputs();
         }
-        return blockInput;
+        return geomBlockInput;
     }
 
     EGS_CDGEOMETRY_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -253,42 +253,121 @@ extern "C" {
         setBaseGeometryInputs(false);
 
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso", {"EGS_Cones"});
-        auto typePtr = blockInput->addSingleInput("type", true, "The type of cone", {"EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet", "EGS_ConeStack"});
+        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", {"EGS_Cones"});
+        auto typePtr = blockInput->addSingleInput("type", true, "The type of cone.", {"EGS_ConeStack", "EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet"});
 
-        blockInput->addSingleInput("axis", false, "The unit vector defining the axis along the length of the cones. Layers or cones are added sequentially in the vector direction");
+        blockInput->addSingleInput("axis", false, "The unit vector defining the axis along the length of the cones. Layers or cones are added sequentially in the vector direction.");
 
-        auto inpPtr = blockInput->addSingleInput("apex", false, "TODO");
-        inpPtr->addDependency(typePtr,"EGS_SimpleCone");
-        inpPtr->addDependency(typePtr,"EGS_ParallelCones");
-        inpPtr->addDependency(typePtr,"EGS_ConeSet");
+        auto inpPtr = blockInput->addSingleInput("apex", false, "The position of the cone apex (x, y, z). For EGS_ParallelCones, this is the position of the first cone apex.");
+        inpPtr->addDependency(typePtr, "EGS_SimpleCone");
+        inpPtr->addDependency(typePtr, "EGS_ParallelCones");
+        inpPtr->addDependency(typePtr, "EGS_ConeSet");
 
+        // EGS_ConeStack
         auto blockPtr = blockInput->addBlockInput("layer");
-        blockPtr->addDependency(typePtr,"EGS_ConeStack");
-        blockPtr->addSingleInput("thickness", true, "TODO");
-        blockPtr->addSingleInput("top radii", false, "TODO");
-        blockPtr->addSingleInput("bottom radii", true, "TODO");
-        blockPtr->addSingleInput("media", true, "TODO");
+        blockPtr->addDependency(typePtr, "EGS_ConeStack");
+        blockPtr->addSingleInput("thickness", true, "The thickness of the layer.");
+        blockPtr->addSingleInput("top radii", false, "A list of the top cone radii. If omitted, the top radii are assumed to be the same as a bottom radii from the previous layer. This improves the algorithm efficiency.");
+        blockPtr->addSingleInput("bottom radii", true, "A list of the bottom cone radii.");
+        blockPtr->addSingleInput("media", true, "A list of media names, one for each region.");
 
         // EGS_ConeSet
-        //auto anglesPtr = blockInput->addSingleInput("opening angles", false, "TODO")->addDependency(typePtr, "EGS_ConeSet");
-//         inpPtr = blockInput->addSingleInput("opening angles in radian", false, "TODO")->addDependency(typePtr, "EGS_ConeSet");
-        //inpPtr->addDependency(anglesPtr, "", true);
+        auto anglesPtr = blockInput->addSingleInput("opening angles", false, "A list of angles in degrees.");
+        anglesPtr->addDependency(typePtr, "EGS_ConeSet");
+        auto anglesRadPtr = blockInput->addSingleInput("opening angles in radian", false, "A list of angles in radians.");
+        anglesRadPtr->addDependency(typePtr, "EGS_ConeSet");
+        // Only one of these inputs two can be included
+        anglesRadPtr->addDependency(anglesPtr, "", true);
+        anglesPtr->addDependency(anglesRadPtr, "", true);
+        blockInput->addSingleInput("flag", false, "0 or 1 or 2. This input affects the region numbering algorithm; see the documentation for details.")->addDependency(typePtr, "EGS_ConeSet");
 
+        // EGS_SimpleCone
+        auto anglePtr = blockInput->addSingleInput("opening angle", false, "The opening angle of the cone in degrees.");
+        anglePtr->addDependency(typePtr, "EGS_SimpleCone");
+        anglePtr->addDependency(typePtr, "EGS_ParallelCones");
+        blockInput->addSingleInput("height", false, "The height of the cone.");
+
+        // EGS_ParallelCones
+        blockInput->addSingleInput("apex distances", false, "A list of distances from the first apex.");
     }
 
     EGS_CONES_EXPORT string getExample(string type) {
         string example;
         example =
 {R"(
-    :start geometry:
-        library         = EGS_CDGeometry
-        name            = my_cd
-        base geometry   = my_regions
-        # set geometry = 1 geom means:
-        # in region 1 of the basegeometry, use geometry named "geom"
-        set geometry   = 0 my_geom1
-        set geometry   = 1 my_geom2
+    # Examples of each of the egs_cones types follow
+    # Simply uncomment the :start line for the example that you
+    # wish to use
+
+    # EGS_ConeStack example
+    #:start geometry:
+        library = egs_cones
+        type = EGS_ConeStack
+        name = my_conestack
+        axis = 1.2417 0 0 -1 0 0
+        :start layer:
+            thickness = 0.0417
+            top radii = 0.
+            bottom radii = 0.0858
+            media = water
+        :stop layer:
+        :start layer:
+            thickness = 0.1283
+            top radii = 0. 0.0858
+            bottom radii = 0.3125 0.35
+            media = air water
+        :stop layer:
+        :start layer:
+            thickness = 0.2217
+            bottom radii = 0.3125 0.35
+            media = air water
+        :stop layer:
+        :start layer:
+            thickness = 2.05
+            top radii = 0.050 0.3125 0.35
+            bottom radii = 0.050 0.3125 0.35
+            media = water air water
+        :stop layer:
+    :stop geometry:
+
+    # EGS_SimpleCone example
+    #:start geometry:
+        library     = egs_cones
+        type        = EGS_SimpleCone
+        name        = my_simple_cone
+        apex        = 0 0 3
+        axis        = 0 0 -1
+        height      = 4
+        opening angle = 30 # deg
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+
+    # EGS_ParallelCones example
+    #:start geometry:
+        library     = egs_cones
+        type        = EGS_ParallelCones
+        name        = my_parallel_cones
+        apex        = 0 0 6
+        axis        = 0 0 -1
+        apex distances  = 1 2 3
+        opening angle   = 30 # deg
+    :stop geometry:
+
+    # EGS_ConeSet example
+    #:start geometry:
+        name        = my_coneset
+        library     = egs_cones
+        type        = EGS_ConeSet
+        apex        = 0 0 3
+        axis        = 0 0 -1
+        opening angles = 10 20 30
+        :start media input:
+            media = water air water
+            set medium = 1 1
+            set medium = 2 2
+        :stop media input:
     :stop geometry:
 )"};
         return example;
@@ -364,7 +443,7 @@ extern "C" {
                 return 0;
             }
 
-            // adjust lable region numbering in each layer
+            // adjust label region numbering in each layer
             int count=0;
             for (size_t i=0; i<layerLabels.size(); i++) {
                 for (int j=0; j<layerLabels[i]; j++) {

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -294,8 +294,8 @@ extern "C" {
 
     EGS_CONES_EXPORT string getExample(string type) {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Examples of each of the egs_cones types follow
     # Simply uncomment the :start line for the example that you
     # wish to use

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -252,20 +252,20 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        blockInput->getSingleInput("library")->setValues({"EGS_Cones"});
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Cones"});
 
         // Format: name, isRequired, description, vector string of allowed values
-        auto typePtr = blockInput->addSingleInput("type", true, "The type of cone.", {"EGS_ConeStack", "EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet"});
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of cone.", {"EGS_ConeStack", "EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet"});
 
-        blockInput->addSingleInput("axis", false, "The unit vector defining the axis along the length of the cones. Layers or cones are added sequentially in the vector direction.");
+        geomBlockInput->addSingleInput("axis", false, "The unit vector defining the axis along the length of the cones. Layers or cones are added sequentially in the vector direction.");
 
-        auto inpPtr = blockInput->addSingleInput("apex", false, "The position of the cone apex (x, y, z). For EGS_ParallelCones, this is the position of the first cone apex.");
+        auto inpPtr = geomBlockInput->addSingleInput("apex", false, "The position of the cone apex (x, y, z). For EGS_ParallelCones, this is the position of the first cone apex.");
         inpPtr->addDependency(typePtr, "EGS_SimpleCone");
         inpPtr->addDependency(typePtr, "EGS_ParallelCones");
         inpPtr->addDependency(typePtr, "EGS_ConeSet");
 
         // EGS_ConeStack
-        auto blockPtr = blockInput->addBlockInput("layer");
+        auto blockPtr = geomBlockInput->addBlockInput("layer");
         blockPtr->addDependency(typePtr, "EGS_ConeStack");
         blockPtr->addSingleInput("thickness", true, "The thickness of the layer.");
         blockPtr->addSingleInput("top radii", false, "A list of the top cone radii. If omitted, the top radii are assumed to be the same as a bottom radii from the previous layer. This improves the algorithm efficiency.");
@@ -273,23 +273,23 @@ extern "C" {
         blockPtr->addSingleInput("media", true, "A list of media names, one for each region.");
 
         // EGS_ConeSet
-        auto anglesPtr = blockInput->addSingleInput("opening angles", false, "A list of angles in degrees.");
+        auto anglesPtr = geomBlockInput->addSingleInput("opening angles", false, "A list of angles in degrees.");
         anglesPtr->addDependency(typePtr, "EGS_ConeSet");
-        auto anglesRadPtr = blockInput->addSingleInput("opening angles in radian", false, "A list of angles in radians.");
+        auto anglesRadPtr = geomBlockInput->addSingleInput("opening angles in radian", false, "A list of angles in radians.");
         anglesRadPtr->addDependency(typePtr, "EGS_ConeSet");
         // Only one of these inputs two can be included
         anglesRadPtr->addDependency(anglesPtr, "", true);
         anglesPtr->addDependency(anglesRadPtr, "", true);
-        blockInput->addSingleInput("flag", false, "0 or 1 or 2. This input affects the region numbering algorithm; see the documentation for details.")->addDependency(typePtr, "EGS_ConeSet");
+        geomBlockInput->addSingleInput("flag", false, "0 or 1 or 2. This input affects the region numbering algorithm; see the documentation for details.")->addDependency(typePtr, "EGS_ConeSet");
 
         // EGS_SimpleCone
-        auto anglePtr = blockInput->addSingleInput("opening angle", false, "The opening angle of the cone in degrees.");
+        auto anglePtr = geomBlockInput->addSingleInput("opening angle", false, "The opening angle of the cone in degrees.");
         anglePtr->addDependency(typePtr, "EGS_SimpleCone");
         anglePtr->addDependency(typePtr, "EGS_ParallelCones");
-        blockInput->addSingleInput("height", false, "The height of the cone.");
+        geomBlockInput->addSingleInput("height", false, "The height of the cone.");
 
         // EGS_ParallelCones
-        blockInput->addSingleInput("apex distances", false, "A list of distances from the first apex.");
+        geomBlockInput->addSingleInput("apex distances", false, "A list of distances from the first apex.");
     }
 
     EGS_CONES_EXPORT string getExample(string type) {
@@ -378,7 +378,7 @@ extern "C" {
         if(!inputSet) {
             setInputs();
         }
-        return blockInput;
+        return geomBlockInput;
     }
 
     EGS_CONES_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -252,8 +252,9 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
+        blockInput->getSingleInput("library")->setValues({"EGS_Cones"});
+
         // Format: name, isRequired, description, vector string of allowed values
-        blockInput->addSingleInput("library", true, "The type of geometry, loaded by shared library in egs++/dso.", {"EGS_Cones"});
         auto typePtr = blockInput->addSingleInput("type", true, "The type of cone.", {"EGS_ConeStack", "EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet"});
 
         blockInput->addSingleInput("axis", false, "The unit vector defining the axis along the length of the cones. Layers or cones are added sequentially in the vector direction.");

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,7 +37,34 @@ string YProjector::type = "EGS_Yconez";
 string ZProjector::type = "EGS_Zconez";
 string Projector::type = "EGS_conez";
 
+static bool EGS_CONEZ_LOCAL inputSet = false;
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Conez"});
+
+        // Format: name, description, isRequired, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", true,"The type of cone", {"EGS_Xconez", "EGS_Yconez", "EGS_Zcones", "EGS_conez"});
+
+        geomBlockInput->addSingleInput("apex", false, "The position of the cone apex (x, y, z)");
+        geomBlockInput->addSingleInput("opening angles", false, "A list of angles in degrees");
+
+        // EGS_Conez
+        auto inpPtr = geomBlockInput->addSingleInput("axis", true, "The unit vector defining the length along the conez");
+        inpPtr->addDependency(typePtr, "EGS_conez");
+    }
+
+    EGS_CONEZ_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_CONEZ_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,7 +38,70 @@
 #include "egs_cylinders.h"
 #include "egs_input.h"
 
+static bool EGS_CYLINDERS_LOCAL inputSet = false;
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Cylinders"});
+
+        // Format: name, isRequired, description, vector string of allowd values
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of cylinder.", {"EGS_XCylinders", "EGS_YCylinders", "EGS_ZCylinders", "EGS_Cylinders"});
+
+        geomBlockInput->addSingleInput("radii", true, "A list of cylinder radii, must be in increasing order");
+        geomBlockInput->addSingleInput("midpoint", false, "The position of the midpoint of the cylinder (x, y, z)");
+
+        // EGS_Cylinders
+        auto inpPtr = geomBlockInput->addSingleInput("axis", true, "The unit vector defining the axis along the length of the cylinder.");
+        inpPtr->addDependency(typePtr, "EGS_Cylinders");
+    }
+
+    EGS_CYLINDERS_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Examples of the egs_cylinders to follow
+
+    # EGS_XCylinder example
+    #:start geometry:
+        library = egs_cylinders
+        type = EGS_XCylinders
+        name = my_xcylinders
+        radii = 1 2 3
+        midpoint = 0
+        :start media input:
+            media = water air water
+            set medium = 1 1
+            set medium = 2 2
+        :stop media input:
+    :stop geometry:
+
+    # EGS_Cylinder example
+    #:start geometry:
+        library = egs_cylinders
+        type = EGS_Cylinders
+        name = my_cylinder
+        radii = 7
+        axis = 4 3 2
+        midpoint = 0 0 0
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_CYLINDERS_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_CYLINDERS_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         // check for valid input

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -45,7 +45,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_Cylinders"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2006
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 #
@@ -44,10 +44,38 @@
 #include "egs_elliptic_cylinders.h"
 #include "egs_input.h"
 
+static bool EGS_ELLIPTIC_CYLINDERS_LOCAL inputSet = false;
+
 extern "C" {
 
-    EGS_ELLIPTIC_CYLINDERS_EXPORT
-    EGS_BaseGeometry *createGeometry(EGS_Input *input) {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_EllipticCylinders"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of elliptic cylinder", {"EGS_EllipticCylindersXY", "EGS_EllipticCylindersXZ", "EGS_EllipticCylindersYZ", "EGS_EllipticCylinders"});
+
+        geomBlockInput->addSingleInput("midpoint", false, "The midpoint of the cylinder (x, y, z)");
+        geomBlockInput->addSingleInput("x-radii", true, "The x radii of the cylinder");
+        geomBlockInput->addSingleInput("y-radii", true, "The y radii of the cylinder");
+
+        auto xaxPtr = geomBlockInput->addSingleInput("x-axis", true, "The x-axis of the cylider (x, y, z)");
+        xaxPtr->addDependency(typePtr, "EGS_EllipticCylinders");
+        auto yaxPtr = geomBlockInput->addSingleInput("y-axis", true, "The y-axis of the cylinder (x, y, z)");
+        yaxPtr->addDependency(typePtr, "EGS_EllipticCylinders");
+    }
+
+    EGS_ELLIPTIC_CYLINDERS_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
+
+    EGS_ELLIPTIC_CYLINDERS_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         // check for valid input
         if (!input) {
             egsWarning("createGeometry(elliptic cylinders): null input?\n");

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
@@ -51,7 +51,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_EllipticCylinders"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -45,6 +46,8 @@ using namespace std;
 
 string EGS_ENVELOPEG_LOCAL EGS_EnvelopeGeometry::type = "EGS_EnvelopeGeometry";
 string EGS_ENVELOPEG_LOCAL EGS_FastEnvelope::type = "EGS_FastEnvelope";
+
+static bool EGS_ENVELOPEG_LOCAL inputSet = false;
 
 void EGS_EnvelopeGeometry::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_EnvelopeGeometry::setMedia: don't use this method. Use the\n"
@@ -358,6 +361,41 @@ static char EGS_ENVELOPEG_LOCAL eeg_keyword2[] = "geometry";
 static char EGS_ENVELOPEG_LOCAL eeg_keyword3[] = "inscribed geometries";
 
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_GEnvelope"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", false, "The type of envelope", {"EGS_FastEnvelope"});
+        geomBlockInput->addSingleInput("base geometry", true, "The name of a previously defined geometry");
+        geomBlockInput->addSingleInput("inscribed geometries", true, "A list of names of previously defined geometries, must be stictly inside the envelope");
+    }
+
+    EGS_ENVELOPEG_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_genvelope
+    #:start geometry:
+        name = my_envelope
+        library = egs_genvelope
+        base_geometry = my_box
+        inscribed geometries: geom1 geom2
+        # create geometries geom1 geom2
+    #:stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_ENVELOPEG_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_ENVELOPEG_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {

--- a/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
@@ -27,6 +27,7 @@
 #  Contributors:    Marc Chamberland
 #                   Rowan Thomson
 #                   Dave Rogers
+#                   Hannah Gallop
 #
 ###############################################################################
 #
@@ -50,8 +51,41 @@
 #include "egs_functions.h"
 #include "egs_glib.h"
 
+static bool EGS_GLIB_LOCAL inputSet = false;
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Glib"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("include file", true, "The path to some geometry.");
+    }
+
+    EGS_GLIB_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_glib
+    #:start geometry:
+        name = my_glib
+        library = egs_glib
+        include file = /path to some external file/
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_GLIB_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     /*! createGeometry function for glib shim */
     EGS_GLIB_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Marc Chamberland
 #                   Ernesto Mainegra-Hing
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -42,6 +43,8 @@
 #include "egs_functions.h"
 
 string EGS_StackGeometry::type = "EGS_StackGeometry";
+
+static bool EGS_STACKG_LOCAL inputSet = false;
 
 EGS_StackGeometry::EGS_StackGeometry(const vector<EGS_BaseGeometry *> &geoms,
                                      const string &Name) : EGS_BaseGeometry(Name) {
@@ -121,6 +124,41 @@ void EGS_StackGeometry::setBScaling(EGS_Input *) {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_GStack"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("geometries", true, "A list of names of previously defined geometries");
+        geomBlockInput->addSingleInput("tolerance", false, "A small floating number boundaryTolerance");
+    }
+
+    EGS_STACKG_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_gstack
+    :start geometry:
+        name = my_gstack
+        library = egs_gstack
+        geometries = geom1 geom2
+        # create geometries called geom1 geom2
+        tolerance = 1e-4
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_STACKG_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_STACKG_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -1089,7 +1089,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_NDGeometry"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -28,6 +28,7 @@
 #                   Ernesto Mainegra-Hing
 #                   Hubert Ho
 #                   Randle Taylor
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -1079,494 +1080,634 @@ const char *err_msg1 = "createGeometry(EGS_XYZRepeater)";
 
 #endif
 
-string EGS_NDGeometry::type = "EGS_NDGeometry";
+static string EGS_NDG_LOCAL typeStr("EGS_NDGeometry");
+string EGS_NDGeometry::type(typeStr);
+
+static bool EGS_NDG_LOCAL inputSet = false;
 
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_NDGeometry"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", false, "type of nd_geometry", {"EGS_XYZGeometry", "EGS_XYZRepeater"});
+
+        auto dimPtr = geomBlockInput->addSingleInput("dimensions", true, "A list of previously defined geometries.");
+        dimPtr->addDependency(typePtr, "", true);
+        auto hownPtr = geomBlockInput->addSingleInput("hownear method", false, "0(for orthogonal constituent geometries) or 1");
+        hownPtr->addDependency(typePtr, "", true);
+
+        // EGS_XYZGeometry
+        // First method
+        auto xPtr = geomBlockInput->addSingleInput("x-planes", false, "A list of the x-plane positions");
+        xPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto yPtr = geomBlockInput->addSingleInput("y-planes", false, "A list of the y-plane positions");
+        yPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto zPtr = geomBlockInput->addSingleInput("z-planes", false, "A list of the z-plane positions");
+        zPtr->addDependency(typePtr, "EGS_XYZGeometry");
+
+        // Second method
+        auto densityPtr = geomBlockInput->addSingleInput("density matrix", false, "Density file");
+        densityPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto ctPtr = geomBlockInput->addSingleInput("ct ramp", false, "Ramp file");
+        ctPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto phantPtr = geomBlockInput->addSingleInput("egsphant file", false, "An egsphant file");
+        phantPtr->addDependency(typePtr, "EGS_XYZGeometry");
+
+        // For second method, must either use "ct ramp" or "egsphant file"
+        densityPtr->addDependency(phantPtr, "", true);
+        phantPtr->addDependency(densityPtr, "", true);
+
+        // Third method
+        auto xslabPtr = geomBlockInput->addSingleInput("x-slabs", false, "Xo Dx Nx");
+        xslabPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto yslabPtr = geomBlockInput->addSingleInput("y-slabs", false, "Yo Dy Ny");
+        yslabPtr->addDependency(typePtr, "EGS_XYZGeometry");
+        auto zslabPtr = geomBlockInput->addSingleInput("z-slabs", false, "Zo Dz Nz");
+        zslabPtr->addDependency(typePtr, "EGS_XYZGeometry");
+
+        // Can only use one method
+        xPtr->addDependency(densityPtr, "", true);
+        yPtr->addDependency(densityPtr, "", true);
+        zPtr->addDependency(densityPtr, "", true);
+        xPtr->addDependency(ctPtr, "", true);
+        yPtr->addDependency(ctPtr, "", true);
+        zPtr->addDependency(ctPtr, "", true);
+        xPtr->addDependency(phantPtr, "", true);
+        yPtr->addDependency(phantPtr, "", true);
+        zPtr->addDependency(phantPtr, "", true);
+        xPtr->addDependency(xslabPtr, "", true);
+        yPtr->addDependency(xslabPtr, "", true);
+        zPtr->addDependency(xslabPtr, "", true);
+        xPtr->addDependency(yslabPtr, "", true);
+        yPtr->addDependency(yslabPtr, "", true);
+        zPtr->addDependency(yslabPtr, "", true);
+        xPtr->addDependency(zslabPtr, "", true);
+        yPtr->addDependency(zslabPtr, "", true);
+        zPtr->addDependency(zslabPtr, "", true);
+        densityPtr->addDependency(xPtr, "", true);
+        ctPtr->addDependency(xPtr, "", true);
+        phantPtr->addDependency(xPtr, "", true);
+        densityPtr->addDependency(yPtr, "", true);
+        ctPtr->addDependency(yPtr, "", true);
+        phantPtr->addDependency(yPtr, "", true);
+        densityPtr->addDependency(zPtr, "", true);
+        ctPtr->addDependency(zPtr, "", true);
+        phantPtr->addDependency(zPtr, "", true);
+        densityPtr->addDependency(xslabPtr, "", true);
+        ctPtr->addDependency(xslabPtr, "", true);
+        phantPtr->addDependency(xslabPtr, "", true);
+        densityPtr->addDependency(yslabPtr, "", true);
+        ctPtr->addDependency(yslabPtr, "", true);
+        phantPtr->addDependency(yslabPtr, "", true);
+        densityPtr->addDependency(zslabPtr, "", true);
+        ctPtr->addDependency(zslabPtr, "", true);
+        phantPtr->addDependency(zslabPtr, "", true);
+        xslabPtr->addDependency(xPtr, "", true);
+        xslabPtr->addDependency(yPtr, "", true);
+        xslabPtr->addDependency(zPtr, "", true);
+        xslabPtr->addDependency(densityPtr, "", true);
+        xslabPtr->addDependency(ctPtr, "", true);
+        xslabPtr->addDependency(phantPtr, "", true);
+        yslabPtr->addDependency(xPtr, "", true);
+        yslabPtr->addDependency(yPtr, "", true);
+        yslabPtr->addDependency(zPtr, "", true);
+        yslabPtr->addDependency(densityPtr, "", true);
+        yslabPtr->addDependency(ctPtr, "", true);
+        yslabPtr->addDependency(phantPtr, "", true);
+        zslabPtr->addDependency(xPtr, "", true);
+        zslabPtr->addDependency(yPtr, "", true);
+        zslabPtr->addDependency(zPtr, "", true);
+        zslabPtr->addDependency(densityPtr, "", true);
+        zslabPtr->addDependency(ctPtr, "", true);
+        zslabPtr->addDependency(phantPtr, "", true);
+
+
+        // EGS_XYZRepeater
+        auto regeomPtr = geomBlockInput->addSingleInput("repeated geometry", true, "The name of a previously defined geometry");
+        regeomPtr->addDependency(typePtr, "EGS_XYZRepeater");
+        auto medPtr = geomBlockInput->addSingleInput("medium", false, "The medium the space between  xmin..xmax, ymin..ymax, and zmin..zmax is filled with");
+        medPtr->addDependency(typePtr, "EGS_XYZRepeater");
+        auto rexPtr = geomBlockInput->addSingleInput("repeat x", true, "xmin xmax Nx");
+        rexPtr->addDependency(typePtr, "EGS_XYZRepeater");
+        auto reyPtr = geomBlockInput->addSingleInput("repeat y", true, "ymin ymax Ny");
+        reyPtr->addDependency(typePtr, "EGS_XYZRepeater");
+        auto rezPtr = geomBlockInput->addSingleInput("repeat z", true, "zmin zmax Nz");
+        rezPtr->addDependency(typePtr, "EGS_XYZRepeater");
+    }
+
+    EGS_NDG_EXPORT string getExample() {
+        string example;
+        example = {
+            R"(
+    # Example of egs_ndgeometry
+    #:start geometry:
+        library = EGS_NDGeometry
+        name = my_ndgeometry
+        dimensions = geom1 geom2
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_NDG_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_NDG_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 #ifdef EXPLICIT_XYZ
         const static char *func = "createGeometry(XYZ)";
-        string type;
-        int is_xyz = input->getInput("type",type);
-        if (!is_xyz && input->compare("EGS_XYZRepeater",type)) {
-            string base,medium;
-            vector<EGS_Float> xr, yr, zr;
-            int err1 = input->getInput("repeated geometry",base);
-            int err2 = input->getInput("repeat x",xr);
-            int err3 = input->getInput("repeat y",yr);
-            int err4 = input->getInput("repeat z",zr);
-            int err5 = input->getInput("medium",medium);
-            EGS_BaseGeometry *g = 0;
-            if (err1) {
-                egsWarning("%s: missing 'repeated geometry' input\n",err_msg1);
-            }
-            else {
-                g = EGS_BaseGeometry::getGeometry(base);
-                if (!g) {
-                    egsWarning("%s: no geometry named %s exists\n",err_msg1,
-                               base.c_str());
+            string type;
+            int is_xyz = input->getInput("type",type);
+            if (!is_xyz && input->compare("EGS_XYZRepeater",type)) {
+                string base,medium;
+                vector<EGS_Float> xr, yr, zr;
+                int err1 = input->getInput("repeated geometry",base);
+                int err2 = input->getInput("repeat x",xr);
+                int err3 = input->getInput("repeat y",yr);
+                int err4 = input->getInput("repeat z",zr);
+                int err5 = input->getInput("medium",medium);
+                EGS_BaseGeometry *g = 0;
+                if (err1) {
+                    egsWarning("%s: missing 'repeated geometry' input\n",err_msg1);
+                }
+                else {
+                    g = EGS_BaseGeometry::getGeometry(base);
+                    if (!g) {
+                        egsWarning("%s: no geometry named %s exists\n",err_msg1,
+                                   base.c_str());
+                        err1 = 1;
+                    }
+                }
+                if (err2 || xr.size() != 3) {
+                    err1 = 1;
+                    egsWarning("%s: wrong/missing 'repeat x' input\n",err_msg1);
+                }
+                if (err3 || yr.size() != 3) {
+                    err1 = 1;
+                    egsWarning("%s: wrong/missing 'repeat y' input\n",err_msg1);
+                }
+                if (err4 || zr.size() != 3) {
+                    err1 = 1;
+                    egsWarning("%s: wrong/missing 'repeat z' input\n",err_msg1);
+                }
+                if (err1) {
+                    return 0;
+                }
+                EGS_Float xmin = xr[0], xmax = xr[1];
+                int nx = (int)(xr[2]+0.1);
+                if (xmin >= xmax || nx < 1) {
+                    egsWarning("%s: wrong 'repeat x' input xmin=%g xmax=%g nx=%d\n",
+                               xmin,xmax,nx);
                     err1 = 1;
                 }
-            }
-            if (err2 || xr.size() != 3) {
-                err1 = 1;
-                egsWarning("%s: wrong/missing 'repeat x' input\n",err_msg1);
-            }
-            if (err3 || yr.size() != 3) {
-                err1 = 1;
-                egsWarning("%s: wrong/missing 'repeat y' input\n",err_msg1);
-            }
-            if (err4 || zr.size() != 3) {
-                err1 = 1;
-                egsWarning("%s: wrong/missing 'repeat z' input\n",err_msg1);
-            }
-            if (err1) {
-                return 0;
-            }
-            EGS_Float xmin = xr[0], xmax = xr[1];
-            int nx = (int)(xr[2]+0.1);
-            if (xmin >= xmax || nx < 1) {
-                egsWarning("%s: wrong 'repeat x' input xmin=%g xmax=%g nx=%d\n",
-                           xmin,xmax,nx);
-                err1 = 1;
-            }
-            EGS_Float ymin = yr[0], ymax = yr[1];
-            int ny = (int)(yr[2]+0.1);
-            if (ymin >= ymax || ny < 1) {
-                egsWarning("%s: wrong 'repeat y' input ymin=%g ymax=%g ny=%d\n",
-                           ymin,ymax,ny);
-                err1 = 1;
-            }
-            EGS_Float zmin = zr[0], zmax = zr[1];
-            int nz = (int)(zr[2]+0.1);
-            if (zmin >= zmax || nz < 1) {
-                egsWarning("%s: wrong 'repeat z' input zmin=%g zmax=%g nz=%d\n",
-                           zmin,zmax,nz);
-                err1 = 1;
-            }
-            if (err1) {
-                return 0;
-            }
-
-            EGS_XYZRepeater *result =
-                new EGS_XYZRepeater(xmin,xmax,ymin,ymax,zmin,zmax,nx,ny,nz,g);
-            result->setName(input);
-            result->setBoundaryTolerance(input);
-            if (!err5) {
-                result->setMedium(medium);
-            }
-            result->setXYZLabels(input);
-            result->setLabels(input);
-            return result;
-        }
-        else if (!is_xyz && input->compare("EGS_XYZGeometry",type)) {
-            string dens_file, ramp_file, egsphant_file, interfile_file;
-            int ierr1 = input->getInput("density matrix",dens_file);
-            int ierr2 = input->getInput("ct ramp",ramp_file);
-            int ierr3 = input->getInput("egsphant file",egsphant_file);
-            int ierr4 = input->getInput("interfile header",interfile_file);
-            int dens_or_egsphant_or_interfile = -1;
-            if (!ierr1) {
-                dens_or_egsphant_or_interfile = 0;
-            }
-            else if (!ierr3) {
-                dens_or_egsphant_or_interfile = 1;
-                dens_file = egsphant_file;
-            }
-            else if (!ierr4) {
-                dens_or_egsphant_or_interfile = 2;
-                dens_file = interfile_file;
-            }
-            if (dens_or_egsphant_or_interfile >= 0 || !ierr2) {
-                if (dens_or_egsphant_or_interfile < 0) {
-                    egsWarning("%s: no 'density matrix', 'egsphant file' or 'interfile header' input\n",func);
+                EGS_Float ymin = yr[0], ymax = yr[1];
+                int ny = (int)(yr[2]+0.1);
+                if (ymin >= ymax || ny < 1) {
+                    egsWarning("%s: wrong 'repeat y' input ymin=%g ymax=%g ny=%d\n",
+                               ymin,ymax,ny);
+                    err1 = 1;
+                }
+                EGS_Float zmin = zr[0], zmax = zr[1];
+                int nz = (int)(zr[2]+0.1);
+                if (zmin >= zmax || nz < 1) {
+                    egsWarning("%s: wrong 'repeat z' input zmin=%g zmax=%g nz=%d\n",
+                               zmin,zmax,nz);
+                    err1 = 1;
+                }
+                if (err1) {
                     return 0;
                 }
-                if (ierr2) {
-                    egsWarning("%s: no 'ct ramp' input\n",func);
-                    return 0;
-                }
-                EGS_XYZGeometry *result =
-                    EGS_XYZGeometry::constructGeometry(dens_file.c_str(),ramp_file.c_str(),dens_or_egsphant_or_interfile);
 
-                if (result) {
-                    result->setName(input);
-                    result->setBoundaryTolerance(input);
-                    result->setBScaling(input);
-                }
-
-                return result;
-            }
-            vector<EGS_Float> xpos, ypos, zpos, xslab, yslab, zslab;
-            int ix = input->getInput("x-planes",xpos);
-            int iy = input->getInput("y-planes",ypos);
-            int iz = input->getInput("z-planes",zpos);
-            int ix1 = input->getInput("x-slabs",xslab);
-            int iy1 = input->getInput("y-slabs",yslab);
-            int iz1 = input->getInput("z-slabs",zslab);
-            int nx=0, ny=0, nz=0;
-            if (!ix1) {
-                if (xslab.size() != 3) {
-                    egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
-                               " when using 'x-slabs' input method\n");
-                    ix1 = 1;
-                }
-                else {
-                    nx = (int)(xslab[2]+0.1);
-                    if (nx < 1) {
-                        egsWarning("createGeometry(XYZ): number of slabs must be"
-                                   " positive!\n");
-                        ix1 = 1;
-                    }
-                    if (xslab[1] <= 0) {
-                        egsWarning("createGeometry(XYZ): slab thickness must be"
-                                   " positive!\n");
-                        ix1 = 1;
-                    }
-                }
-            }
-            if (ix && ix1) {
-                egsWarning("createGeometry(XYZ): wrong/missing 'x-planes' "
-                           "and 'x-slabs' input\n");
-                return 0;
-            }
-            if (!iy1) {
-                if (yslab.size() != 3) {
-                    egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
-                               " when using 'y-slabs' input method\n");
-                    iy1 = 1;
-                }
-                else {
-                    ny = (int)(yslab[2]+0.1);
-                    if (ny < 1) {
-                        egsWarning("createGeometry(XYZ): number of slabs must be"
-                                   " positive!\n");
-                        iy1 = 1;
-                    }
-                    if (yslab[1] <= 0) {
-                        egsWarning("createGeometry(XYZ): slab thickness must be"
-                                   " positive!\n");
-                        iy1 = 1;
-                    }
-                }
-            }
-            if (iy && iy1) {
-                egsWarning("createGeometry(XYZ): wrong/missing 'y-planes' "
-                           "and 'y-slabs' input\n");
-                return 0;
-            }
-            if (!iz1) {
-                if (zslab.size() != 3) {
-                    egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
-                               " when using 'z-slabs' input method\n");
-                    iz1 = 1;
-                }
-                else {
-                    nz = (int)(zslab[2]+0.1);
-                    if (nz < 1) {
-                        egsWarning("createGeometry(XYZ): number of slabs must be"
-                                   " positive!\n");
-                        iz1 = 1;
-                    }
-                    if (zslab[1] <= 0) {
-                        egsWarning("createGeometry(XYZ): slab thickness must be"
-                                   " positive!\n");
-                        iz1 = 1;
-                    }
-                }
-            }
-            if (iz && iz1) {
-                egsWarning("createGeometry(XYZ): wrong/missing 'z-planes' "
-                           "and 'z-slabs' input\n");
-                return 0;
-            }
-            EGS_PlanesX *xp = !ix1 ?
-                              new EGS_PlanesX(xslab[0],xslab[1],nx,"",EGS_XProjector("x-planes")) :
-                              new EGS_PlanesX(xpos,"",EGS_XProjector("x-planes"));
-            EGS_PlanesY *yp = !iy1 ?
-                              new EGS_PlanesY(yslab[0],yslab[1],ny,"",EGS_YProjector("y-planes")) :
-                              new EGS_PlanesY(ypos,"",EGS_YProjector("y-planes"));
-            EGS_PlanesZ *zp = !iz1 ?
-                              new EGS_PlanesZ(zslab[0],zslab[1],nz,"",EGS_ZProjector("z-planes")) :
-                              new EGS_PlanesZ(zpos,"",EGS_ZProjector("z-planes"));
-            EGS_XYZGeometry *result = new EGS_XYZGeometry(xp,yp,zp);
-
-            if (result) {
-                egsWarning("**********************************************\n");
-                EGS_BaseGeometry *g = result;
+                EGS_XYZRepeater *result =
+                    new EGS_XYZRepeater(xmin,xmax,ymin,ymax,zmin,zmax,nx,ny,nz,g);
                 result->setName(input);
                 result->setBoundaryTolerance(input);
-                g->setMedia(input);
-                result->voxelizeGeometry(input);
-
-                // labels
+                if (!err5) {
+                    result->setMedium(medium);
+                }
                 result->setXYZLabels(input);
-                g->setLabels(input);
+                result->setLabels(input);
+                return result;
             }
-            return result;
-        }
+            else if (!is_xyz && input->compare("EGS_XYZGeometry",type)) {
+                string dens_file, ramp_file, egsphant_file, interfile_file;
+                int ierr1 = input->getInput("density matrix",dens_file);
+                int ierr2 = input->getInput("ct ramp",ramp_file);
+                int ierr3 = input->getInput("egsphant file",egsphant_file);
+                int ierr4 = input->getInput("interfile header",interfile_file);
+                int dens_or_egsphant_or_interfile = -1;
+                if (!ierr1) {
+                    dens_or_egsphant_or_interfile = 0;
+                }
+                else if (!ierr3) {
+                    dens_or_egsphant_or_interfile = 1;
+                    dens_file = egsphant_file;
+                }
+                else if (!ierr4) {
+                    dens_or_egsphant_or_interfile = 2;
+                    dens_file = interfile_file;
+                }
+                if (dens_or_egsphant_or_interfile >= 0 || !ierr2) {
+                    if (dens_or_egsphant_or_interfile < 0) {
+                        egsWarning("%s: no 'density matrix', 'egsphant file' or 'interfile header' input\n",func);
+                        return 0;
+                    }
+                    if (ierr2) {
+                        egsWarning("%s: no 'ct ramp' input\n",func);
+                        return 0;
+                    }
+                    EGS_XYZGeometry *result =
+                        EGS_XYZGeometry::constructGeometry(dens_file.c_str(),ramp_file.c_str(),dens_or_egsphant_or_interfile);
+
+                    if (result) {
+                        result->setName(input);
+                        result->setBoundaryTolerance(input);
+                        result->setBScaling(input);
+                    }
+
+                    return result;
+                }
+                vector<EGS_Float> xpos, ypos, zpos, xslab, yslab, zslab;
+                int ix = input->getInput("x-planes",xpos);
+                int iy = input->getInput("y-planes",ypos);
+                int iz = input->getInput("z-planes",zpos);
+                int ix1 = input->getInput("x-slabs",xslab);
+                int iy1 = input->getInput("y-slabs",yslab);
+                int iz1 = input->getInput("z-slabs",zslab);
+                int nx=0, ny=0, nz=0;
+                if (!ix1) {
+                    if (xslab.size() != 3) {
+                        egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
+                                   " when using 'x-slabs' input method\n");
+                        ix1 = 1;
+                    }
+                    else {
+                        nx = (int)(xslab[2]+0.1);
+                        if (nx < 1) {
+                            egsWarning("createGeometry(XYZ): number of slabs must be"
+                                       " positive!\n");
+                            ix1 = 1;
+                        }
+                        if (xslab[1] <= 0) {
+                            egsWarning("createGeometry(XYZ): slab thickness must be"
+                                       " positive!\n");
+                            ix1 = 1;
+                        }
+                    }
+                }
+                if (ix && ix1) {
+                    egsWarning("createGeometry(XYZ): wrong/missing 'x-planes' "
+                               "and 'x-slabs' input\n");
+                    return 0;
+                }
+                if (!iy1) {
+                    if (yslab.size() != 3) {
+                        egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
+                                   " when using 'y-slabs' input method\n");
+                        iy1 = 1;
+                    }
+                    else {
+                        ny = (int)(yslab[2]+0.1);
+                        if (ny < 1) {
+                            egsWarning("createGeometry(XYZ): number of slabs must be"
+                                       " positive!\n");
+                            iy1 = 1;
+                        }
+                        if (yslab[1] <= 0) {
+                            egsWarning("createGeometry(XYZ): slab thickness must be"
+                                       " positive!\n");
+                            iy1 = 1;
+                        }
+                    }
+                }
+                if (iy && iy1) {
+                    egsWarning("createGeometry(XYZ): wrong/missing 'y-planes' "
+                               "and 'y-slabs' input\n");
+                    return 0;
+                }
+                if (!iz1) {
+                    if (zslab.size() != 3) {
+                        egsWarning("createGeometry(XYZ): exactly 3 inputs are required"
+                                   " when using 'z-slabs' input method\n");
+                        iz1 = 1;
+                    }
+                    else {
+                        nz = (int)(zslab[2]+0.1);
+                        if (nz < 1) {
+                            egsWarning("createGeometry(XYZ): number of slabs must be"
+                                       " positive!\n");
+                            iz1 = 1;
+                        }
+                        if (zslab[1] <= 0) {
+                            egsWarning("createGeometry(XYZ): slab thickness must be"
+                                       " positive!\n");
+                            iz1 = 1;
+                        }
+                    }
+                }
+                if (iz && iz1) {
+                    egsWarning("createGeometry(XYZ): wrong/missing 'z-planes' "
+                               "and 'z-slabs' input\n");
+                    return 0;
+                }
+                EGS_PlanesX *xp = !ix1 ?
+                                  new EGS_PlanesX(xslab[0],xslab[1],nx,"",EGS_XProjector("x-planes")) :
+                                  new EGS_PlanesX(xpos,"",EGS_XProjector("x-planes"));
+                EGS_PlanesY *yp = !iy1 ?
+                                  new EGS_PlanesY(yslab[0],yslab[1],ny,"",EGS_YProjector("y-planes")) :
+                                  new EGS_PlanesY(ypos,"",EGS_YProjector("y-planes"));
+                EGS_PlanesZ *zp = !iz1 ?
+                                  new EGS_PlanesZ(zslab[0],zslab[1],nz,"",EGS_ZProjector("z-planes")) :
+                                  new EGS_PlanesZ(zpos,"",EGS_ZProjector("z-planes"));
+                EGS_XYZGeometry *result = new EGS_XYZGeometry(xp,yp,zp);
+
+                if (result) {
+                    egsWarning("**********************************************\n");
+                    EGS_BaseGeometry *g = result;
+                    result->setName(input);
+                    result->setBoundaryTolerance(input);
+                    g->setMedia(input);
+                    result->voxelizeGeometry(input);
+
+                    // labels
+                    result->setXYZLabels(input);
+                    g->setLabels(input);
+                }
+                return result;
+            }
 #endif
-        vector<EGS_BaseGeometry *> dims;
-        EGS_Input *ij;
-        int error = 0;
-        while ((ij = input->takeInputItem("geometry",false)) != 0) {
-            EGS_BaseGeometry *g = EGS_BaseGeometry::createSingleGeometry(ij);
-            if (g) {
-                dims.push_back(g);
-                g->ref();
-            }
-            else {
-                error++;
-            }
-            delete ij;
-        }
-        vector<string> gnames;
-        int err1 = input->getInput("dimensions",gnames);
-        if (!err1) {
-            for (unsigned int j=0; j<gnames.size(); j++) {
-                EGS_BaseGeometry *g = EGS_BaseGeometry::getGeometry(gnames[j]);
+            vector<EGS_BaseGeometry *> dims;
+            EGS_Input *ij;
+            int error = 0;
+            while ((ij = input->takeInputItem("geometry",false)) != 0) {
+                EGS_BaseGeometry *g = EGS_BaseGeometry::createSingleGeometry(ij);
                 if (g) {
                     dims.push_back(g);
                     g->ref();
                 }
                 else {
-                    egsWarning("Geometry %s does not exist\n",gnames[j].c_str());
                     error++;
                 }
+                delete ij;
             }
-        }
-        if (error) {
-            egsWarning("createGeometry(ND_Geometry): %d errors while "
-                       "creating/geting geometries defining individual dimensions\n",error);
-            return 0;
-        }
-        if (dims.size() < 2) {
-            egsWarning("createGeometry(ND_Geometry): why do you want to "
-                       "construct a ND geometry with a single dimension?\n");
-            input->print(0,cerr);
-            for (int j=0; j<gnames.size(); j++) egsWarning("dimension %d: %s\n",
-                        j+1,gnames[j].c_str());
-        }
-        int n_concav = 0;
-        for (int j=0; j<dims.size(); j++) if (!dims[j]->isConvex()) {
-                n_concav++;
+            vector<string> gnames;
+            int err1 = input->getInput("dimensions",gnames);
+            if (!err1) {
+                for (unsigned int j=0; j<gnames.size(); j++) {
+                    EGS_BaseGeometry *g = EGS_BaseGeometry::getGeometry(gnames[j]);
+                    if (g) {
+                        dims.push_back(g);
+                        g->ref();
+                    }
+                    else {
+                        egsWarning("Geometry %s does not exist\n",gnames[j].c_str());
+                        error++;
+                    }
+                }
             }
-        bool is_ok = true;
-        if (n_concav > 1) {
-            egsWarning("createGeometry(ND_Geometry): a ND geometry can not have "
-                       " more than one non-convex dimension, yours has %d\n",n_concav);
-            is_ok = false;
-        }
-        else if (n_concav == 1) {
-            if (dims[dims.size()-1]->isConvex()) {
-                egsWarning("createGeometry(ND_Geometry): the non-convex "
-                           "dimension must be the last dimension\n");
+            if (error) {
+                egsWarning("createGeometry(ND_Geometry): %d errors while "
+                           "creating/geting geometries defining individual dimensions\n",error);
+                return 0;
+            }
+            if (dims.size() < 2) {
+                egsWarning("createGeometry(ND_Geometry): why do you want to "
+                           "construct a ND geometry with a single dimension?\n");
+                input->print(0,cerr);
+                for (int j=0; j<gnames.size(); j++) egsWarning("dimension %d: %s\n",
+                            j+1,gnames[j].c_str());
+            }
+            int n_concav = 0;
+            for (int j=0; j<dims.size(); j++) if (!dims[j]->isConvex()) {
+                    n_concav++;
+                }
+            bool is_ok = true;
+            if (n_concav > 1) {
+                egsWarning("createGeometry(ND_Geometry): a ND geometry can not have "
+                           " more than one non-convex dimension, yours has %d\n",n_concav);
                 is_ok = false;
             }
-        }
-        if (!is_ok) {
-            for (int j=0; j<dims.size(); j++)
-                if (dims[j]->deref()) {
-                    delete dims[j];
+            else if (n_concav == 1) {
+                if (dims[dims.size()-1]->isConvex()) {
+                    egsWarning("createGeometry(ND_Geometry): the non-convex "
+                               "dimension must be the last dimension\n");
+                    is_ok = false;
                 }
-            return 0;
-        }
-        int hn_method=0;
-        err1 = input->getInput("hownear method",hn_method);
-        EGS_BaseGeometry *result;
-        if (!err1 && hn_method == 1) {
-            result = new EGS_NDGeometry(dims,"",false);
-        }
-        else {
-            result = new EGS_NDGeometry(dims);
-        }
-        result->setName(input);
-        result->setBoundaryTolerance(input);
-        result->setMedia(input);
-        result->setLabels(input);
-        return result;
-    }
-
-
-    void EGS_XYZGeometry::setXYZLabels(EGS_Input *input) {
-
-        // x,y,z labels
-        string inp;
-        int err;
-
-        err = input->getInput("set x label", inp);
-        if (!err) {
-            xp->setLabels(inp);
-        }
-
-        err = input->getInput("set y label", inp);
-        if (!err) {
-            yp->setLabels(inp);
-        }
-
-        err = input->getInput("set z label", inp);
-        if (!err) {
-            zp->setLabels(inp);
-        }
-    }
-
-
-    void EGS_NDGeometry::ndRegions(int r, int dim, int dimk, int k, vector<int> &regs) {
-
-        // skip looping over selected dimension
-        if (dim == dimk) {
-            r += k*n[dimk];
-            if (dim == N-1) {
-                regs.push_back(r);
+            }
+            if (!is_ok) {
+                for (int j=0; j<dims.size(); j++)
+                    if (dims[j]->deref()) {
+                        delete dims[j];
+                    }
+                return 0;
+            }
+            int hn_method=0;
+            err1 = input->getInput("hownear method",hn_method);
+            EGS_BaseGeometry *result;
+            if (!err1 && hn_method == 1) {
+                result = new EGS_NDGeometry(dims,"",false);
             }
             else {
-                ndRegions(r, dim+1, dimk, k, regs);
+                result = new EGS_NDGeometry(dims);
+            }
+            result->setName(input);
+            result->setBoundaryTolerance(input);
+            result->setMedia(input);
+            result->setLabels(input);
+            return result;
+        }
+
+
+        void EGS_XYZGeometry::setXYZLabels(EGS_Input *input) {
+
+            // x,y,z labels
+            string inp;
+            int err;
+
+            err = input->getInput("set x label", inp);
+            if (!err) {
+                xp->setLabels(inp);
+            }
+
+            err = input->getInput("set y label", inp);
+            if (!err) {
+                yp->setLabels(inp);
+            }
+
+            err = input->getInput("set z label", inp);
+            if (!err) {
+                zp->setLabels(inp);
             }
         }
 
-        // last dimension: end recursion and record global region number
-        else if (dim == N-1) {
-            for (int j=0; j<g[dim]->regions(); j++) {
-                regs.push_back(r+j*n[dim]);
+
+        void EGS_NDGeometry::ndRegions(int r, int dim, int dimk, int k, vector<int> &regs) {
+
+            // skip looping over selected dimension
+            if (dim == dimk) {
+                r += k*n[dimk];
+                if (dim == N-1) {
+                    regs.push_back(r);
+                }
+                else {
+                    ndRegions(r, dim+1, dimk, k, regs);
+                }
+            }
+
+            // last dimension: end recursion and record global region number
+            else if (dim == N-1) {
+                for (int j=0; j<g[dim]->regions(); j++) {
+                    regs.push_back(r+j*n[dim]);
+                }
+            }
+
+            // keep collecting by recursion
+            else {
+                for (int j=0; j<g[dim]->regions(); j++) {
+                    ndRegions(r + j*n[dim], dim+1, dimk, k, regs);
+                }
             }
         }
 
-        // keep collecting by recursion
-        else {
-            for (int j=0; j<g[dim]->regions(); j++) {
-                ndRegions(r + j*n[dim], dim+1, dimk, k, regs);
+
+        void EGS_NDGeometry::getLabelRegions(const string &str, vector<int> &regs) {
+
+            // label defined in the sub-geometries
+            vector<int> local_regs;
+            for (int i=0; i<N; i++) {
+                local_regs.clear();
+                if (g[i]) {
+                    g[i]->getLabelRegions(str, local_regs);
+                }
+                if (local_regs.size() == 0) {
+                    continue;
+                }
+
+                // recurse to collect all global regions comprised in each local region
+                for (int j=0; j<local_regs.size(); j++) {
+                    ndRegions(0, 0, i, local_regs[j], regs);
+                }
             }
+
+            // label defined in self (nd input block)
+            EGS_BaseGeometry::getLabelRegions(str, regs);
+
         }
-    }
 
 
-    void EGS_NDGeometry::getLabelRegions(const string &str, vector<int> &regs) {
+        void EGS_XYZGeometry::getLabelRegions(const string &str, vector<int> &regs) {
 
-        // label defined in the sub-geometries
-        vector<int> local_regs;
-        for (int i=0; i<N; i++) {
+            vector<int> local_regs;
+
+            // x plane labels
             local_regs.clear();
-            if (g[i]) {
-                g[i]->getLabelRegions(str, local_regs);
-            }
-            if (local_regs.size() == 0) {
-                continue;
+            xp->getLabelRegions(str, local_regs);
+            for (int i=0; i<local_regs.size(); i++) {
+                for (int j=0; j<ny; j++) {
+                    for (int k=0; k<nz; k++) {
+                        regs.push_back(local_regs[i] + nx*j + nxy*k);
+                    }
+                }
             }
 
-            // recurse to collect all global regions comprised in each local region
+            // y plane labels
+            local_regs.clear();
+            yp->getLabelRegions(str, local_regs);
             for (int j=0; j<local_regs.size(); j++) {
-                ndRegions(0, 0, i, local_regs[j], regs);
-            }
-        }
-
-        // label defined in self (nd input block)
-        EGS_BaseGeometry::getLabelRegions(str, regs);
-
-    }
-
-
-    void EGS_XYZGeometry::getLabelRegions(const string &str, vector<int> &regs) {
-
-        vector<int> local_regs;
-
-        // x plane labels
-        local_regs.clear();
-        xp->getLabelRegions(str, local_regs);
-        for (int i=0; i<local_regs.size(); i++) {
-            for (int j=0; j<ny; j++) {
-                for (int k=0; k<nz; k++) {
-                    regs.push_back(local_regs[i] + nx*j + nxy*k);
+                for (int i=0; i<nx; i++) {
+                    for (int k=0; k<nz; k++) {
+                        regs.push_back(i + nx*local_regs[j] + nxy*k);
+                    }
                 }
             }
-        }
 
-        // y plane labels
-        local_regs.clear();
-        yp->getLabelRegions(str, local_regs);
-        for (int j=0; j<local_regs.size(); j++) {
-            for (int i=0; i<nx; i++) {
-                for (int k=0; k<nz; k++) {
-                    regs.push_back(i + nx*local_regs[j] + nxy*k);
+            // z plane labels
+            local_regs.clear();
+            zp->getLabelRegions(str, local_regs);
+            for (int k=0; k<local_regs.size(); k++) {
+                for (int i=0; i<nx; i++) {
+                    for (int j=0; j<ny; j++) {
+                        regs.push_back(i + nx*j + nxy*local_regs[k]);
+                    }
                 }
             }
+
+            // label defined in self (xyz input block)
+            EGS_BaseGeometry::getLabelRegions(str, regs);
+
         }
 
-        // z plane labels
-        local_regs.clear();
-        zp->getLabelRegions(str, local_regs);
-        for (int k=0; k<local_regs.size(); k++) {
+
+        void EGS_XYZRepeater::getLabelRegions(const string &str, vector<int> &regs) {
+
+            vector<int> local_regs;
+
+            // label in repeated geometry
+            local_regs.clear();
+            g->getLabelRegions(str, local_regs);
             for (int i=0; i<nx; i++) {
                 for (int j=0; j<ny; j++) {
-                    regs.push_back(i + nx*j + nxy*local_regs[k]);
-                }
-            }
-        }
-
-        // label defined in self (xyz input block)
-        EGS_BaseGeometry::getLabelRegions(str, regs);
-
-    }
-
-
-    void EGS_XYZRepeater::getLabelRegions(const string &str, vector<int> &regs) {
-
-        vector<int> local_regs;
-
-        // label in repeated geometry
-        local_regs.clear();
-        g->getLabelRegions(str, local_regs);
-        for (int i=0; i<nx; i++) {
-            for (int j=0; j<ny; j++) {
-                for (int k=0; k<nz; k++) {
-                    for (int r=0; r<local_regs.size(); r++) {
-                        regs.push_back(ng*(i + nx*j + nxy*k) + local_regs[r]);
+                    for (int k=0; k<nz; k++) {
+                        for (int r=0; r<local_regs.size(); r++) {
+                            regs.push_back(ng*(i + nx*j + nxy*k) + local_regs[r]);
+                        }
                     }
                 }
             }
-        }
 
-        // x plane labels
-        local_regs.clear();
-        xyz->getXLabelRegions(str, local_regs);
-        for (int i=0; i<local_regs.size(); i++) {
-            for (int j=0; j<ny; j++) {
-                for (int k=0; k<nz; k++) {
-                    for (int r=0; r<ng; r++) {
-                        regs.push_back(ng*(local_regs[i] + nx*j + nxy*k) + r);
-                    }
-                }
-            }
-        }
-
-        // y plane labels
-        local_regs.clear();
-        xyz->getYLabelRegions(str, local_regs);
-        for (int j=0; j<local_regs.size(); j++) {
-            for (int i=0; i<nx; i++) {
-                for (int k=0; k<nz; k++) {
-                    for (int r=0; r<ng; r++) {
-                        regs.push_back(ng*(i + nx*local_regs[j] + nxy*k) + r);
-                    }
-                }
-            }
-        }
-
-        // z plane labels
-        local_regs.clear();
-        xyz->getZLabelRegions(str, local_regs);
-        for (int k=0; k<local_regs.size(); k++) {
-            for (int i=0; i<nx; i++) {
+            // x plane labels
+            local_regs.clear();
+            xyz->getXLabelRegions(str, local_regs);
+            for (int i=0; i<local_regs.size(); i++) {
                 for (int j=0; j<ny; j++) {
-                    for (int r=0; r<ng; r++) {
-                        regs.push_back(ng*(i + nx*j + nxy*local_regs[k]) + r);
+                    for (int k=0; k<nz; k++) {
+                        for (int r=0; r<ng; r++) {
+                            regs.push_back(ng*(local_regs[i] + nx*j + nxy*k) + r);
+                        }
                     }
                 }
             }
+
+            // y plane labels
+            local_regs.clear();
+            xyz->getYLabelRegions(str, local_regs);
+            for (int j=0; j<local_regs.size(); j++) {
+                for (int i=0; i<nx; i++) {
+                    for (int k=0; k<nz; k++) {
+                        for (int r=0; r<ng; r++) {
+                            regs.push_back(ng*(i + nx*local_regs[j] + nxy*k) + r);
+                        }
+                    }
+                }
+            }
+
+            // z plane labels
+            local_regs.clear();
+            xyz->getZLabelRegions(str, local_regs);
+            for (int k=0; k<local_regs.size(); k++) {
+                for (int i=0; i<nx; i++) {
+                    for (int j=0; j<ny; j++) {
+                        for (int r=0; r<ng; r++) {
+                            regs.push_back(ng*(i + nx*j + nxy*local_regs[k]) + r);
+                        }
+                    }
+                }
+            }
+
+            // label defined in self (repeater input block)
+            EGS_BaseGeometry::getLabelRegions(str, regs);
+
         }
 
-        // label defined in self (repeater input block)
-        EGS_BaseGeometry::getLabelRegions(str, regs);
-
     }
-
-}

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Iwan Kawrakow
 #                   Hubert Ho
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -194,7 +195,7 @@ static char EGS_OCTREE_LOCAL eoctree_message2[]  = "null input?";
 static char EGS_OCTREE_LOCAL eoctree_message5[]  = "wrong/missing 'min' or input?";
 static char EGS_OCTREE_LOCAL eoctree_message6[]  = "expecting 3 float inputs for 'box min' input";
 static char EGS_OCTREE_LOCAL eoctree_message7[]  = "wrong/missing 'max' or input?";
-static char EGS_OCTREE_LOCAL eoctree_message8[]  = "expecting 3 float inputs for 'max max' input";
+static char EGS_OCTREE_LOCAL eoctree_message8[]  = "expecting 3 float inputs for 'box max' input";
 static char EGS_OCTREE_LOCAL eoctree_message9[]  = "wrong or missing 'resolution' input?";
 static char EGS_OCTREE_LOCAL eoctree_message10[] = "expecting 3 integer inputs for 'resolution' input";
 static char EGS_OCTREE_LOCAL eoctree_message11[] = "wrong or missing 'discard child' input?";
@@ -212,7 +213,34 @@ static char EGS_OCTREE_LOCAL eoctree_key4[] = "child geometry";
 static char EGS_OCTREE_LOCAL eoctree_key5[] = "discard child";
 static char EGS_OCTREE_LOCAL eoctree_key6[] = "prune tree";
 
+static bool EGS_OCTREE_LOCAL inputSet = false;
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Octree"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("child geometry", true, "The name of child geometry");
+        geomBlockInput->addSingleInput("discard child", true, "yes or no");
+        geomBlockInput->addSingleInput("prune tree", false, "yes or no");
+
+        auto blockPtr = geomBlockInput->addBlockInput("octree box");
+        blockPtr->addSingleInput("box min", true, "(x, y, z)");
+        blockPtr->addSingleInput("box max", true, "(x, y, z)");
+        blockPtr->addSingleInput("resolution", true, "A specified resolution (x, y, z)");
+    }
+
+    EGS_OCTREE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_OCTREE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -46,6 +47,8 @@ const string EGS_PLANES_LOCAL xproj_type("EGS_Xplanes");
 const string EGS_PLANES_LOCAL yproj_type("EGS_Yplanes");
 const string EGS_PLANES_LOCAL zproj_type("EGS_Zplanes");
 const string EGS_PLANES_LOCAL proj_type("EGS_Planes");
+
+static bool EGS_PLANES_LOCAL inputSet = false;
 
 string EGS_PlaneCollection::type = "EGS_PlaneCollection";
 
@@ -87,6 +90,78 @@ void EGS_PlaneCollection::printInfo() const {
 }
 
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Planes"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of plane.", {"EGS_XPlanes", "EGS_YPlanes", "EGS_ZPlanes", "EGS_Planes", "EGS_PlaneCollection"});
+
+        auto posPtr = geomBlockInput->addSingleInput("positions", false, "A list of plane co-ordinates");
+
+        // EGS_Planes
+        auto norPtr = geomBlockInput->addSingleInput("normal", true, "The plane normal (x, y, z)");
+        norPtr->addDependency(typePtr, "EGS_Planes");
+
+        // EGS_PlaneCollection
+        auto normsPtr = geomBlockInput->addSingleInput("normals", true, "3N number inputs For each plane's normal");
+        normsPtr->addDependency(typePtr, "EGS_PlaneCollection");
+
+        // Alternative definition of the plane position
+        auto fpPtr = geomBlockInput->addSingleInput("first plane", false, "The position of the first plane.");
+        auto slabPtr = geomBlockInput->addSingleInput("slab thickness", false, "A list of the thickness between each set of planes");
+        auto numPtr = geomBlockInput->addSingleInput("number of slabs", false, "A list of the number of slabs");
+
+        // Either positions or the alternatives must be used, not both
+        fpPtr->addDependency(posPtr, "", true);
+        slabPtr->addDependency(posPtr, "", true);
+        numPtr->addDependency(posPtr, "", true);
+        posPtr->addDependency(fpPtr, "", true);
+        posPtr->addDependency(slabPtr, "", true);
+        posPtr->addDependency(numPtr, "", true);
+    }
+
+    EGS_PLANES_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Examples of the egs_planes
+
+    # EGS_Plane example
+    #:start geometry:
+        library = egs_planes
+        type = EGS_Planes
+        name = my_plane
+        positions = 2 2 2
+        normal = 0
+    :stop geometry:
+
+   # EGS_PlaneCollection example
+   #:start geometry:
+        library = egs_planes
+        type = EGS_PlaneCollection
+        name = my_plane_collection
+        normals = 0 0 1 0.1  -0.1 1  -0.1 -0.3 1  0 0 1
+        positions = -5 -2 2 12
+        :start media input:
+            media = air water air
+            set medium = 1 1
+            set medium = 2 2
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_PLANES_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_PLANES_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         string type;

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -45,7 +46,51 @@ static EGS_PRISM_LOCAL string __prismY("EGS_PrismY");
 static EGS_PRISM_LOCAL string __prismZ("EGS_PrismZ");
 static EGS_PRISM_LOCAL string __prism("EGS_Prism");
 
+static bool EGS_PRISM_LOCAL inputSet = false;
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Prism"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of prism", {"EGS_PrismX", "EGS_PrismY", "EGS_PrismZ", "EGS_Prism"});
+
+        geomBlockInput->addSingleInput("closed", false, "Two inputs that define the distance from the top and bottom prism plane to the plane used to define the polygon");
+        geomBlockInput->addSingleInput("points", true, "A list of 2D or 3D positions.");
+    }
+
+    EGS_PRISM_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_prisms
+
+    # EGS_PrismZ example
+    #:start geometry:
+        name = my_prism
+        library = egs_prism
+        type = EGS_PrismZ
+        points = 1 1  -1 1  -1 -1  4 -1
+        closed = 1 4
+        :start media input:
+            media = air
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_PRISM_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_PRISM_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -53,7 +53,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_Prism"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -100,7 +100,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_Pyramid"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -45,6 +46,8 @@ static EGS_PYRAMID_LOCAL string __pyrX = "EGS_PyramidX";
 static EGS_PYRAMID_LOCAL string __pyrY = "EGS_PyramidY";
 static EGS_PYRAMID_LOCAL string __pyrZ = "EGS_PyramidZ";
 static EGS_PYRAMID_LOCAL string __pyr  = "EGS_Pyramid";
+
+static bool EGS_PYRAMID_LOCAL inputSet = false;
 
 template<class T>
 EGS_PyramidT<T>::EGS_PyramidT(T *P, const EGS_Vector &Xo, bool O,
@@ -93,6 +96,50 @@ void EGS_PyramidT<T>::printInfo() const {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Pyramid"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of pyramid", {"EGS_PyramidX", "EGS_PyramidY", "EGS_PyramidZ", "EGS_Pyramid"});
+
+        geomBlockInput->addSingleInput("points", true, "A list of 2D or 3D positions");
+        geomBlockInput->addSingleInput("tip", true, "The 3D position of the tip of the pyramid (x, y ,z)");
+        geomBlockInput->addSingleInput("closed", false, "0 (open) or 1 (closed)");
+    }
+
+    EGS_PYRAMID_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_pyramid
+
+    # EGS_PyramidZ example
+    #:start geometry:
+        name = my_pyramid
+        library = egs_pyramid
+        type = EGS_PyramidZ
+        points = 1 1  -1 1  -1 -1  4 -1
+        tip = 0 0 7
+        closed = 0
+        :start media input:
+            media = air
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_PYRAMID_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_PYRAMID_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Manuel Stoeckl, 2016
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 #
@@ -41,7 +41,58 @@
 #include "egs_roundrect_cylinders.h"
 #include "egs_input.h"
 
+static bool EGS_ROUNDRECT_CYLINDERS_LOCAL inputSet = false;
+
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_RoundRect_Cylinders"});
+
+        // Format: name, isRequired, description, vector string of allowed inputs
+        auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of rounded rectangle cylinder", {"EGS_RoundRectCylinders", "EGS_RoundRectCylindersXY", "EGS_RoundRectCylindersYZ", "EGS_RoundRectCylindersXZ"});
+
+        geomBlockInput->addSingleInput("x-widths", true, "A list of cylinder half-widths in the x-direction, must be in increasing order");
+        geomBlockInput->addSingleInput("y-widths", true, "A list of cylinder half-widths in the y-direction, must be in increasing order");
+        geomBlockInput->addSingleInput("radii", true, "A list of fillet radii, must be in increasing order");
+        geomBlockInput->addSingleInput("midpoint", false, "The position of the midpoint (x, y, z)");
+
+        // EGS_RoundRectCylinders
+        auto inpPtr = geomBlockInput->addSingleInput("x-axis", true, "x-axis of rounded rectangle (x, y, z)");
+        inpPtr->addDependency(typePtr, "EGS_RoundRectCylinders");
+        auto yinpPtr = geomBlockInput->addSingleInput("y-axis", true, "y-axis of rounded rectangle (x, y, z)");
+        yinpPtr->addDependency(typePtr, "EGS_RoundRectCylinders");
+    }
+
+    EGS_ROUNDRECT_CYLINDERS_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of rounded reactangle cylinder
+    #:start geometry:
+        name = my_roundedrectcylinder
+        library = egs_roundrect_cylinders
+        type = EGS_RoundRectCylindersXY
+        x-widths = 1 2
+        y-widths = 0.5 1
+        radii = 0.1 0.5
+        :start media input:
+            media = air water
+            set medium = 1 1
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_ROUNDRECT_CYLINDERS_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_ROUNDRECT_CYLINDERS_EXPORT
     EGS_BaseGeometry *createGeometry(EGS_Input *input) {

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
@@ -47,7 +47,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_RoundRect_Cylinders"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
@@ -27,6 +27,7 @@
 #  Contributors:    Marc Chamberland
 #                   Rowan Thomson
 #                   Dave Rogers
+#                   Hannah Gallop
 #
 ###############################################################################
 #
@@ -47,6 +48,7 @@
 #include "../egs_cylinders/egs_cylinders.h"
 #include "../egs_planes/egs_planes.h"
 
+static bool EGS_RZ_LOCAL inputSet = false;
 
 string EGS_RZGeometry::RZType = "EGS_RZ";
 
@@ -228,6 +230,72 @@ bool allIncreasing(vector<EGS_Float> vec) {
 };
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_RZ"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto  radPtr = geomBlockInput->addSingleInput("radii", false, "A list of radii, must be in increasing order");
+        auto planePtr = geomBlockInput->addSingleInput("z-planes", false, "Input for z-planes");
+
+        // Or can define using slabs and shells
+        auto num_shellPtr = geomBlockInput->addSingleInput("number of shells", false, "A list of the number of shells");
+        auto shellPtr = geomBlockInput->addSingleInput("shell thickness", false, "A list of shell thicknesses");
+        auto firstPtr = geomBlockInput->addSingleInput("first plane", false, "first plane");
+        auto num_slabPtr = geomBlockInput->addSingleInput("number of slabs", false, "A list of the number of slabs");
+        auto slabPtr = geomBlockInput->addSingleInput("slab thickness", false, "A list of the slab thicknesses");
+
+        // Can only use one method
+        radPtr->addDependency(num_shellPtr, "", true);
+        radPtr->addDependency(shellPtr, "", true);
+        radPtr->addDependency(firstPtr, "", true);
+        radPtr->addDependency(num_slabPtr, "", true);
+        radPtr->addDependency(slabPtr, "", true);
+        planePtr->addDependency(num_shellPtr, "", true);
+        planePtr->addDependency(shellPtr, "", true);
+        planePtr->addDependency(firstPtr, "", true);
+        planePtr->addDependency(num_slabPtr, "", true);
+        planePtr->addDependency(slabPtr, "", true);
+        num_shellPtr->addDependency(radPtr, "", true);
+        num_shellPtr->addDependency(planePtr, "", true);
+        shellPtr->addDependency(radPtr, "", true);
+        shellPtr->addDependency(planePtr, "", true);
+        firstPtr->addDependency(radPtr, "", true);
+        firstPtr->addDependency(planePtr, "", true);
+        num_slabPtr->addDependency(radPtr, "", true);
+        num_slabPtr->addDependency(planePtr, "", true);
+        slabPtr->addDependency(radPtr, "", true);
+        slabPtr->addDependency(planePtr, "", true);
+    }
+
+    EGS_RZ_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_rz
+    :start geometry:
+        name = my_rz
+        library = egs_rz
+        radii = 1 2 3
+        z-planes= -4 -3 -2 -1 0 1 2 3 4
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_RZ_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_RZ_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
 

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
+#                   Hannah Gallop
 #
 ###############################################################################
 #

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -65,6 +65,8 @@ using namespace std;
 
 string EGS_SMART_ENVELOPE_LOCAL EGS_SmartEnvelope::type = "EGS_SmartEnvelope";
 
+static bool EGS_SMART_ENVELOPE_LOCAL inputSet = false;
+
 void EGS_SmartEnvelope::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_SmartEnvelope::setMedia: don't use this method. Use the\n"
                " setMedia() methods of the geometry objects that make up this geometry\n");
@@ -253,6 +255,25 @@ static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword2[] = "geometry";
 //static char EGS_SMART_ENVELOPE_LOCAL eeg_keyword3[] = "inscribed geometries";
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_SmartEnvelope"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("base geometry", true, "The name of a previously defined geometry");
+        geomBlockInput->addSingleInput("inscribed geometries", true, "A list of previously defined geometries");
+    }
+
+    EGS_SMART_ENVELOPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_SMART_ENVELOPE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {

--- a/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -39,7 +40,24 @@
 
 string EGS_Space::type = "EGS_Space";
 
+static bool EGS_SPACE_LOCAL inputSet = false;
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Space"});
+    }
+
+    EGS_SPACE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if (!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_SPACE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         EGS_Space *g = new EGS_Space("");

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -687,7 +687,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs();
 
         geomBlockInput->getSingleInput("library")->setValues({"EGS_Spheres"});
 

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -27,6 +27,7 @@
 #                   Frederic Tessier
 #                   Reid Townson
 #                   Randle Taylor
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -45,6 +46,8 @@
 using std::vector;
 
 string EGS_cSpheres::type = "EGS_cSpheres";
+
+static bool EGS_SPHERES_LOCAL inputSet = false;
 
 // generate the concentric spheres
 EGS_cSpheres::EGS_cSpheres(int ns, const EGS_Float *radius,
@@ -680,6 +683,45 @@ void EGS_cSphericalShell::printInfo() const {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_Spheres"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("radii", true, "A of list of sphere radii in increasing order.");
+        geomBlockInput->addSingleInput("midpoint", false, "The position of the middle of the sphere (x, y, z)");
+    }
+
+    EGS_SPHERES_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_spheres
+    #:start geometry:
+        name = my_spheres
+        library = egs_spheres
+        midpoint = 0 0 0
+        radii = 1 2 3
+        :start media input:
+            media = air water air
+            set medium = 1 1
+            set medium = 2 2
+        :stop media input:
+    :stop geometry input:
+)"};
+        return example;
+    }
+
+    EGS_SPHERES_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_SPHERES_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Frederic Tessier
 #                   Ernesto Mainegra-Hing
 #                   Hubert Ho
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -43,6 +44,8 @@
 using namespace std;
 
 string EGS_UNIONG_LOCAL EGS_UnionGeometry::type = "EGS_UnionGeometry";
+
+static bool EGS_UNIONG_LOCAL inputSet = false;
 
 void EGS_UnionGeometry::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_UnionGeometry::setMedia: don't use this method. Use the\n"
@@ -167,6 +170,38 @@ void EGS_UnionGeometry::printInfo() const {
 }
 
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"EGS_gunion"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("geometries", true, "A list of names of previously defined geometries");
+        geomBlockInput->addSingleInput("priorities", false, "A list of integers defining the geometry priorities");
+    }
+
+    EGS_UNIONG_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example of egs_gunion
+    #:start geometry:
+        name = my_union
+        library = egs_union
+        geometries = my_box my_sphere
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_UNIONG_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_UNIONG_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {
@@ -203,8 +238,8 @@ extern "C" {
                 }
             }
             else egsWarning("createGeometry(union): the number of priorities (%d)"
-                                " is not the same as the number of geometries (%d) => ignoring\n",
-                                pri.size(),geoms.size());
+            " is not the same as the number of geometries (%d) => ignoring\n",
+            pri.size(),geoms.size());
         }
         EGS_BaseGeometry *result = new EGS_UnionGeometry(geoms,p);
         result->setName(input);

--- a/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 */
@@ -38,7 +38,39 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static string EGS_CIRCLE_LOCAL typeStr("EGS_Circle");
+static bool EGS_CIRCLE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_CIRCLE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", vector<string>(1, typeStr));
+        shapeBlockInput->addSingleInput("radius", false, "The radius of the circle.");
+        shapeBlockInput->addSingleInput("midpoint", false, "The x, y midpoint of the circle, which is in the x-y plane located at z=0. Use an EGS_AffineTransform block to translate or rotate the shape.");
+        shapeBlockInput->addSingleInput("inner radius", false, "The inner radius, to define a ring. Points will only be sampled within the ring between the 'inner radius' and 'radius'.");
+    }
+
+    EGS_CIRCLE_EXPORT string getExample() {
+        string example
+{R"(
+        :start shape:
+            library = egs_circle
+            radius = the circle radius
+            midpoint = Ox, Oy (optional)
+            inner radius = the inner radius (optional)
+        :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_CIRCLE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_CIRCLE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
@@ -50,6 +50,7 @@ extern "C" {
         shapeBlockInput->addSingleInput("radius", false, "The radius of the circle.");
         shapeBlockInput->addSingleInput("midpoint", false, "The x, y midpoint of the circle, which is in the x-y plane located at z=0. Use an EGS_AffineTransform block to translate or rotate the shape.");
         shapeBlockInput->addSingleInput("inner radius", false, "The inner radius, to define a ring. Points will only be sampled within the ring between the 'inner radius' and 'radius'.");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_CIRCLE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
@@ -54,8 +54,8 @@ extern "C" {
     }
 
     EGS_CIRCLE_EXPORT string getExample() {
-        string example
-{R"(
+        string example {
+            R"(
         :start shape:
             library = egs_circle
             radius = the circle radius

--- a/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
@@ -205,6 +205,8 @@ extern "C" {
         blockPtr->addSingleInput("thickness", true, "The thickness of the layer");
         blockPtr->addSingleInput("top radii", false, "1 (outer radius, inner radius assumed to be 0) or 2 (outer and inner radius) inputs, only required for top layer");
         blockPtr->addSingleInput("bottom radii", true, "1 (outer radius, inner radius assumed to be 0) or 2 (outer and inner radius) inputs");
+
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_CONICAL_SHELL_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
@@ -211,8 +211,8 @@ extern "C" {
 
     EGS_CONICAL_SHELL_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_conical_shell
     #:start shape:
         library = egs_conical_shell

--- a/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -38,7 +38,39 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static bool EGS_ELLIPSE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_ELLIPSE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Ellipse"});
+        shapeBlockInput->addSingleInput("halfaxis", true, "The two half axis of the ellipse.");
+        shapeBlockInput->addSingleInput("midpoint", false, "The midpoint of the ellipse, (x, y).");
+    }
+
+    EGS_ELLIPSE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example fo egs_ellipse
+    #:start shape:
+        library = egs_ellipse
+        halfway = the two half axis of the ellipse
+        midpoint = Ox, Oy (optional)
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_ELLIPSE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+       if(!inputSet) {
+           setInputs();
+       }
+       return shapeBlockInput;
+    }
 
     EGS_ELLIPSE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
@@ -49,6 +49,7 @@ extern "C" {
         shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Ellipse"});
         shapeBlockInput->addSingleInput("halfaxis", true, "The two half axis of the ellipse.");
         shapeBlockInput->addSingleInput("midpoint", false, "The midpoint of the ellipse, (x, y).");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_ELLIPSE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
@@ -54,8 +54,8 @@ extern "C" {
 
     EGS_ELLIPSE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example fo egs_ellipse
     #:start shape:
         library = egs_ellipse

--- a/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
@@ -54,8 +54,8 @@ extern "C" {
 
     EGS_EXTENDED_SHAPE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_extended_shape
     #:start shape:
         library = egs_extended_shape

--- a/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -38,7 +38,41 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static bool EGS_EXTENDED_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_EXTENDED_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Extended_Shape"});
+        shapeBlockInput->addSingleInput("extension", true, "Adds delta z to the z-component of the position vector (z1, z2)");
+
+        auto shapePtr = shapeBlockInput->addBlockInput("shape");
+        setShapeInputs(shapePtr);
+    }
+
+    EGS_EXTENDED_SHAPE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_extended_shape
+    #:start shape:
+        library = egs_extended_shape
+        :start shape:
+            definition of the shape to be 'extended'
+        :stop shape:
+        extension = z1 z2
+)"};
+        return example;
+    }
+
+    EGS_EXTENDED_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_EXTENDED_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -38,7 +38,42 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static bool EGS_GAUSSIAN_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_GAUSSIAN_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Gaussian_Shape"});
+        shapeBlockInput->addSingleInput("sigma", true, "1 or 2 or 3 inputs");
+
+        auto shapePtr = shapeBlockInput->addBlockInput("shape");
+        setShapeInputs(shapePtr);
+    }
+
+    EGS_GAUSSIAN_SHAPE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_gaussiam_shape
+    #:start shape:
+        library = egs_gaussian_shape
+        :start shape:
+            definition of the shape to be smeared
+        :stop shape:
+        sigma = 1, 2 or 3 inputs
+)"};
+        return example;
+    }
+
+    EGS_GAUSSIAN_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_GAUSSIAN_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
@@ -55,8 +55,8 @@ extern "C" {
 
     EGS_GAUSSIAN_SHAPE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_gaussiam_shape
     #:start shape:
         library = egs_gaussian_shape

--- a/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,6 +37,9 @@
 #include "egs_line_shape.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_LINE_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_LINE_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 EGS_LineShape::EGS_LineShape(const vector<EGS_Float> &points,
                              const string &Name, EGS_ObjectFactory *f) : EGS_BaseShape(Name,f) {
@@ -62,6 +65,33 @@ EGS_LineShape::EGS_LineShape(const vector<EGS_Float> &points,
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Line_Shape"});
+        shapeBlockInput->addSingleInput("points", true, "A list of 2D positions, at least 2 required");
+    }
+
+    EGS_LINE_SHAPE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_line_shape
+    :start shape:
+        library = egs_line_shape
+        points = list of 2D positions
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_LINE_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_LINE_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
@@ -71,6 +71,7 @@ extern "C" {
 
         shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Line_Shape"});
         shapeBlockInput->addSingleInput("points", true, "A list of 2D positions, at least 2 required");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_LINE_SHAPE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
@@ -76,8 +76,8 @@ extern "C" {
 
     EGS_LINE_SHAPE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_line_shape
     :start shape:
         library = egs_line_shape

--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
@@ -152,8 +152,8 @@ extern "C" {
 
     EGS_POLYGON_SHAPE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_polygon_shape
     #:start shape:
         library = egs_polygon_shape

--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
@@ -147,6 +147,7 @@ extern "C" {
         inputSet = true;
         shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Polygon_Shape"});
         shapeBlockInput->addSingleInput("points", true, "A list of at least 3 2D points (at least 6 floating numbers)");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_POLYGON_SHAPE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -39,6 +39,9 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 #include "egs_math.h"
+
+static bool EGS_POLYGON_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_POLYGON_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 EGS_TriangleShape::EGS_TriangleShape(const vector<EGS_Float> &points,
                                      const string &Name, EGS_ObjectFactory *f) : EGS_SurfaceShape(Name,f) {
@@ -139,6 +142,32 @@ EGS_PolygonShape::EGS_PolygonShape(const vector<EGS_Float> &points,
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Polygon_Shape"});
+        shapeBlockInput->addSingleInput("points", true, "A list of at least 3 2D points (at least 6 floating numbers)");
+    }
+
+    EGS_POLYGON_SHAPE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_polygon_shape
+    #:start shape:
+        library = egs_polygon_shape
+        points = list of 2D points
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_POLYGON_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_POLYGON_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -105,6 +105,7 @@ extern "C" {
         shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Rectangle"});
         shapeBlockInput->addSingleInput("rectangle", true, "x1 y1 x2 y2");
         shapeBlockInput->addSingleInput("inner rectangle", false, "xp1 yp1 xp2 yp2");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_RECTANGLE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -110,8 +110,8 @@ extern "C" {
 
     EGS_RECTANGLE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_rectangle
     #:start shape:
         library = egs_rectangle

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,6 +37,9 @@
 #include "egs_rectangle.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_RECTANGLE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_RECTANGLE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 EGS_RectangularRing::EGS_RectangularRing(EGS_Float xmin, EGS_Float xmax,
         EGS_Float ymin, EGS_Float ymax, EGS_Float xmin_i, EGS_Float xmax_i,
@@ -96,6 +99,32 @@ EGS_RectangularRing::~EGS_RectangularRing() {
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Rectangle"});
+        shapeBlockInput->addSingleInput("rectangle", true, "x1 y1 x2 y2");
+        shapeBlockInput->addSingleInput("inner rectangle", false, "xp1 yp1 xp2 yp2");
+    }
+
+    EGS_RECTANGLE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_rectangle
+    #:start shape:
+        library = egs_rectangle
+        reactangle = -.1 -.1 .1 .1
+)"};
+        return example;
+    }
+
+    EGS_RECTANGLE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_RECTANGLE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -115,7 +115,7 @@ extern "C" {
     # Example of egs_rectangle
     #:start shape:
         library = egs_rectangle
-        reactangle = -.1 -.1 .1 .1
+        rectangle = -.1 -.1 .1 .1
 )"};
         return example;
     }

--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
@@ -75,8 +75,8 @@ extern "C" {
 
     EGS_SHAPE_COLLECTION_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_shape_collection
     #:start shape:
         library = egs_shape_sollection
@@ -147,7 +147,7 @@ extern "C" {
         }
         if (shapes.size() != probs.size()) {
             egsWarning("createShape(shape collection): the number of shapes (%d)"
-                       " is not the same as the number of input probabilities (%d)\n");
+            " is not the same as the number of input probabilities (%d)\n");
             ok = false;
         }
         for (unsigned int i=0; i<probs.size(); i++) {

--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Marc Chamberland
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,6 +38,9 @@
 #include "egs_shape_collection.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_SHAPE_COLLECTION_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_SHAPE_COLLECTION_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 EGS_ShapeCollection::EGS_ShapeCollection(const vector<EGS_BaseShape *> &Shapes,
         const vector<EGS_Float> &Probs, const string &Name, EGS_ObjectFactory *f) :
@@ -59,6 +63,45 @@ EGS_ShapeCollection::EGS_ShapeCollection(const vector<EGS_BaseShape *> &Shapes,
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Shape_Collection"});
+        shapeBlockInput->addSingleInput("probabilities", true, "p1 p2 ... pn");
+
+        auto shapePtr = shapeBlockInput->addBlockInput("shape");
+        setShapeInputs(shapePtr);
+    }
+
+    EGS_SHAPE_COLLECTION_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_shape_collection
+    #:start shape:
+        library = egs_shape_sollection
+        :start shape:
+            definition of the first shape in the collection:
+        :stop shape:
+        :start shape:
+            definition of the second shape in the collection
+        :stop shape:
+        ...
+        :start shape:
+            definition of the last shape in the collection
+        :stop shape:
+        probablities = p1 p2 ... pn
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_SHAPE_COLLECTION_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_SHAPE_COLLECTION_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
@@ -79,7 +79,7 @@ extern "C" {
             R"(
     # Example of egs_shape_collection
     #:start shape:
-        library = egs_shape_sollection
+        library = egs_shape_collection
         :start shape:
             definition of the first shape in the collection:
         :stop shape:

--- a/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
@@ -146,8 +146,8 @@ extern "C" {
 
     EGS_SPHERICAL_SHELL_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_spherical_shell
     #:start shape:
         library = egs_spherical_shell

--- a/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
@@ -152,7 +152,7 @@ extern "C" {
     #:start shape:
         library = egs_spherical_shell
         midpoint = 0 0 0
-        innner radius = 0.5
+        inner radius = 0.5
         outer radius = 1
         hemisphere = 1
         half angle = 35

--- a/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
@@ -141,6 +141,7 @@ extern "C" {
         shapeBlockInput->addSingleInput("outer radius", true, "The outer radius");
         shapeBlockInput->addSingleInput("hemisphere", false, "Hemisphere");
         shapeBlockInput->addSingleInput("hemisphere", false, "The half angle, in degrees");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_SPHERICAL_SHELL_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
@@ -27,6 +27,7 @@
 #  Contributors:    Marc Chamberland
 #                   Rowan Thomson
 #                   Dave Rogers
+#                   Hannah Gallop
 #
 ###############################################################################
 #
@@ -45,6 +46,9 @@
 #include "egs_spherical_shell.h"
 #include "egs_input.h"
 #include "egs_functions.h"
+
+static bool EGS_SPHERICAL_SHELL_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_SPHERICAL_SHELL_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 EGS_SphericalShellShape::EGS_SphericalShellShape(EGS_Float ri, EGS_Float ro, int hemisph, EGS_Float halfangle, const EGS_Vector &Xo,
         const string &Name,EGS_ObjectFactory *f) :
@@ -127,6 +131,41 @@ EGS_Float EGS_SphericalShellShape::area() const {
 };
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Spherical_Shape"});
+        shapeBlockInput->addSingleInput("midpoint", true, "The midpoint of the shape, (x y z)");
+        shapeBlockInput->addSingleInput("inner radius", true, "The inner radius");
+        shapeBlockInput->addSingleInput("outer radius", true, "The outer radius");
+        shapeBlockInput->addSingleInput("hemisphere", false, "Hemisphere");
+        shapeBlockInput->addSingleInput("hemisphere", false, "The half angle, in degrees");
+    }
+
+    EGS_SPHERICAL_SHELL_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_spherical_shell
+    #:start shape:
+        library = egs_spherical_shell
+        midpoint = 0 0 0
+        innner radius = 0.5
+        outer radius = 1
+        hemisphere = 1
+        half angle = 35
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_SPHERICAL_SHELL_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_SPHERICAL_SHELL_EXPORT EGS_BaseShape *createShape(EGS_Input *input, EGS_ObjectFactory *f) {
 

--- a/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2009
 #
 #  Contributors:    Frederic Tessier
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -40,6 +41,9 @@
 
 #include <fstream>
 using namespace std;
+
+static bool EGS_VOXELIZED_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_VOXELIZED_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 
 void EGS_VoxelizedShape::EGS_VoxelizedShapeFormat0(const char *fname,
         const string &Name,EGS_ObjectFactory *f) {
@@ -367,6 +371,33 @@ EGS_VoxelizedShape::~EGS_VoxelizedShape() {
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Voxelized_Shape"});
+        shapeBlockInput->addSingleInput("file name", true, "The name of a file that is in binary");
+    }
+
+    EGS_VOXELIZED_SHAPE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_voxelized_shape
+    #:start shape:
+        library = egs_voxelized_shape
+        file name = some_file
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_VOXELIZED_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_VOXELIZED_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
@@ -382,8 +382,8 @@ extern "C" {
 
     EGS_VOXELIZED_SHAPE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_voxelized_shape
     #:start shape:
         library = egs_voxelized_shape
@@ -403,31 +403,31 @@ extern "C" {
     EGS_VOXELIZED_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {
         static const char *func = "createShape(voxelized shape)";
-        if (!input) {
-            egsWarning("%s: null input?\n",func);
-            return 0;
+            if (!input) {
+                egsWarning("%s: null input?\n",func);
+                return 0;
+            }
+            string fname;
+            int err = input->getInput("file name",fname);
+            int file_format;
+            int err2 = input->getInput("file format",file_format);
+            if (err) {
+                egsWarning("%s: missing 'file name' input\n",func);
+                return 0;
+            }
+            if (err2) {
+                egsInformation("%s: 'file format' input missing. Using default 'binary'"
+                "file format \n",func);
+                file_format = 0;
+            }
+            EGS_VoxelizedShape *shape = new EGS_VoxelizedShape(file_format, fname.c_str());
+            if (!shape->isValid()) {
+                delete shape;
+                return 0;
+            }
+            shape->setName(input);
+            shape->setTransformation(input);
+            return shape;
         }
-        string fname;
-        int err = input->getInput("file name",fname);
-        int file_format;
-        int err2 = input->getInput("file format",file_format);
-        if (err) {
-            egsWarning("%s: missing 'file name' input\n",func);
-            return 0;
-        }
-        if (err2) {
-            egsInformation("%s: 'file format' input missing. Using default 'binary'"
-                           "file format \n",func);
-            file_format = 0;
-        }
-        EGS_VoxelizedShape *shape = new EGS_VoxelizedShape(file_format, fname.c_str());
-        if (!shape->isValid()) {
-            delete shape;
-            return 0;
-        }
-        shape->setName(input);
-        shape->setTransformation(input);
-        return shape;
-    }
 
-}
+    }

--- a/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
@@ -377,6 +377,7 @@ extern "C" {
 
         shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Voxelized_Shape"});
         shapeBlockInput->addSingleInput("file name", true, "The name of a file that is in binary");
+        setShapeInputs(shapeBlockInput);
     }
 
     EGS_VOXELIZED_SHAPE_EXPORT string getExample() {

--- a/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2009
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -37,6 +37,8 @@
 #include "egs_angular_spread_source.h"
 #include "egs_input.h"
 #include "egs_math.h"
+
+static bool EGS_ANGULAR_SPREAD_SOURCE_LOCAL inputSet = false;
 
 EGS_AngularSpreadSource::EGS_AngularSpreadSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSource(input,f), source(0), sigma(0) {
@@ -80,6 +82,41 @@ void EGS_AngularSpreadSource::setUp() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs(false, false);
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Angular_Spread_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("source name", true, "The name of a previously defined source.");
+        srcBlockInput->addSingleInput("sigma", false, "Angular spread in degrees.");
+    }
+
+    EGS_ANGULAR_SPREAD_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_angular_spread_source
+    #:start source:
+        library = egs_angular_spread_source
+        name = my_source
+        sigma = 10
+        source name = my_parallel_source
+        #create source called my_parallel_source
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_ANGULAR_SPREAD_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_ANGULAR_SPREAD_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
@@ -97,8 +97,8 @@ extern "C" {
 
     EGS_ANGULAR_SPREAD_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_angular_spread_source
     #:start source:
         library = egs_angular_spread_source

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -359,8 +359,8 @@ extern "C" {
 
     EGS_BEAM_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_beam_source
     #:start source:
         library = egs_beam_source

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -27,6 +27,7 @@
 #                   Frederic Tessier
 #                   Reid Townson
 #                   Ernesto Mainegra-Hing
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -50,6 +51,8 @@
 #define HELP_S(s) #s
 #define F77_NAME(fname,FNAME) STRINGIFY(F77_OBJ(fname,FNAME))
 #define F77_NAME_(fname,FNAME) STRINGIFY(F77_OBJ_(fname,FNAME))
+
+static bool EGS_BEAM_SOURCE_LOCAL inputSet = false;
 
 EGS_BeamSource::EGS_BeamSource(EGS_Input *input, EGS_ObjectFactory *f) :
     EGS_BaseSource(input,f) {
@@ -337,6 +340,45 @@ EGS_BeamSource::~EGS_BeamSource() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs(false, false);
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Beam_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("beam code", true, "The name of the BEAMnrc user code");
+        srcBlockInput->addSingleInput("pegs file", true, "The name of the PEGS file to be used in the BEAMnrc simulation");
+        srcBlockInput->addSingleInput("input file", true, "The name of the input file specifying the BEAMnrc simulation");
+        srcBlockInput->addSingleInput("cutout", false, "Cutout of a rectangle defined by x1, y1, x2, y2");
+        srcBlockInput->addSingleInput("particle type", false, "The type of particle.", {"all", "electrons", "photons", "positrons", "charged"});
+        srcBlockInput->addSingleInput("weight window", true, "wmin wmax");
+    }
+
+    EGS_BEAM_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_beam_source
+    #:start source:
+        library = egs_beam_source
+        name = my_source
+        beam code = BEAM_EX10MeVe
+        pegs file = 521icru
+        particle type = all
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_BEAM_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_BEAM_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Hubert Ho
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -36,6 +37,8 @@
 
 #include "egs_collimated_source.h"
 #include "egs_input.h"
+
+static bool EGS_COLLIMATED_SOURCE_LOCAL inputSet = false;
 
 EGS_CollimatedSource::EGS_CollimatedSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f),
@@ -119,6 +122,57 @@ void EGS_CollimatedSource::setUp() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Collimated_Source"});
+
+        // Format: name,  isRequired, description, vector string of allowed values
+        auto source_shapePtr = srcBlockInput->addBlockInput("source shape");
+        auto target_shapePtr = srcBlockInput->addBlockInput("target shape");
+
+        setShapeInputs(source_shapePtr);
+        setShapeInputs(target_shapePtr);
+
+        srcBlockInput->addSingleInput("distance", false, "source-target minimum distance");
+    }
+
+    EGS_COLLIMATED_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_collimated_source
+    #:start source:
+        library = egs_collimated_source
+        name = my_source
+        :start source shape:
+            type = point
+            position = 0 0 5
+        :stop source shape:
+        :start target shape:
+            library = egs_rectangle
+            rectangle = -1 -1 1 1
+        :stop target shape:
+        distance = 5
+        charge = -1
+        :start spectrum:
+            type = monoenergetic
+            energy = 20
+        :stop spectrum:
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_COLLIMATED_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_COLLIMATED_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
@@ -142,8 +142,8 @@ extern "C" {
 
     EGS_COLLIMATED_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_collimated_source
     #:start source:
         library = egs_collimated_source

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
@@ -199,8 +199,8 @@ extern "C" {
 
     EGS_DYNAMIC_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_dynamic_source
     #:start source:
         library = egs_dynamic_source

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -24,7 +24,7 @@
 #  Authors:         Ernesto Mainegra-Hing, 2016
 #                   Hugo Bouchard, 2016
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -40,6 +40,8 @@
 #include "egs_input.h"
 #include "egs_math.h"
 #include <sstream>
+
+static bool EGS_FANO_SOURCE_LOCAL inputSet = false;
 
 EGS_FanoSource::EGS_FanoSource(EGS_Input *input,
                                EGS_ObjectFactory *f) :
@@ -143,6 +145,55 @@ void EGS_FanoSource::setUp() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Fano_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto shapePtr = srcBlockInput->addBlockInput("shape");
+        setShapeInputs(shapePtr);
+
+        srcBlockInput->addSingleInput("geometry", true, "The name of a predefined geometry");
+        srcBlockInput->addSingleInput("max mass density", true, "The maximum mass density");
+    }
+
+    EGS_FANO_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_fano_source
+    #:start source:
+        library = egs_fano_source
+        name = my_fano_source
+        :start shape:
+            type = box
+            box size = 1 2 3
+            :start media input:
+                media = water
+            :stop media input:
+        :stop shape:
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        charge = 0
+        max mass density = 1.2
+        geometry = some_name
+        #create a geometry called some_name
+)"};
+        return example;
+    }
+
+    EGS_FANO_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_FANO_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -163,8 +163,8 @@ extern "C" {
 
     EGS_FANO_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_fano_source
     #:start source:
         library = egs_fano_source

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -163,7 +163,7 @@ extern "C" {
         auto shapePtr = srcBlockInput->addBlockInput("shape");
         /* Commented out because I don't think this input is used
         Also at this point dependency of a block on an input hasn't been implemented
-        auto shapeNamePtr = srcBlockInput->addSingleInput("shape name", false, "TODO");
+        auto shapeNamePtr = srcBlockInput->addSingleInput("shape name", false, "...");
         shapeNamePtr->addDependency(shapePtr, true);
         shapePtr->addDependency(shapeNamePtr, true);*/
 

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -25,6 +25,7 @@
 #
 #  Contributors:    Long Zhang
 #                   Hubert Ho
+#                   Reid Townson
 #
 ###############################################################################
 */
@@ -38,6 +39,9 @@
 #include "egs_isotropic_source.h"
 #include "egs_input.h"
 #include "egs_math.h"
+
+static string EGS_ISOTROPIC_SOURCE_LOCAL typeStr("EGS_Isotropic_Source");
+static bool EGS_ISOTROPIC_SOURCE_LOCAL inputSet = false;
 
 EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f), shape(0), geom(0),
@@ -148,6 +152,67 @@ void EGS_IsotropicSource::setUp() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues(vector<string>(1, typeStr));
+
+        auto shapePtr = srcBlockInput->addBlockInput("shape");
+        /* Commented out because I don't think this input is used
+        Also at this point dependency of a block on an input hasn't been implemented
+        auto shapeNamePtr = srcBlockInput->addSingleInput("shape name", false, "TODO");
+        shapeNamePtr->addDependency(shapePtr, true);
+        shapePtr->addDependency(shapeNamePtr, true);*/
+
+        setShapeInputs(shapePtr);
+
+        auto geomPtr = srcBlockInput->addSingleInput("geometry", false, "The name of a geometry, used for complex source shapes. Only particles generated inside the geometry or some of its regions are used.");
+        auto regPtr = srcBlockInput->addSingleInput("region selection", false, "Include or exclude regions from the named geometry, to define a volume for source particle generation.", {"IncludeAll", "ExcludeAll","IncludeSelected","ExcludeSelected"});
+        regPtr->addDependency(geomPtr);
+        auto selPtr = srcBlockInput->addSingleInput("selected regions", false, "If region selection = IncludeSelected or ExcludeSelected, then this is a list of the regions in the named geometry to include or exclude.");
+        selPtr->addDependency(geomPtr);
+        selPtr->addDependency(regPtr);
+        srcBlockInput->addSingleInput("min theta", false, "The minimum theta angle in degrees, to restrict the directions of source particles. Defaults to 0.");
+        srcBlockInput->addSingleInput("max theta", false, "The maximum theta angle in degrees, to restrict the directions of source particles. Defaults to 180.");
+        srcBlockInput->addSingleInput("min phi", false, "The minimum phi angle in degrees, to restrict the directions of source particles. Defaults to 0.");
+        srcBlockInput->addSingleInput("max phi", false, "The maximum phi angle in degrees, to restrict the directions of source particles. Defaults to 360.");
+    }
+
+    EGS_ISOTROPIC_SOURCE_EXPORT string getExample() {
+        string example
+{R"(
+    :start source:
+        name                = my_source
+        library             = egs_isotropic_source
+        charge              = 0
+        geometry            = my_envelope
+        region selection    = IncludeSelected
+        selected regions    = 1 2
+        :start shape:
+            type     = box
+            box size    = 1 2 3
+            :start media input:
+                media = H2O521ICRU
+            :stop media input:
+        :stop shape:
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_ISOTROPIC_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_ISOTROPIC_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -182,8 +182,8 @@ extern "C" {
     }
 
     EGS_ISOTROPIC_SOURCE_EXPORT string getExample() {
-        string example
-{R"(
+        string example {
+            R"(
     :start source:
         name                = my_source
         library             = egs_isotropic_source

--- a/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
@@ -128,8 +128,8 @@ extern "C" {
 
     EGS_PARALLEL_BEAM_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_parallel_beam
     #:start source:
         library = egs_parallel_beam

--- a/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -36,6 +36,8 @@
 
 #include "egs_parallel_beam.h"
 #include "egs_input.h"
+
+static bool EGS_PARALLEL_BEAM_LOCAL inputSet = false;
 
 EGS_ParallelBeam::EGS_ParallelBeam(EGS_Input *input,
                                    EGS_ObjectFactory *f) : EGS_BaseSimpleSource(input,f), shape(0), uo(0,0,1) {
@@ -108,6 +110,54 @@ void EGS_ParallelBeam::setUp() {
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Parallel_Beam"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        auto shapePtr = srcBlockInput->addBlockInput("shape");
+
+        setShapeInputs(shapePtr);
+
+        srcBlockInput->addSingleInput("direction", true, "Direction of the beam (x, y, z)");
+    }
+
+    EGS_PARALLEL_BEAM_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_parallel_beam
+    #:start source:
+        library = egs_parallel_beam
+        name = my_source
+        :start shape:
+            type = cylinder
+            radius = 1
+            height = 2
+            axis = 0 0 1
+            midpoint = 0
+        :stop shape:
+        direction = 0 0 1
+        charge = 0
+        :start spectrum:
+            type = monoenergetic
+            energy = 6
+        :stop spectrum:
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_PARALLEL_BEAM_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+            return srcBlockInput;
+    }
 
     EGS_PARALLEL_BEAM_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -524,8 +524,8 @@ extern "C" {
 
     EGS_PHSP_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_phsp_soure
     #:start source:
         name = my_source

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -516,7 +516,7 @@ extern "C" {
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("phase space file", true, "The name of the phase space file.");
         srcBlockInput->addSingleInput("particle type", true, "The type of particle", {"all", "charged", "electrons", "positrons", "photons"});
-        srcBlockInput->addSingleInput("cutout", false, "A rectagular cutout defined by x1, x2, y1, y2");
+        srcBlockInput->addSingleInput("cutout", false, "A rectangular cutout defined by x1, x2, y1, y2");
         srcBlockInput->addSingleInput("weight window", false, "wmin, wmax, the min and max particle weights to use. If the particle is not in this range, it is rejected.");
         srcBlockInput->addSingleInput("recyle photons", false, "The number of time to recycle each photon");
         srcBlockInput->addSingleInput("recycle electrons", false, "The number of times to recycle each electron");

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -26,6 +26,7 @@
 #  Contributors:    Ernesto Mainegra-Hing
 #                   Frederic Tessier
 #                   Reid Townson
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -40,6 +41,8 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 #include "egs_application.h"
+
+static bool EGS_PHSP_SOURCE_LOCAL inputSet = false;
 
 EGS_PhspSource::EGS_PhspSource(const string &phsp_file,
                                const string &Name, EGS_ObjectFactory *f) : EGS_BaseSource(Name,f) {
@@ -502,6 +505,47 @@ void EGS_PhspSource::setFilter(int type, int nbit1, int nbit2, const int *bits) 
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs(false, false);
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Phsp_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("phase space file", true, "The name of the phase space file.");
+        srcBlockInput->addSingleInput("particle type", true, "The type of particle", {"all", "charged", "electrons", "positrons", "photons"});
+        srcBlockInput->addSingleInput("cutout", false, "A rectagular cutout defined by x1, x2, y1, y2");
+        srcBlockInput->addSingleInput("weight window", false, "wmin, wmax, the min and max particle weights to use. If the particle is not in this range, it is rejected.");
+        srcBlockInput->addSingleInput("recyle photons", false, "The number of time to recycle each photon");
+        srcBlockInput->addSingleInput("recycle electrons", false, "The number of times to recycle each electron");
+    }
+
+    EGS_PHSP_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_phsp_soure
+    #:start source:
+        name = my_source
+        library = egs_phsp_source
+        phase space file = ../BEAM_EX16MVp/EX16MVp.egsphsp1
+        particle type = all
+        cutout = -1 1 -2 2
+        recycle photons = 10
+        recycle electrons = 10
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_PHSP_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_PHSP_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
@@ -92,8 +92,8 @@ extern "C" {
 
     EGS_POINT_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_point_source
     #:start source:
         library = egs_point_source

--- a/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Iwan Kawrakow, 2005
 #
-#  Contributors:
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */
@@ -36,6 +36,8 @@
 
 #include "egs_point_source.h"
 #include "egs_input.h"
+
+static bool EGS_POINT_SOURCE_LOCAL inputSet = false;
 
 EGS_PointSource::EGS_PointSource(EGS_Input *input, EGS_ObjectFactory *f) :
     EGS_BaseSimpleSource(input,f), xo(), valid(true) {
@@ -76,6 +78,43 @@ void EGS_PointSource::setUp() {
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Point_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("position", true, "The position of the point source, (x, y, z)");
+    }
+
+    EGS_POINT_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_point_source
+    #:start source:
+        library = egs_point_source
+        name = my_source
+        position = 0 0 0
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        charge = 0
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_POINT_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_POINT_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -617,8 +617,8 @@ extern "C" {
 
     EGS_RADIONUCLIDE_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_radionuclide_source
     #:start source:
         name = my_source

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
@@ -149,8 +149,8 @@ extern "C" {
 
     EGS_SOURCE_COLLECTION_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_source_collection
     :start source:
         library = egs_source_collection

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
@@ -24,6 +24,7 @@
 #  Author:          Iwan Kawrakow, 2005
 #
 #  Contributors:    Marc Chamberland
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -36,6 +37,8 @@
 
 #include "egs_source_collection.h"
 #include "egs_input.h"
+
+static bool EGS_SOURCE_COLLECTION_LOCAL inputSet = false;
 
 EGS_SourceCollection::EGS_SourceCollection(EGS_Input *input,
         EGS_ObjectFactory *f) : EGS_BaseSource(input,f), nsource(0), count(0) {
@@ -131,6 +134,41 @@ void EGS_SourceCollection::setUp(const vector<EGS_BaseSource *> &S,
 }
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs(false, false);
+
+        srcBlockInput->getSingleInput("library")->setValues({"EGS_Source_Collection"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("source names", true, "A list of names of previously defined sources.");
+        srcBlockInput->addSingleInput("weights", true, "A list of weights for the sources");
+    }
+
+    EGS_SOURCE_COLLECTION_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of egs_source_collection
+    :start source:
+        library = egs_source_collection
+        name = my_source
+        source name = p1 p2
+        # create sources called p1 and p2
+        weights = 0.1 0.9
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_SOURCE_COLLECTION_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_SOURCE_COLLECTION_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
@@ -99,8 +99,8 @@ extern "C" {
 
     EGS_TRANSFORMED_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of egs_transformed_source
     #:start source:
         library = egs_transformed_source

--- a/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
@@ -85,7 +85,7 @@ extern "C" {
 
         srcBlockInput->getSingleInput("library")->setValues({"EGS_Transformed_Source"});
 
-        // Format: name, isRequired, description, vector striing of allowed values
+        // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("source name", true, "The name of a previously defined source.");
 
         auto blockPtr = srcBlockInput->addBlockInput("transformation");
@@ -105,7 +105,7 @@ extern "C" {
     #:start source:
         library = egs_transformed_source
         name = my_source
-        source_name = my_parallel_source
+        source name = my_parallel_source
         #create source called my_parallel_source
         :start transformation:
             rotation vector = 0 -1 1

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -545,8 +545,8 @@ extern "C" {
 
     IAEA_PHSP_SOURCE_EXPORT string getExample() {
         string example;
-        example =
-{R"(
+        example = {
+            R"(
     # Example of iaea_phsp_soure
     #:start source:
         name = my_source

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -40,6 +40,8 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static bool IAEA_PHSP_SOURCE_LOCAL inputSet = false;
+
 IAEA_PhspSource::IAEA_PhspSource(const string &phsp_file,
                                  const string &Name, EGS_ObjectFactory *f) : EGS_BaseSource(Name,f) {
     init();
@@ -525,6 +527,47 @@ void IAEA_PhspSource::setFilter(int type, int nbit1, int nbit2, const int *bits)
 
 extern "C" {
 
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs(false, false);
+
+        srcBlockInput->getSingleInput("library")->setValues({"IAEA_Phsp_Source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("iaea phase space file", true, "The path to and name of the phase-space file, no extension. Both the .IAEAphsp and .IAEAheader file must be in the same directory.");
+        srcBlockInput->addSingleInput("particle type", true, "The type of particle to use from the phase-space", {"all", "charged", "electrons", "positrons", "photons"});
+        srcBlockInput->addSingleInput("cutout", false, "A rectangular cutout defined by x1, x2, y1, y2");
+        srcBlockInput->addSingleInput("weight window", false, "wmin, wmax; the min and max particle weights to use. If the particle is not in this (inclusive) range, it is rejected.");
+        srcBlockInput->addSingleInput("recycle photons", false, "The number of time to recycle each photon");
+        srcBlockInput->addSingleInput("recycle electrons", false, "The number of times to recycle each electron");
+    }
+
+    IAEA_PHSP_SOURCE_EXPORT string getExample() {
+        string example;
+        example =
+{R"(
+    # Example of iaea_phsp_soure
+    #:start source:
+        name = my_source
+        library = iaea_phsp_source
+        iaea phase space file = myPhsp # No extension, both .IAEAphsp and .IAEAheader must be present
+        particle type = all
+        cutout      = -1 1 -2 2
+        recycle photons = 10
+        recycle electrons = 10
+    :stop source:
+)"};
+        return example;
+    }
+
+    IAEA_PHSP_SOURCE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
+
     IAEA_PHSP_SOURCE_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {
         return
@@ -532,3 +575,4 @@ extern "C" {
     }
 
 }
+

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -89,13 +89,13 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
 }
 
 EGS_Editor::~EGS_Editor() {
-    if(lineNumberArea) {
+    if (lineNumberArea) {
         delete lineNumberArea;
     }
-    if(popup) {
+    if (popup) {
         delete popup;
     }
-    if(model) {
+    if (model) {
         delete model;
     }
 }
@@ -169,7 +169,7 @@ void EGS_Editor::highlightCurrentLine() {
 
 int EGS_Editor::countStartingWhitespace(const QString &s) {
     int i, l = s.size();
-    for(i = 0; i < l && s[i] == ' ' || s[i] == '\t'; ++i);
+    for (i = 0; i < l && s[i] == ' ' || s[i] == '\t'; ++i);
     return i;
 }
 
@@ -190,18 +190,18 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
     shared_ptr<EGS_BlockInput> inputBlockTemplate = getBlockInput(blockTitle, cursor);
 
     // If we aren't inside an input block, ignore this line
-    if(blockTitle.size() < 1) {
+    if (blockTitle.size() < 1) {
         return;
     }
 
-    if(selectedText.startsWith("#")) {
+    if (selectedText.startsWith("#")) {
         return;
     }
 
     // Check the validity of the inputs
     // If this line contains an "=" then it should match a single input
     int equalsPos = selectedText.indexOf("=");
-    if(equalsPos != -1) {
+    if (equalsPos != -1) {
         cursor.beginEditBlock();
 
         QString inputTag = selectedText.left(equalsPos).simplified();
@@ -212,7 +212,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
 
         // If we found a template for this type of input block,
         // check that the input tag  (LHS) is valid
-        if(inputBlockTemplate) {
+        if (inputBlockTemplate) {
 
             QList<QTextEdit::ExtraSelection> extraSelections = this->extraSelections();
             QTextEdit::ExtraSelection selection;
@@ -232,7 +232,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
             // Check that the input block template contains this type of input
             // If the input isn't defined, it will return nullptr
             shared_ptr<EGS_SingleInput> inputPtr = inputBlockTemplate->getSingleInput(inputTag.toStdString(), blockTitle.toStdString());
-            if(!inputPtr) {
+            if (!inputPtr) {
                 // Red underline the input tag
                 // Select the input tag
 
@@ -242,7 +242,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                 // we account for it so only the input tag is underlined
                 int originalEqualsPos = cursor.block().text().indexOf("=");
                 int numWhitespace = countStartingWhitespace(cursor.block().text());
-                if(numWhitespace > 0) {
+                if (numWhitespace > 0) {
                     selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
                 }
 
@@ -251,37 +251,39 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                 // Set the format to have a red underline
                 format.setUnderlineColor(QColor("red"));
                 format.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
-            } else {
+            }
+            else {
 
                 // Get the description for this input
                 string desc = inputPtr->getDescription();
 
                 bool isRequired = inputPtr->getRequired();
-                if(isRequired) {
+                if (isRequired) {
                     desc += "\nRequired.";
                 }
 
                 // Check if this input has any dependencies
                 // and then confirm that the dependencies are satisfied
-                if(inputHasDependency(inputPtr)) {
+                if (inputHasDependency(inputPtr)) {
                     // Add the list of dependencies to the description tooltip
                     desc += "\nDependencies: ";
                     auto vals = inputPtr->getDependencyVal();
                     int i = 0;
-                    for(auto &inp: inputPtr->getDependencyInp()) {
-                        if(vals[i].size() > 0) {
+                    for (auto &inp: inputPtr->getDependencyInp()) {
+                        if (vals[i].size() > 0) {
                             desc += "'" + inp->getTag() + "=" + vals[i] + "' ";
-                        } else {
+                        }
+                        else {
                             desc += "'" + inp->getTag() + "' ";
                         }
                         ++i;
                     }
                     auto depBlock = inputPtr->getDependencyBlock();
-                    if(depBlock) {
+                    if (depBlock) {
                         desc += "':start " + depBlock->getTitle() + ":'";
                     }
 
-                    if(inputDependencySatisfied(inputPtr, cursor) == false) {
+                    if (inputDependencySatisfied(inputPtr, cursor) == false) {
                         // Red underline the input tag
                         // Select the input tag
                         selection.cursor.movePosition(QTextCursor::StartOfBlock);
@@ -290,7 +292,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                         // we account for it so only the input tag is underlined
                         int originalEqualsPos = cursor.block().text().indexOf("=");
                         int numWhitespace = countStartingWhitespace(cursor.block().text());
-                        if(numWhitespace > 0) {
+                        if (numWhitespace > 0) {
                             selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
                         }
 
@@ -326,7 +328,7 @@ void EGS_Editor::autoComplete() {
     popup->setModel(model);
 
     // If the first character is a "#", ignore this line
-    if(selectedText.startsWith("#")) {
+    if (selectedText.startsWith("#")) {
         return;
     }
 
@@ -335,14 +337,14 @@ void EGS_Editor::autoComplete() {
     shared_ptr<EGS_BlockInput> inputBlockTemplate = getBlockInput(blockTitle);
 
     // If we aren't inside an input block, ignore this line
-    if(blockTitle.size() < 1) {
+    if (blockTitle.size() < 1) {
         return;
     }
 
     // Check the validity of the inputs
     // If this line contains an "=" then it should match a single input
     int equalsPos = selectedText.indexOf("=");
-    if(equalsPos != -1) {
+    if (equalsPos != -1) {
         QString inputTag = selectedText.left(equalsPos).simplified();
         QString inputVal = selectedText.right(selectedText.size() - equalsPos - 1).simplified();
 #ifdef EDITOR_DEBUG
@@ -354,7 +356,7 @@ void EGS_Editor::autoComplete() {
 
         // Return if the input value (RHS) is already filled
         // This way we only offer options for blank inputs
-        if(inputVal != "") {
+        if (inputVal != "") {
             return;
         }
 
@@ -367,10 +369,10 @@ void EGS_Editor::autoComplete() {
 
             // Populate the popup list
             QStringList itemList;
-            for(auto &v: vals) {
+            for (auto &v: vals) {
                 itemList << QString(v.c_str());
             }
-            if(itemList.size() > 0) {
+            if (itemList.size() > 0) {
                 model->setStringList(itemList);
 
 
@@ -404,10 +406,11 @@ void EGS_Editor::autoComplete() {
                     popup->show();
                 }
             }
-        } else {
+        }
+        else {
 
             // Return if we couldn't find a template for this input block
-            if(!inputBlockTemplate) {
+            if (!inputBlockTemplate) {
                 return;
             }
 
@@ -415,7 +418,7 @@ void EGS_Editor::autoComplete() {
             shared_ptr<EGS_SingleInput> inp = inputBlockTemplate->getSingleInput(inputTag.toStdString(), blockTitle.toStdString());
 
             // Return if we didn't find this input in the template
-            if(!inp) {
+            if (!inp) {
                 return;
             }
 
@@ -423,16 +426,16 @@ void EGS_Editor::autoComplete() {
             auto vals = inp->getValues();
 
             // Return if we don't have a list of values to choose from
-            if(vals.size() == 0) {
+            if (vals.size() == 0) {
                 return;
             }
 
             // Populate the popup list
             QStringList itemList;
-            for(auto &v: vals) {
+            for (auto &v: vals) {
                 itemList << QString(v.c_str());
             }
-            if(itemList.size() > 0) {
+            if (itemList.size() > 0) {
                 model->setStringList(itemList);
 
 
@@ -468,8 +471,9 @@ void EGS_Editor::autoComplete() {
             }
         }
 
-    // If this is just an empty line, we can offer suggestions of valid inputs
-    } else if(inputBlockTemplate && selectedText == "") {
+        // If this is just an empty line, we can offer suggestions of valid inputs
+    }
+    else if (inputBlockTemplate && selectedText == "") {
 
         vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlockTemplate->getSingleInputs(blockTitle.toStdString());
 
@@ -481,26 +485,26 @@ void EGS_Editor::autoComplete() {
         QStringList itemList;
 
         // Add all the single inputs for the top level block
-        for(auto &inp: singleInputs) {
+        for (auto &inp: singleInputs) {
             //if(!egsEquivStr(inp->getTag(), "library")) {
-                // Skip any inputs that have a dependency which is not satisfied
-                if(inputHasDependency(inp) && inputDependencySatisfied(inp, cursor) == false) {
-                    continue;
-                }
+            // Skip any inputs that have a dependency which is not satisfied
+            if (inputHasDependency(inp) && inputDependencySatisfied(inp, cursor) == false) {
+                continue;
+            }
 
-                itemList << QString((inp->getTag() + " = ").c_str());
+            itemList << QString((inp->getTag() + " = ").c_str());
             //}
         }
 
         // Store the block titles in a set to remove duplicates
         QSet<QString> blockTitles;
-        for(auto &block: blockInputs) {
+        for (auto &block: blockInputs) {
             blockTitles << QString((":start " + block->getTitle() + ":").c_str());
         }
-        for(auto &title: blockTitles) {
+        for (auto &title: blockTitles) {
             itemList << title;
         }
-        if(itemList.size() > 0) {
+        if (itemList.size() > 0) {
             model->setStringList(itemList);
 
             popup->setModel(model);
@@ -534,19 +538,20 @@ void EGS_Editor::autoComplete() {
             }
         }
 
-    // If this is the start of an input block, check that it belongs here
-    } else if(selectedText.contains(":start ")) {
+        // If this is the start of an input block, check that it belongs here
+    }
+    else if (selectedText.contains(":start ")) {
 
         // If we're inside another input block that we have a template for,
         // Check to this that this is a valid input block to exist here
-        if(inputBlockTemplate) {
+        if (inputBlockTemplate) {
 
             // Get the block title
             QString blockTit;
             int pos = selectedText.lastIndexOf(":start ");
             pos += 7;
             int endPos = selectedText.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 blockTit = selectedText.mid(pos, endPos-pos);
             }
 
@@ -564,7 +569,7 @@ void EGS_Editor::autoComplete() {
             format.setUnderlineStyle(QTextCharFormat::NoUnderline);
 
             auto inputPtr = inputBlockTemplate->getBlockInput(blockTit.toStdString());
-            if(!inputPtr) {
+            if (!inputPtr) {
                 // Red underline the input tag
                 // Select the input tag
                 selection.cursor.movePosition(QTextCursor::StartOfBlock);
@@ -573,7 +578,7 @@ void EGS_Editor::autoComplete() {
                 // we account for it so only the input tag is underlined
                 int originalEqualsPos = cursor.block().text().lastIndexOf(":");
                 int numWhitespace = countStartingWhitespace(cursor.block().text());
-                if(numWhitespace > 0) {
+                if (numWhitespace > 0) {
                     selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
                 }
 
@@ -591,14 +596,15 @@ void EGS_Editor::autoComplete() {
             setExtraSelections(extraSelections);
         }
 
-    // For geometry and source blocks that don't contain a library line,
-    // add 'library =' as an option in the popup
-    } else if(selectedText.size() == 0 && (egsEquivStr(blockTitle.toStdString(), "geometry") || egsEquivStr(blockTitle.toStdString(), "source"))) {
+        // For geometry and source blocks that don't contain a library line,
+        // add 'library =' as an option in the popup
+    }
+    else if (selectedText.size() == 0 && (egsEquivStr(blockTitle.toStdString(), "geometry") || egsEquivStr(blockTitle.toStdString(), "source"))) {
 
         // Populate the popup list
         QStringList itemList;
         itemList << "library = ";
-        if(itemList.size() > 0) {
+        if (itemList.size() > 0) {
             model->setStringList(itemList);
 
             popup->setModel(model);
@@ -644,12 +650,12 @@ void EGS_Editor::insertCompletion(QModelIndex index) {
 }
 
 shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextCursor cursor) {
-    if(cursor == QTextCursor()) {
+    if (cursor == QTextCursor()) {
         cursor = textCursor();
     }
 
     blockTitle = getBlockTitle(cursor);
-    if(blockTitle.size() < 1) {
+    if (blockTitle.size() < 1) {
         return nullptr;
     }
 
@@ -658,7 +664,7 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
 
     // If we couldn't find a library tag in the current block,
     // try searching the containing block (if there is one)
-    if(library.size() < 1) {
+    if (library.size() < 1) {
 #ifdef EDITOR_DEBUG
         egsInformation("EGS_Editor::getBlockInput: Searching containing block for library: %s\n", blockTitle.toLatin1().data());
 #endif
@@ -669,18 +675,18 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
         blockEnd = cursor.block();
         int loopGuard = 10000;
         int i = 0;
-        while(blockEnd.text().contains(":start ")) {
+        while (blockEnd.text().contains(":start ")) {
             blockEnd = getBlockEnd(blockEnd.next());
-            if(++i > loopGuard) {
+            if (++i > loopGuard) {
                 egsInformation("Warning: Encountered infinite loop while processing the input file. Contact the developers to report this bug.\n");
                 break;
             }
-            if(blockEnd.isValid()) {
+            if (blockEnd.isValid()) {
                 blockEnd = blockEnd.next();
             }
         }
         blockEnd = getBlockEnd(blockEnd);
-        if(blockEnd.isValid()) {
+        if (blockEnd.isValid()) {
             // Go to the line after the end of the current input block
             blockEnd = blockEnd.next();
 
@@ -689,7 +695,7 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
         }
 
         // If we still didn't find the library, search one block higher
-        if(library.size() < 1) {
+        if (library.size() < 1) {
 #ifdef EDITOR_DEBUG
             egsInformation("EGS_Editor::getBlockInput: Checking up a level...\n");
 #endif
@@ -697,18 +703,18 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
             // so that we're actually starting within the block
             int loopGuard = 10000;
             int i = 0;
-            while(blockEnd.text().contains(":start ")) {
+            while (blockEnd.text().contains(":start ")) {
                 blockEnd = getBlockEnd(blockEnd.next());
-                if(++i > loopGuard) {
+                if (++i > loopGuard) {
                     egsInformation("Warning: Encountered infinite loop while processing the input file. Contact the developers to report this bug.\n");
                     break;
                 }
-                if(blockEnd.isValid()) {
+                if (blockEnd.isValid()) {
                     blockEnd = blockEnd.next();
                 }
             }
             blockEnd = getBlockEnd(blockEnd);
-            if(blockEnd.isValid()) {
+            if (blockEnd.isValid()) {
                 // Go to the line after the end of the current input block
                 blockEnd = blockEnd.next();
 
@@ -719,30 +725,30 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
     }
 
     // If we got the library tag, we can directly look up this input block structure
-    if(library.size() > 0) {
+    if (library.size() > 0) {
         shared_ptr<EGS_BlockInput> inputBlock = inputStruct->getLibraryBlock(blockTitle.toStdString(), library.toStdString());
-        if(inputBlock) {
+        if (inputBlock) {
 #ifdef EDITOR_DEBUG
             egsInformation("EGS_Editor::getBlockInput: Found library: %s\n", library.toLatin1().data());
-            vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
-            for (auto &inp : singleInputs) {
-                const vector<string> vals = inp->getValues();
-                egsInformation("   single %s\n", inp->getTag().c_str());
-                for (auto&& val : vals) {
-                    egsInformation("      %s\n", val.c_str());
-                }
-            }
-            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
-            for (auto &block : inputBlocks) {
-                singleInputs = inputBlock->getSingleInputs();
-                for (auto &inp : singleInputs) {
-                    const vector<string> vals = inp->getValues();
-                    egsInformation("   single %s\n", inp->getTag().c_str());
-                    for (auto&& val : vals) {
-                        egsInformation("      %s\n", val.c_str());
-                    }
-                }
-            }
+//             vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
+//             for (auto &inp : singleInputs) {
+//                 const vector<string> vals = inp->getValues();
+//                 egsInformation("   single %s\n", inp->getTag().c_str());
+//                 for (auto&& val : vals) {
+//                     egsInformation("      %s\n", val.c_str());
+//                 }
+//             }
+//             vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
+//             for (auto &block : inputBlocks) {
+//                 singleInputs = inputBlock->getSingleInputs();
+//                 for (auto &inp : singleInputs) {
+//                     const vector<string> vals = inp->getValues();
+//                     egsInformation("   single %s\n", inp->getTag().c_str());
+//                     for (auto&& val : vals) {
+//                         egsInformation("      %s\n", val.c_str());
+//                     }
+//                 }
+//             }
 #endif
             return inputBlock;
         }
@@ -753,14 +759,14 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
     shared_ptr<EGS_BlockInput> inputBlock = inputStruct->getBlockInput(blockTitle.toStdString());
 
 #ifdef EDITOR_DEBUG
-            egsInformation("EGS_Editor::getBlockInput: No library found, assuming '%s' is top-level block\n", blockTitle.toLatin1().data());
+    egsInformation("EGS_Editor::getBlockInput: No library found, assuming '%s' is top-level block\n", blockTitle.toLatin1().data());
 #endif
 
     return inputBlock;
 }
 
 QString EGS_Editor::getBlockTitle(QTextCursor cursor) {
-    if(cursor == QTextCursor()) {
+    if (cursor == QTextCursor()) {
         cursor = textCursor();
     }
 
@@ -770,21 +776,22 @@ QString EGS_Editor::getBlockTitle(QTextCursor cursor) {
 
     // Starting at the current line, starting iterating in reverse through
     // the previous lines
-    for(QTextBlock block = cursor.block(); block.isValid(); block = block.previous()) {
+    for (QTextBlock block = cursor.block(); block.isValid(); block = block.previous()) {
         QString line = block.text().simplified();
 
         // Get block title
         int pos = line.lastIndexOf(":start ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 7;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 blockTitle = line.mid(pos, endPos-pos);
-                if(innerList.size() > 0 && blockTitle == innerList.back()) {
+                if (innerList.size() > 0 && blockTitle == innerList.back()) {
                     innerList.pop_back();
                     blockTitle.clear();
                     withinOtherBlock = false;
-                } else {
+                }
+                else {
                     break;
                 }
             }
@@ -794,10 +801,10 @@ QString EGS_Editor::getBlockTitle(QTextCursor cursor) {
         // This means both a matching :start and :stop are above the cursor
         // so we're not inside the block
         pos = line.lastIndexOf(":stop ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 6;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 QString stopTitle = line.mid(pos, endPos-pos);
                 innerList.push_back(stopTitle);
                 withinOtherBlock = true;
@@ -817,27 +824,27 @@ QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &fo
     // Get the last textblock in this input block
     // so that we search all the inputs in the block
     QTextBlock blockEnd = getBlockEnd(currentBlock);
-    if(!blockEnd.isValid()) {
+    if (!blockEnd.isValid()) {
         return "";
     }
 
     // Starting at the last line, start iterating in reverse through
     // the previous lines
     blockEnd = blockEnd.previous();
-    for(QTextBlock block = blockEnd; block.isValid(); block = block.previous()) {
+    for (QTextBlock block = blockEnd; block.isValid(); block = block.previous()) {
         QString line = block.text().simplified();
 
         // Get block library for input blocks based on a shared library
         // e.g. geometries and sources
         // Only look for the library tag if we're not in a sub-block
         int pos;
-        if(!withinOtherBlock) {
+        if (!withinOtherBlock) {
             pos = line.lastIndexOf(inp);
-            if(pos >= 0) {
+            if (pos >= 0) {
                 int pos2 = line.lastIndexOf("=");
-                if(pos2 > pos) {
+                if (pos2 > pos) {
                     QString tag = line.left(pos2).simplified();
-                    if(egsEquivStr(tag.toStdString(), inp.simplified().toStdString())) {
+                    if (egsEquivStr(tag.toStdString(), inp.simplified().toStdString())) {
                         foundTag = true;
                         value = line.right(line.size()-pos2-1).simplified();
                         break;
@@ -847,18 +854,19 @@ QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &fo
         }
 
         // Get block title
-        startPos = line.lastIndexOf(":start ");
-        if(startPos >= 0) {
-            startPos += 7;
-            int endPos = line.indexOf(":",startPos);
-            if(endPos > 0) {
+        pos = line.lastIndexOf(":start ");
+        if (pos >= 0) {
+            pos += 7;
+            int endPos = line.indexOf(":",pos);
+            if (endPos > 0) {
                 QString blockTitle = line.mid(pos, endPos-pos);
-                if(innerList.size() > 0 && blockTitle == innerList.back()) {
+                if (innerList.size() > 0 && blockTitle == innerList.back()) {
                     innerList.pop_back();
-                    if(innerList.size() == 0) {
+                    if (innerList.size() == 0) {
                         withinOtherBlock = false;
                     }
-                } else {
+                }
+                else {
                     // If we got to the start of the block,
                     // then we failed to find the input
                     return "";
@@ -870,10 +878,10 @@ QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &fo
         // This means both a matching :start and :stop are above the cursor
         // so we're not inside the block
         pos = line.lastIndexOf(":stop ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 6;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 QString stopTitle = line.mid(pos, endPos-pos);
                 innerList.push_back(stopTitle);
                 withinOtherBlock = true;
@@ -890,17 +898,17 @@ QTextBlock EGS_Editor::getBlockEnd(QTextBlock currentBlock) {
 
     // Starting at the current line, starting iterating in forward through
     // the next lines
-    for(QTextBlock block = currentBlock; block.isValid(); block = block.next()) {
+    for (QTextBlock block = currentBlock; block.isValid(); block = block.next()) {
         QString line = block.text().simplified();
 
         // Save a vector of blocks that are contained within this input block
         // This means both a matching :start and :stop are below the cursor
         // so we're not inside the block
         int pos = line.lastIndexOf(":start ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 7;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 QString startTitle = line.mid(pos, endPos-pos);
                 innerList.push_back(startTitle);
                 withinOtherBlock = true;
@@ -910,16 +918,17 @@ QTextBlock EGS_Editor::getBlockEnd(QTextBlock currentBlock) {
         // Save a vector of blocks that are contained within this input block
         // so that we can skip them
         pos = line.lastIndexOf(":stop ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 6;
             int startPos = line.indexOf(":",pos);
-            if(startPos > 0) {
+            if (startPos > 0) {
                 QString blockTitle = line.mid(pos, startPos-pos);
-                if(innerList.size() > 0 && blockTitle == innerList.back()) {
+                if (innerList.size() > 0 && blockTitle == innerList.back()) {
                     innerList.pop_back();
                     blockTitle.clear();
                     withinOtherBlock = false;
-                } else {
+                }
+                else {
                     return block;
                 }
             }
@@ -932,15 +941,16 @@ QTextBlock EGS_Editor::getBlockEnd(QTextBlock currentBlock) {
 bool EGS_Editor::inputHasDependency(shared_ptr<EGS_SingleInput> inp) {
     auto dependencyInp = inp->getDependencyInp();
     auto dependencyBlock = inp->getDependencyBlock();
-    if(dependencyInp.size() < 1 && !dependencyBlock) {
+    if (dependencyInp.size() < 1 && !dependencyBlock) {
         return false;
-    } else {
+    }
+    else {
         return true;
     }
 }
 
 bool EGS_Editor::inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp, QTextCursor cursor) {
-    if(cursor == QTextCursor()) {
+    if (cursor == QTextCursor()) {
         cursor = textCursor();
     }
     bool satisfied = true;
@@ -956,8 +966,8 @@ bool EGS_Editor::inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp, QText
     // Loop through the dependencies
     vector<bool> previousSatisfied;
     string previousTag;
-    for(size_t i = 0; i < dependencyInp.size(); ++i) {
-        if(!satisfied) {
+    for (size_t i = 0; i < dependencyInp.size(); ++i) {
+        if (!satisfied) {
             break;
         }
 
@@ -967,49 +977,55 @@ bool EGS_Editor::inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp, QText
         bool foundTag;
         QString val = getInputValue(QString::fromStdString(depTag), cursor.block(), foundTag);
 
-        if(foundTag && !dependencyAnti[i]) {
-            if(dependencyVal[i].size() > 0) {
-                if(egsEquivStr(val.toLatin1().data(), dependencyVal[i])) {
+        if (foundTag && !dependencyAnti[i]) {
+            if (dependencyVal[i].size() > 0) {
+                if (egsEquivStr(val.toLatin1().data(), dependencyVal[i])) {
                     satisfied = true;
-                } else {
+                }
+                else {
                     satisfied = false;
                 }
-            } else {
+            }
+            else {
                 satisfied = true;
             }
-        } else {
+        }
+        else {
             // If this is an anti dependency, then we didn't want to find the tag
             // Note that we don't check the value, only whether or not the input tag is used
-            if(!foundTag && dependencyAnti[i]) {
+            if (!foundTag && dependencyAnti[i]) {
                 satisfied = true;
-            } else {
+            }
+            else {
                 satisfied = false;
             }
         }
         // Look ahead, if the following inputs have the same tag as this one (i)
-        for(size_t j = i+1; j < dependencyInp.size(); ++j) {
-            if(egsEquivStr(dependencyInp[j]->getTag(), depTag)) {
+        for (size_t j = i+1; j < dependencyInp.size(); ++j) {
+            if (egsEquivStr(dependencyInp[j]->getTag(), depTag)) {
                 // If we already were satisfied by the first one, just skip
                 // ahead.
                 // This is because dependencies with the same tag are treated
                 // with an OR operation
-                if(satisfied) {
+                if (satisfied) {
                     // If we hit the end because all the tags matched, reset i
-                    if(j == dependencyInp.size()-1) {
+                    if (j == dependencyInp.size()-1) {
                         i = j;
                     }
                     continue;
-                } else {
-                    if(egsEquivStr(val.toLatin1().data(), dependencyVal[j])) {
+                }
+                else {
+                    if (egsEquivStr(val.toLatin1().data(), dependencyVal[j])) {
                         satisfied = true;
                         // If we hit the end because all the tags matched, reset i
-                        if(j == dependencyInp.size()-1) {
+                        if (j == dependencyInp.size()-1) {
                             i = j;
                         }
                         continue;
                     }
                 }
-            } else {
+            }
+            else {
                 i = j-1;
                 break;
             }
@@ -1019,24 +1035,27 @@ bool EGS_Editor::inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp, QText
     // Check for any input blocks that this input depends on
     // We are doing an AND between the input-type dependencies and the block-type ones
     // So we can skip this section if the input-type dependencies failed
-    if(satisfied) {
+    if (satisfied) {
         auto dependencyBlock = inp->getDependencyBlock();
 
-        if(dependencyBlock) {
+        if (dependencyBlock) {
             auto dependencyBlockAnti = inp->getDependencyBlockAnti();
 
             QTextBlock depBlock = findSiblingBlock(QString::fromStdString(dependencyBlock->getTitle()), cursor.block());
 
-            if(depBlock.isValid()) {
-                if(dependencyBlockAnti) {
+            if (depBlock.isValid()) {
+                if (dependencyBlockAnti) {
                     satisfied = false;
-                } else {
+                }
+                else {
                     satisfied = true;
                 }
-            } else {
-                if(dependencyBlockAnti) {
+            }
+            else {
+                if (dependencyBlockAnti) {
                     satisfied = true;
-                } else {
+                }
+                else {
                     satisfied = false;
                 }
             }
@@ -1053,39 +1072,40 @@ QTextBlock EGS_Editor::findSiblingBlock(QString title, QTextBlock currentBlock) 
     // Get the last textblock in this input block
     // so that we search all the inputs in the block
     QTextBlock blockEnd = getBlockEnd(currentBlock);
-    if(!blockEnd.isValid()) {
+    if (!blockEnd.isValid()) {
         return QTextBlock();
     }
 
     // Starting at the last line, start iterating in reverse through
     // the previous lines
     blockEnd = blockEnd.previous();
-    for(QTextBlock block = blockEnd; block.isValid(); block = block.previous()) {
+    for (QTextBlock block = blockEnd; block.isValid(); block = block.previous()) {
         QString line = block.text().simplified();
 
         // Find a sibling block with the title we're looking for
         // Here we expect to be within another block because the start line counts as inside the block
         int pos;
-        if(withinOtherBlock) {
+        if (withinOtherBlock) {
             pos = line.lastIndexOf(":start " + title + ":");
-            if(pos >= 0) {
+            if (pos >= 0) {
                 return block;
             }
         }
 
         // Get block title
         pos = line.lastIndexOf(":start ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 7;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 QString blockTitle = line.mid(pos, endPos-pos);
-                if(innerList.size() > 0 && blockTitle == innerList.back()) {
+                if (innerList.size() > 0 && blockTitle == innerList.back()) {
                     innerList.pop_back();
-                    if(innerList.size() == 0) {
+                    if (innerList.size() == 0) {
                         withinOtherBlock = false;
                     }
-                } else {
+                }
+                else {
                     // If we got to the start of the current block,
                     // then we failed to find the target block
                     return QTextBlock();
@@ -1097,10 +1117,10 @@ QTextBlock EGS_Editor::findSiblingBlock(QString title, QTextBlock currentBlock) 
         // This means both a matching :start and :stop are above the cursor
         // so we're not inside the block
         pos = line.lastIndexOf(":stop ");
-        if(pos >= 0) {
+        if (pos >= 0) {
             pos += 6;
             int endPos = line.indexOf(":",pos);
-            if(endPos > 0) {
+            if (endPos > 0) {
                 QString stopTitle = line.mid(pos, endPos-pos);
                 innerList.push_back(stopTitle);
                 withinOtherBlock = true;
@@ -1149,7 +1169,8 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
             //openLinkAtCursorPosition();
             return true;
         }
-    } else if(event->type() == QEvent::KeyPress) {
+    }
+    else if (event->type() == QEvent::KeyPress) {
         QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
 
         // Insert 4 spaces instead of tabs
@@ -1158,21 +1179,24 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
                 insertPlainText("    ");
                 return true;
             }
-        } else if(keyEvent->key() == Qt::Key_Backtab) {
+        }
+        else if (keyEvent->key() == Qt::Key_Backtab) {
             // Delete 4 spaces from the front of the line
             QTextCursor cursor = textCursor();
             QString line = cursor.block().text();
-            if(line.startsWith("    ")) {
+            if (line.startsWith("    ")) {
                 cursor.movePosition(QTextCursor::StartOfBlock);
                 cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 4);
                 cursor.removeSelectedText();
-            } else if(line.startsWith("\t")) {
+            }
+            else if (line.startsWith("\t")) {
                 cursor.movePosition(QTextCursor::StartOfBlock);
                 cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 1);
                 cursor.removeSelectedText();
             }
             return true;
-        } else if(keyEvent->key() == Qt::Key_Return) {
+        }
+        else if (keyEvent->key() == Qt::Key_Return) {
             if (!popup->isVisible()) {
 
                 QTextCursor cursor = textCursor();
@@ -1180,44 +1204,49 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
 
                 // Get the current indentation amount
                 QString indentation;
-                for(size_t i = 0; i < line.size(); ++i) {
-                    if(line.at(i) == ' ') {
+                for (size_t i = 0; i < line.size(); ++i) {
+                    if (line.at(i) == ' ') {
                         indentation += ' ';
-                   } else if(line.at(i) == '\t') {
+                    }
+                    else if (line.at(i) == '\t') {
                         indentation += "    ";
-                   } else {
+                    }
+                    else {
                         break;
-                   }
+                    }
                 }
 
                 QString stopLine;
                 int pos = line.lastIndexOf(":start ");
                 int posInBlock = cursor.positionInBlock();
-                if(pos > -1 && posInBlock > pos) {
+                if (pos > -1 && posInBlock > pos) {
                     stopLine = line.replace(pos, 7, ":stop ");
                 }
 
                 // If we inserted the ":stop" line, then also insert a line between
                 // and leave the cursor there
-                if(stopLine.size() > 0) {
+                if (stopLine.size() > 0) {
                     insertPlainText("\n" + indentation + "    ");
                     insertPlainText("\n" + stopLine);
                     cursor.movePosition(QTextCursor::PreviousBlock);
                     cursor.movePosition(QTextCursor::EndOfBlock);
                     setTextCursor(cursor);
 
-                // Normally, we just insert a new line with matching indentation
-                } else {
+                    // Normally, we just insert a new line with matching indentation
+                }
+                else {
                     insertPlainText("\n" + indentation);
                 }
 
                 // Skip the usual return event! So we have to handle it here
                 return true;
             }
-        } else if(keyEvent->key() == Qt::Key_Escape) {
+        }
+        else if (keyEvent->key() == Qt::Key_Escape) {
             popup->hide();
             popup->QWidget::releaseKeyboard();
-        } else if(keyEvent->key() == Qt::Key_Right) {
+        }
+        else if (keyEvent->key() == Qt::Key_Right) {
             if (popup->isVisible()) {
                 popupGrabbing = true;
                 popup->QWidget::grabKeyboard();
@@ -1226,13 +1255,15 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
         }
 //     } else if(event->type() == QEvent::FocusOut || event->type() == QEvent::Move || event->type() == QEvent::Resize || event->type() == QEvent::Scroll || event->type() == QEvent::WindowDeactivate) {
 
-    //} else if(event->type() == QEvent::Wheel || event->type() == QEvent::WindowDeactivate) {
-    } else if(event->type() == QEvent::Wheel || event->type() == QEvent::FocusOut) {
-        if(!popupGrabbing) {
+        //} else if(event->type() == QEvent::Wheel || event->type() == QEvent::WindowDeactivate) {
+    }
+    else if (event->type() == QEvent::Wheel || event->type() == QEvent::FocusOut) {
+        if (!popupGrabbing) {
             popup->hide();
             popup->QWidget::releaseKeyboard();
         }
-    } else if(obj == popup && event->type() == QEvent::FocusIn) {
+    }
+    else if (obj == popup && event->type() == QEvent::FocusIn) {
         popupGrabbing = false;
     }
 

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -23,7 +23,7 @@
 #
 #  Author:          Reid Townson, 2020
 #
-#  Contributors:    
+#  Contributors:    Hannah Gallop
 #
 ###############################################################################
 */

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -1,37 +1,82 @@
-
-#include <QtWidgets>
-
 #include "egs_editor.h"
 #include "egs_functions.h"
 
 EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
     this->setFrameShape(QFrame::NoFrame);
 
+    // Capture events
     installEventFilter(this);
     viewport()->installEventFilter(this);
 
+    // Set the font
     const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
     this->setFont(fixedFont);
 
+    // Set the tab width to 4 spaces
+    const int tabStop = 4; // 4 characters
+    QFontMetrics metrics(fixedFont);
+    this->setTabStopWidth(tabStop * metrics.width(' '));
+
+    // Initialize an area for displaying line numbers
     lineNumberArea = new LineNumberArea(this);
+    updateLineNumberAreaWidth(0);
+
+    // Highlight the line currently selected by the cursor
+    highlightCurrentLine();
+
+    // The standard font format has no underline
+    normalFormat.setUnderlineStyle(QTextCharFormat::NoUnderline);
+
+    // The format for invalid inputs
+    // Adds a little red squiggly line
+    invalidFormat.setUnderlineColor(QColor("red"));
+    invalidFormat.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
+
+    // Initialize the auto completion popup
+    popup = new QListView;
+    popup->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    popup->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    popup->setSelectionBehavior(QAbstractItemView::SelectRows);
+    popup->setSelectionMode(QAbstractItemView::SingleSelection);
+    popup->setParent(nullptr);
+    popup->setFocusPolicy(Qt::NoFocus);
+    popup->installEventFilter(this);
+
+    // The Qt::Popup option seems to take control of mouse + key inputs
+    // essentially locking up the computer, beware!
+    //popup->setWindowFlag(Qt::Popup);
+    popup->setWindowFlag(Qt::ToolTip);
+
+    // Init model
+    model = new QStringListModel(this);
 
     connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
     connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
+    connect(this, SIGNAL(cursorPositionChanged()), popup, SLOT(hide()));
     connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
     connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(autoComplete()));
+    connect(popup, SIGNAL(clicked(QModelIndex)), this, SLOT(insertCompletion(QModelIndex)));
 
-    updateLineNumberAreaWidth(0);
-    highlightCurrentLine();
+//
+//         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
+//                         this, SLOT(_q_completionSelected(QItemSelection)));
+
+
 }
 
 EGS_Editor::~EGS_Editor() {
     if(lineNumberArea) {
         delete lineNumberArea;
     }
+    if(popup) {
+        delete popup;
+    }
+    if(model) {
+        delete model;
+    }
 }
 
 void EGS_Editor::setInputStruct(shared_ptr<EGS_InputStruct> inp) {
-    cout << "test EGS_Editor::setInputStruct" << endl;
     inputStruct = inp;
 }
 
@@ -98,108 +143,219 @@ void EGS_Editor::highlightCurrentLine() {
     setExtraSelections(extraSelections);
 }
 
-
+int EGS_Editor::countStartingWhitespace(const QString &s) {
+    int i, l = s.size();
+    for(i = 0; i < l && s[i] == ' '; ++i);
+    return i;
+}
 
 void EGS_Editor::autoComplete() {
     // Get the input structure
-    EGS_BlockInput inp = getBlockInput();
+    QString blockTitle;
+    shared_ptr<EGS_BlockInput> inputBlockTemplate = getBlockInput(blockTitle);
 
     // Get the text of the current line
     QTextCursor cursor = textCursor();
-    cursor.movePosition(QTextCursor::StartOfBlock);
-    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
-    QString selectedText = cursor.selectedText();
+    QString selectedText = cursor.block().text().simplified();
 
-    if (selectedText.simplified() == "library = ") {
+    // If the first character is a "#", ignore this line
+    if(selectedText.startsWith("#")) {
+        return;
+    }
 
-        // Init popup
-        QListView *popup = new QListView;
-        popup->setEditTriggers(QAbstractItemView::NoEditTriggers);
-        popup->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
-        popup->setSelectionBehavior(QAbstractItemView::SelectRows);
-        popup->setSelectionMode(QAbstractItemView::SingleSelection);
-        popup->setParent(nullptr);
-        popup->setFocusPolicy(Qt::NoFocus);
-        popup->installEventFilter(this);
+    // Check the validity of the inputs
+    // If this line contains an "=" then it should match a single input
+    int equalsPos = selectedText.indexOf("=");
+    if(equalsPos != -1) {
+        QString inputTag = selectedText.left(equalsPos).simplified();
+        QString inputVal = selectedText.right(selectedText.size() - equalsPos - 1).simplified();
 
-        // The Qt::Popup option seems to take control of mouse + key inputs
-        // essentially locking up the computer, beware!
-        //popup->setWindowFlag(Qt::Popup);
-        popup->setWindowFlag(Qt::ToolTip);
+        // If we found a template for this type of input block,
+        // check that the input tag  (LHS) is valid
+        if(inputBlockTemplate) {
 
-        QObject::connect(popup, SIGNAL(clicked(QModelIndex)),
-                         this, SLOT(insertCompletion(QModelIndex)));
-        QObject::connect(this, SIGNAL(cursorPositionChanged()),
-                         popup, SLOT(hide()));
-//
-//         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
-//                         this, SLOT(_q_completionSelected(QItemSelection)));
 
-        // Init model
-        QStringListModel *model;
-        model = new QStringListModel(this);
+            QList<QTextEdit::ExtraSelection> extraSelections = this->extraSelections();
+            QTextEdit::ExtraSelection selection;
+            selection.cursor = textCursor();
+            selection.cursor.joinPreviousEditBlock();
 
-        // Make data
-        QStringList itemList;
-        itemList << "egs_box" << "egs_cd_geometry" << "egs_cones" << "eii_iii";
-        model->setStringList(itemList);
+            // Select the whole line
+            selection.cursor.movePosition(QTextCursor::StartOfBlock);
+            selection.cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
 
-        popup->setModel(model);
-        popup->setFont(this->font());
+            // Reset the format to have no red underline
+            selection.cursor.setCharFormat(normalFormat);
 
-        // Get max string length
-        int strLength = 0;
-        for (auto &item: itemList) {
-            if (item.size() > strLength) {
-                strLength = item.size();
+            // Check that the input block template contains this type of input
+            //bool inputValid = inputBlockTemplate->contains(inputTag.toStdString());
+            shared_ptr<EGS_SingleInput> inputPtr = inputBlockTemplate->getSingleInput(inputTag.toStdString());
+            if(!inputPtr) {
+                // Select the input tag
+                selection.cursor.movePosition(QTextCursor::StartOfBlock);
+
+                // If whitespace was trimmed from the start of the line,
+                // we account for it so only the input tag is underlined
+                int originalEqualsPos = cursor.block().text().indexOf("=");
+                int numWhitespace = countStartingWhitespace(cursor.block().text());
+                if(numWhitespace > 0) {
+                    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
+                }
+
+                selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, originalEqualsPos - numWhitespace);
+
+                // Set the format to have a red underline
+                selection.cursor.setCharFormat(invalidFormat);
+            } else {
+                // If the input is valid, add the description as a tooltip
+                QTextCharFormat newFormat;
+                newFormat.setToolTip(QString::fromStdString(inputPtr->getDescription()));
+
+                selection.cursor.setCharFormat(newFormat);
             }
+
+            selection.cursor.endEditBlock();
+            extraSelections.append(selection);
+            setExtraSelections(extraSelections);
         }
 
-        // Create a selection popup
-        int maxVisibleItems = 6;
-        const QRect screen = this->frameRect();
-        QPoint pos;
-        int rh, w;
-        int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
-        QScrollBar *hsb = popup->horizontalScrollBar();
-        if (hsb && hsb->isVisible()) {
-            h += popup->horizontalScrollBar()->sizeHint().height();
+        // Return if the input value (RHS) is already filled
+        // This way we only offer options for blank inputs
+        if(inputVal != "") {
+            return;
         }
 
-        rh = this->height();
-        pos = this->viewport()->mapToGlobal(this->cursorRect().bottomRight());
-        QFontMetrics fm(popup->font());
-        w = 20 + strLength * fm.horizontalAdvance('9');
+        // Create a pop-up if there is a list of possible input values
+        if (inputTag == "library") {
 
-        popup->setGeometry(pos.x(), pos.y(), w, h);
+            // Get the list of possible libraries for this type of input block
+            // I.e. if this is a geometry, only offer geometries as options
+            vector<string> vals = inputStruct->getLibraryOptions(blockTitle.toStdString());
 
-        // Show the popup
-        if (!popup->isVisible()) {
-            popup->show();
+            // Populate the popup list
+            QStringList itemList;
+            for(auto &v: vals) {
+                itemList << QString(v.c_str());
+            }
+            if(itemList.size() > 0) {
+                model->setStringList(itemList);
+            }
+
+            popup->setModel(model);
+            popup->setFont(this->font());
+
+            // Get max string length
+            int strLength = 0;
+            for (auto &item: itemList) {
+                if (item.size() > strLength) {
+                    strLength = item.size();
+                }
+            }
+
+            // Create a selection popup
+            int maxVisibleItems = 6;
+            int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
+            QScrollBar *hsb = popup->horizontalScrollBar();
+            if (hsb && hsb->isVisible()) {
+                h += popup->horizontalScrollBar()->sizeHint().height();
+            }
+
+            QPoint pos = this->viewport()->mapToGlobal(this->cursorRect().bottomRight());
+            QFontMetrics fm(popup->font());
+            int w = 20 + strLength * fm.horizontalAdvance('9');
+
+            popup->setGeometry(pos.x(), pos.y(), w, h);
+
+            // Show the popup
+            if (!popup->isVisible()) {
+                popup->show();
+            }
+        } else {
+
+            // Return if we couldn't find a template for this input block
+            if(!inputBlockTemplate) {
+                return;
+            }
+
+            // Check for this input tag in the template
+            shared_ptr<EGS_SingleInput> inp = inputBlockTemplate->getSingleInput(inputTag.toStdString());
+
+            // Return if we didn't find this input in the template
+            if(!inp) {
+                return;
+            }
+
+            // Get the possible values
+            auto vals = inp->getValues();
+
+            // Return if we don't have a list of values to choose from
+            if(vals.size() == 0) {
+                return;
+            }
+
+            // Populate the popup list
+            QStringList itemList;
+            for(auto &v: vals) {
+                itemList << QString(v.c_str());
+            }
+            if(itemList.size() > 0) {
+                model->setStringList(itemList);
+            }
+
+            popup->setModel(model);
+            popup->setFont(this->font());
+
+            // Get max string length
+            int strLength = 0;
+            for (auto &item: itemList) {
+                if (item.size() > strLength) {
+                    strLength = item.size();
+                }
+            }
+
+            // Create a selection popup
+            int maxVisibleItems = 6;
+            int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
+            QScrollBar *hsb = popup->horizontalScrollBar();
+            if (hsb && hsb->isVisible()) {
+                h += popup->horizontalScrollBar()->sizeHint().height();
+            }
+
+            QPoint pos = this->viewport()->mapToGlobal(this->cursorRect().bottomRight());
+            QFontMetrics fm(popup->font());
+            int w = 20 + strLength * fm.horizontalAdvance('9');
+
+            popup->setGeometry(pos.x(), pos.y(), w, h);
+
+            // Show the popup
+            if (!popup->isVisible()) {
+                popup->show();
+            }
         }
     }
 }
 
 void EGS_Editor::insertCompletion(QModelIndex index) {
-    insertPlainText("test");
-    //insertPlainText(index);
+    insertPlainText(model->data(index).toString());
 }
 
-// TODO: on clicking a new position in doc
-// - get nearest :start, load inputstruct (for geom/src, get library first)
-EGS_BlockInput EGS_Editor::getBlockInput() {
-
-    QString library, blockTitle;
+shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle) {
+    QString library;
+    vector<QString> stopList;
+    bool withinOtherBlock = false;
     for(QTextBlock block = textCursor().block(); block.isValid(); block = block.previous()) {
         QString line = block.text().simplified();
 
         // Get block library for input blocks based on a shared library
         // e.g. geometries and sources
-        int startPos = line.lastIndexOf("library =");
-        if(startPos >= 0) {
-            startPos += 9;
-            library = line.mid(startPos, line.size()-startPos).simplified();
-            cout << "test1 " << library.toLatin1().data() << endl;
+        // Only look for the library tag if we're not in a sub-block
+        int pos;
+        if(!withinOtherBlock) {
+            pos = line.lastIndexOf("library =");
+            if(pos >= 0) {
+                pos += 9;
+                library = line.mid(pos, line.size()-pos).simplified();
+            }
         }
 
         // Get block title
@@ -208,28 +364,41 @@ EGS_BlockInput EGS_Editor::getBlockInput() {
             startPos += 7;
             int endPos = line.indexOf(":",startPos);
             if(endPos > 0) {
-                blockTitle = line.mid(startPos, endPos-startPos);
-                cout << "test2 " << blockTitle.toLatin1().data() << endl;
-                break;
+                blockTitle = line.mid(pos, endPos-pos);
+                if(stopList.size() > 0 && blockTitle == stopList.back()) {
+                    stopList.pop_back();
+                    blockTitle.clear();
+                    withinOtherBlock = false;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Save a vector of blocks that have already been closed
+        // This means both a matching :start and :stop are above the cursor
+        // so we're not inside the block
+        pos = line.lastIndexOf(":stop ");
+        if(pos >= 0) {
+            pos += 6;
+            int endPos = line.indexOf(":",pos);
+            if(endPos > 0) {
+                QString stopTitle = line.mid(pos, endPos-pos);
+                stopList.push_back(stopTitle);
+                withinOtherBlock = true;
             }
         }
     }
 
     // If we got the library tag, we can directly look up this input block structure
-    shared_ptr<EGS_BlockInput> inputBlock;
-    cout << "test4a " << endl;
-    shared_ptr<EGS_BlockInput> libraryBlock = inputStruct->getLibraryBlock("","");
     if(library.size() > 0) {
-        cout << "test3a " << endl;
-        inputBlock = inputStruct->getLibraryBlock(blockTitle.toStdString(), library.toStdString());
-        cout << "test3b " << endl;
+        shared_ptr<EGS_BlockInput> inputBlock = inputStruct->getLibraryBlock(blockTitle.toStdString(), library.toStdString());
         if(inputBlock) {
-            cout << "test3 " << inputBlock->getTitle().c_str() << endl;
+            return inputBlock;
         }
     }
 
-
-    return EGS_BlockInput();
+    return nullptr;
 }
 
 void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event) {
@@ -270,6 +439,30 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
             //openLinkAtCursorPosition();
             return true;
         }
+    } else if(event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+
+        // Insert 4 spaces instead of tabs
+        if (keyEvent->key() == Qt::Key_Tab) {
+            insertPlainText("    ");
+            return true;
+        } else if(keyEvent->key() == Qt::Key_Backtab) {
+            // Delete 4 spaces from the front of the line
+            QTextCursor cursor = textCursor();
+            QString line = cursor.block().text();
+            if(line.startsWith("    ")) {
+                cursor.movePosition(QTextCursor::StartOfBlock);
+                cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 4);
+                cursor.removeSelectedText();
+            } else if(line.startsWith("\t")) {
+                cursor.movePosition(QTextCursor::StartOfBlock);
+                cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, 1);
+                cursor.removeSelectedText();
+            }
+            return true;
+        }
+    } else if(event->type() == QEvent::Wheel || event->type() == QEvent::FocusOut) {
+        popup->hide();
     }
 
     return QPlainTextEdit::eventFilter(obj, event);

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -1,0 +1,277 @@
+
+#include <QtWidgets>
+
+#include "egs_editor.h"
+
+EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent)
+{
+    this->setFrameShape(QFrame::NoFrame);
+
+    installEventFilter(this);
+    viewport()->installEventFilter(this);
+
+    lineNumberArea = new LineNumberArea(this);
+
+    connect(this, SIGNAL(blockCountChanged(int)), this, SLOT(updateLineNumberAreaWidth(int)));
+    connect(this, SIGNAL(updateRequest(QRect,int)), this, SLOT(updateLineNumberArea(QRect,int)));
+    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(highlightCurrentLine()));
+    connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(autoComplete()));
+
+    updateLineNumberAreaWidth(0);
+    highlightCurrentLine();
+}
+
+
+
+int EGS_Editor::lineNumberAreaWidth()
+{
+    int digits = 1;
+    int max = qMax(1, blockCount());
+    while (max >= 10) {
+        max /= 10;
+        ++digits;
+    }
+
+    int space = 3 + fontMetrics().horizontalAdvance(QLatin1Char('9')) * digits;
+
+    return space;
+}
+
+
+
+void EGS_Editor::updateLineNumberAreaWidth(int /* newBlockCount */)
+{
+    setViewportMargins(lineNumberAreaWidth()+5, 0, 0, 0);
+}
+
+
+
+void EGS_Editor::updateLineNumberArea(const QRect &rect, int dy)
+{
+    if (dy)
+        lineNumberArea->scroll(0, dy);
+    else
+        lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+
+    if (rect.contains(viewport()->rect()))
+        updateLineNumberAreaWidth(0);
+}
+
+
+
+void EGS_Editor::resizeEvent(QResizeEvent *e)
+{
+    QPlainTextEdit::resizeEvent(e);
+
+    QRect cr = contentsRect();
+    lineNumberArea->setGeometry(QRect(cr.left(), cr.top(), lineNumberAreaWidth(), cr.height()));
+}
+
+
+
+void EGS_Editor::highlightCurrentLine()
+{
+    QList<QTextEdit::ExtraSelection> extraSelections;
+
+    if (!isReadOnly()) {
+        QTextEdit::ExtraSelection selection;
+
+        QColor lineColor = QColor(Qt::lightGray).lighter(120);
+
+        selection.format.setBackground(lineColor);
+        selection.format.setProperty(QTextFormat::FullWidthSelection, true);
+        selection.cursor = textCursor();
+        selection.cursor.clearSelection();
+        extraSelections.append(selection);
+    }
+
+    setExtraSelections(extraSelections);
+}
+
+
+
+void EGS_Editor::autoComplete()
+{
+    QTextCursor cursor = textCursor();
+    int clickedPosition = cursor.position();
+
+    // Get the text of the current line
+    cursor.movePosition(QTextCursor::StartOfBlock);
+    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+    QString selectedText = cursor.selectedText();
+
+    if(selectedText.simplified() == "library =") {
+        //insertPlainText(selectedText);
+
+        // Init popup
+        QListView *popup = new QListView;
+        popup->setEditTriggers(QAbstractItemView::NoEditTriggers);
+        popup->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+        popup->setSelectionBehavior(QAbstractItemView::SelectRows);
+        popup->setSelectionMode(QAbstractItemView::SingleSelection);
+        //popup->setModelColumn(d->column);
+
+        popup->setParent(nullptr);
+        // This option seems to take control of mouse + key inputs
+        // essentially locking up the computer, beware!
+        //popup->setWindowFlag(Qt::Popup);
+        popup->setWindowFlag(Qt::ToolTip);
+        popup->setFocusPolicy(Qt::NoFocus);
+
+        popup->installEventFilter(this);
+
+        QObject::connect(popup, SIGNAL(clicked(QModelIndex)),
+                        this, SLOT(insertCompletion(QModelIndex)));
+        QObject::connect(this, SIGNAL(cursorPositionChanged()),
+                        popup, SLOT(hide()));
+//
+//         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
+//                         this, SLOT(_q_completionSelected(QItemSelection)));
+
+        // Init model
+        QStringListModel *model;
+        model = new QStringListModel(this);
+
+        // Make data
+        QStringList List;
+        List << "egs_box" << "egs_cd_geometry" << "egs_cones";
+        model->setStringList(List);
+
+        popup->setModel(model);
+
+        // Create a selection popup
+        QRect rect; //tmp rect
+        int maxVisibleItems = 6;
+        const QRect screen = this->frameRect();
+        Qt::LayoutDirection dir = this->layoutDirection();
+        QPoint pos;
+        int rh, w;
+        int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
+        QScrollBar *hsb = popup->horizontalScrollBar();
+        if (hsb && hsb->isVisible())
+            h += popup->horizontalScrollBar()->sizeHint().height();
+
+        if (rect.isValid()) {
+            rh = rect.height();
+            w = rect.width();
+            pos = this->mapToGlobal(dir == Qt::RightToLeft ? rect.bottomRight() : rect.bottomLeft());
+        } else {
+            rh = this->height();
+            pos = this->mapToGlobal(QPoint(0, this->height() - 2));
+            w = this->width();
+        }
+
+        // Constrain the box size to the window
+        if (w > screen.width())
+            w = screen.width();
+        if ((pos.x() + w) > (screen.x() + screen.width()))
+            pos.setX(screen.x() + screen.width() - w);
+        if (pos.x() < screen.x())
+            pos.setX(screen.x());
+
+        int top = pos.y() - rh - screen.top() + 2;
+        int bottom = screen.bottom() - pos.y();
+        h = qMax(h, popup->minimumHeight());
+        if (h > bottom) {
+            h = qMin(qMax(top, bottom), h);
+
+            if (top > bottom)
+                pos.setY(pos.y() - h - rh + 2);
+        }
+
+        popup->setGeometry(pos.x(), pos.y(), w, h);
+
+        // Show the popup
+        if (!popup->isVisible())
+            popup->show();
+    }
+}
+
+void EGS_Editor::insertCompletion(QModelIndex index) {
+    insertPlainText("test");
+    //insertPlainText(index);
+}
+
+
+
+void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event)
+{
+    QPainter painter(lineNumberArea);
+    //painter.fillRect(event->rect(), QColor(Qt::lightGray).lighter(110));
+
+
+    QTextBlock block = firstVisibleBlock();
+    int blockNumber = block.blockNumber();
+    int top = static_cast<int>(blockBoundingGeometry(block).translated(contentOffset()).top());
+    int bottom = top + static_cast<int>(blockBoundingRect(block).height());
+
+    while (block.isValid() && top <= event->rect().bottom()) {
+        if (block.isVisible() && bottom >= event->rect().top()) {
+            QString number = QString::number(blockNumber + 1);
+            painter.setPen(Qt::black);
+            painter.drawText(0, top, lineNumberArea->width(), fontMetrics().height(),
+                             Qt::AlignRight, number);
+        }
+
+        block = block.next();
+        top = bottom;
+        bottom = top + static_cast<int>(blockBoundingRect(block).height());
+        ++blockNumber;
+    }
+}
+
+bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
+
+    if (event->type() == QEvent::MouseButtonRelease) {
+        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
+
+        // track `Ctrl + Click` in the text edit
+        if ((obj == this->viewport()) &&
+            (mouseEvent->button() == Qt::LeftButton) &&
+            (QGuiApplication::keyboardModifiers() == Qt::ControlModifier)) {
+            // open the link (if any) at the current position
+            //openLinkAtCursorPosition();
+            return true;
+        }
+    }
+
+    return QPlainTextEdit::eventFilter(obj, event);
+}
+
+//bool EGS_Editor::openLinkAtCursorPosition() {
+//    QTextCursor cursor = this->textCursor();
+//    int clickedPosition = cursor.position();
+
+//    // select the text in the clicked block and find out on
+//    // which position we clicked
+//    cursor.movePosition(QTextCursor::StartOfBlock);
+//    int positionFromStart = clickedPosition - cursor.position();
+//    cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
+
+//    QString selectedText = cursor.selectedText();
+
+//    // find out which url in the selected text was clicked
+//    QString urlString = getMarkdownUrlAtPosition(selectedText,
+//                                                 positionFromStart);
+//    QUrl url = QUrl(urlString);
+//    bool isRelativeFileUrl = urlString.startsWith("file://..");
+
+//    qDebug() << __func__ << " - 'emit urlClicked( urlString )': "
+//             << urlString;
+
+//    emit urlClicked(urlString);
+
+//    if ((url.isValid() && isValidUrl(urlString)) || isRelativeFileUrl) {
+//        // ignore some schemata
+//        if (!(_ignoredClickUrlSchemata.contains(url.scheme()) ||
+//                isRelativeFileUrl)) {
+//            // open the url
+//            openUrl(urlString);
+//        }
+
+//        return true;
+//    }
+
+//    return false;
+//}
+

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -2,13 +2,16 @@
 #include <QtWidgets>
 
 #include "egs_editor.h"
+#include "egs_functions.h"
 
-EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent)
-{
+EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
     this->setFrameShape(QFrame::NoFrame);
 
     installEventFilter(this);
     viewport()->installEventFilter(this);
+
+    const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    this->setFont(fixedFont);
 
     lineNumberArea = new LineNumberArea(this);
 
@@ -21,10 +24,18 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent)
     highlightCurrentLine();
 }
 
+EGS_Editor::~EGS_Editor() {
+    if(lineNumberArea) {
+        delete lineNumberArea;
+    }
+}
 
+void EGS_Editor::setInputStruct(shared_ptr<EGS_InputStruct> inp) {
+    cout << "test EGS_Editor::setInputStruct" << endl;
+    inputStruct = inp;
+}
 
-int EGS_Editor::lineNumberAreaWidth()
-{
+int EGS_Editor::lineNumberAreaWidth() {
     int digits = 1;
     int max = qMax(1, blockCount());
     while (max >= 10) {
@@ -39,28 +50,28 @@ int EGS_Editor::lineNumberAreaWidth()
 
 
 
-void EGS_Editor::updateLineNumberAreaWidth(int /* newBlockCount */)
-{
+void EGS_Editor::updateLineNumberAreaWidth(int /* newBlockCount */) {
     setViewportMargins(lineNumberAreaWidth()+5, 0, 0, 0);
 }
 
 
 
-void EGS_Editor::updateLineNumberArea(const QRect &rect, int dy)
-{
-    if (dy)
+void EGS_Editor::updateLineNumberArea(const QRect &rect, int dy) {
+    if (dy) {
         lineNumberArea->scroll(0, dy);
-    else
+    }
+    else {
         lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+    }
 
-    if (rect.contains(viewport()->rect()))
+    if (rect.contains(viewport()->rect())) {
         updateLineNumberAreaWidth(0);
+    }
 }
 
 
 
-void EGS_Editor::resizeEvent(QResizeEvent *e)
-{
+void EGS_Editor::resizeEvent(QResizeEvent *e) {
     QPlainTextEdit::resizeEvent(e);
 
     QRect cr = contentsRect();
@@ -69,8 +80,7 @@ void EGS_Editor::resizeEvent(QResizeEvent *e)
 
 
 
-void EGS_Editor::highlightCurrentLine()
-{
+void EGS_Editor::highlightCurrentLine() {
     QList<QTextEdit::ExtraSelection> extraSelections;
 
     if (!isReadOnly()) {
@@ -90,18 +100,17 @@ void EGS_Editor::highlightCurrentLine()
 
 
 
-void EGS_Editor::autoComplete()
-{
-    QTextCursor cursor = textCursor();
-    int clickedPosition = cursor.position();
+void EGS_Editor::autoComplete() {
+    // Get the input structure
+    EGS_BlockInput inp = getBlockInput();
 
     // Get the text of the current line
+    QTextCursor cursor = textCursor();
     cursor.movePosition(QTextCursor::StartOfBlock);
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
     QString selectedText = cursor.selectedText();
 
-    if(selectedText.simplified() == "library =") {
-        //insertPlainText(selectedText);
+    if (selectedText.simplified() == "library = ") {
 
         // Init popup
         QListView *popup = new QListView;
@@ -109,21 +118,19 @@ void EGS_Editor::autoComplete()
         popup->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         popup->setSelectionBehavior(QAbstractItemView::SelectRows);
         popup->setSelectionMode(QAbstractItemView::SingleSelection);
-        //popup->setModelColumn(d->column);
-
         popup->setParent(nullptr);
-        // This option seems to take control of mouse + key inputs
+        popup->setFocusPolicy(Qt::NoFocus);
+        popup->installEventFilter(this);
+
+        // The Qt::Popup option seems to take control of mouse + key inputs
         // essentially locking up the computer, beware!
         //popup->setWindowFlag(Qt::Popup);
         popup->setWindowFlag(Qt::ToolTip);
-        popup->setFocusPolicy(Qt::NoFocus);
-
-        popup->installEventFilter(this);
 
         QObject::connect(popup, SIGNAL(clicked(QModelIndex)),
-                        this, SLOT(insertCompletion(QModelIndex)));
+                         this, SLOT(insertCompletion(QModelIndex)));
         QObject::connect(this, SIGNAL(cursorPositionChanged()),
-                        popup, SLOT(hide()));
+                         popup, SLOT(hide()));
 //
 //         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
 //                         this, SLOT(_q_completionSelected(QItemSelection)));
@@ -133,57 +140,43 @@ void EGS_Editor::autoComplete()
         model = new QStringListModel(this);
 
         // Make data
-        QStringList List;
-        List << "egs_box" << "egs_cd_geometry" << "egs_cones";
-        model->setStringList(List);
+        QStringList itemList;
+        itemList << "egs_box" << "egs_cd_geometry" << "egs_cones" << "eii_iii";
+        model->setStringList(itemList);
 
         popup->setModel(model);
+        popup->setFont(this->font());
+
+        // Get max string length
+        int strLength = 0;
+        for (auto &item: itemList) {
+            if (item.size() > strLength) {
+                strLength = item.size();
+            }
+        }
 
         // Create a selection popup
-        QRect rect; //tmp rect
         int maxVisibleItems = 6;
         const QRect screen = this->frameRect();
-        Qt::LayoutDirection dir = this->layoutDirection();
         QPoint pos;
         int rh, w;
         int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
         QScrollBar *hsb = popup->horizontalScrollBar();
-        if (hsb && hsb->isVisible())
+        if (hsb && hsb->isVisible()) {
             h += popup->horizontalScrollBar()->sizeHint().height();
-
-        if (rect.isValid()) {
-            rh = rect.height();
-            w = rect.width();
-            pos = this->mapToGlobal(dir == Qt::RightToLeft ? rect.bottomRight() : rect.bottomLeft());
-        } else {
-            rh = this->height();
-            pos = this->mapToGlobal(QPoint(0, this->height() - 2));
-            w = this->width();
         }
 
-        // Constrain the box size to the window
-        if (w > screen.width())
-            w = screen.width();
-        if ((pos.x() + w) > (screen.x() + screen.width()))
-            pos.setX(screen.x() + screen.width() - w);
-        if (pos.x() < screen.x())
-            pos.setX(screen.x());
-
-        int top = pos.y() - rh - screen.top() + 2;
-        int bottom = screen.bottom() - pos.y();
-        h = qMax(h, popup->minimumHeight());
-        if (h > bottom) {
-            h = qMin(qMax(top, bottom), h);
-
-            if (top > bottom)
-                pos.setY(pos.y() - h - rh + 2);
-        }
+        rh = this->height();
+        pos = this->viewport()->mapToGlobal(this->cursorRect().bottomRight());
+        QFontMetrics fm(popup->font());
+        w = 20 + strLength * fm.horizontalAdvance('9');
 
         popup->setGeometry(pos.x(), pos.y(), w, h);
 
         // Show the popup
-        if (!popup->isVisible())
+        if (!popup->isVisible()) {
             popup->show();
+        }
     }
 }
 
@@ -192,10 +185,54 @@ void EGS_Editor::insertCompletion(QModelIndex index) {
     //insertPlainText(index);
 }
 
+// TODO: on clicking a new position in doc
+// - get nearest :start, load inputstruct (for geom/src, get library first)
+EGS_BlockInput EGS_Editor::getBlockInput() {
+
+    QString library, blockTitle;
+    for(QTextBlock block = textCursor().block(); block.isValid(); block = block.previous()) {
+        QString line = block.text().simplified();
+
+        // Get block library for input blocks based on a shared library
+        // e.g. geometries and sources
+        int startPos = line.lastIndexOf("library =");
+        if(startPos >= 0) {
+            startPos += 9;
+            library = line.mid(startPos, line.size()-startPos).simplified();
+            cout << "test1 " << library.toLatin1().data() << endl;
+        }
+
+        // Get block title
+        startPos = line.lastIndexOf(":start ");
+        if(startPos >= 0) {
+            startPos += 7;
+            int endPos = line.indexOf(":",startPos);
+            if(endPos > 0) {
+                blockTitle = line.mid(startPos, endPos-startPos);
+                cout << "test2 " << blockTitle.toLatin1().data() << endl;
+                break;
+            }
+        }
+    }
+
+    // If we got the library tag, we can directly look up this input block structure
+    shared_ptr<EGS_BlockInput> inputBlock;
+    cout << "test4a " << endl;
+    shared_ptr<EGS_BlockInput> libraryBlock = inputStruct->getLibraryBlock("","");
+    if(library.size() > 0) {
+        cout << "test3a " << endl;
+        inputBlock = inputStruct->getLibraryBlock(blockTitle.toStdString(), library.toStdString());
+        cout << "test3b " << endl;
+        if(inputBlock) {
+            cout << "test3 " << inputBlock->getTitle().c_str() << endl;
+        }
+    }
 
 
-void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event)
-{
+    return EGS_BlockInput();
+}
+
+void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event) {
     QPainter painter(lineNumberArea);
     //painter.fillRect(event->rect(), QColor(Qt::lightGray).lighter(110));
 
@@ -227,8 +264,8 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
 
         // track `Ctrl + Click` in the text edit
         if ((obj == this->viewport()) &&
-            (mouseEvent->button() == Qt::LeftButton) &&
-            (QGuiApplication::keyboardModifiers() == Qt::ControlModifier)) {
+                (mouseEvent->button() == Qt::LeftButton) &&
+                (QGuiApplication::keyboardModifiers() == Qt::ControlModifier)) {
             // open the link (if any) at the current position
             //openLinkAtCursorPosition();
             return true;

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -193,6 +193,10 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
         return;
     }
 
+    if(selectedText.startsWith("#")) {
+        return;
+    }
+
     // Check the validity of the inputs
     // If this line contains an "=" then it should match a single input
     int equalsPos = selectedText.indexOf("=");
@@ -228,6 +232,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
             if(!inputPtr) {
                 // Red underline the input tag
                 // Select the input tag
+
                 selection.cursor.movePosition(QTextCursor::StartOfBlock);
 
                 // If whitespace was trimmed from the start of the line,

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -2,13 +2,16 @@
 #include <QtWidgets>
 
 #include "egs_editor.h"
+#include "egs_functions.h"
 
-EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent)
-{
+EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
     this->setFrameShape(QFrame::NoFrame);
 
     installEventFilter(this);
     viewport()->installEventFilter(this);
+
+    const QFont fixedFont = QFontDatabase::systemFont(QFontDatabase::FixedFont);
+    this->setFont(fixedFont);
 
     lineNumberArea = new LineNumberArea(this);
 
@@ -21,10 +24,19 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent)
     highlightCurrentLine();
 }
 
+EGS_Editor::~EGS_Editor() {
+    if(lineNumberArea) {
+        delete lineNumberArea;
+    }
+}
 
+void EGS_Editor::setInputStruct(shared_ptr<EGS_InputStruct> inp) {
+    cout << "test EGS_Editor::setInputStruct" << endl;
+    inputStruct = *inp;
+    shared_ptr<EGS_BlockInput> libraryBlock = inputStruct.getLibraryBlock("","");
+}
 
-int EGS_Editor::lineNumberAreaWidth()
-{
+int EGS_Editor::lineNumberAreaWidth() {
     int digits = 1;
     int max = qMax(1, blockCount());
     while (max >= 10) {
@@ -39,28 +51,28 @@ int EGS_Editor::lineNumberAreaWidth()
 
 
 
-void EGS_Editor::updateLineNumberAreaWidth(int /* newBlockCount */)
-{
+void EGS_Editor::updateLineNumberAreaWidth(int /* newBlockCount */) {
     setViewportMargins(lineNumberAreaWidth()+5, 0, 0, 0);
 }
 
 
 
-void EGS_Editor::updateLineNumberArea(const QRect &rect, int dy)
-{
-    if (dy)
+void EGS_Editor::updateLineNumberArea(const QRect &rect, int dy) {
+    if (dy) {
         lineNumberArea->scroll(0, dy);
-    else
+    }
+    else {
         lineNumberArea->update(0, rect.y(), lineNumberArea->width(), rect.height());
+    }
 
-    if (rect.contains(viewport()->rect()))
+    if (rect.contains(viewport()->rect())) {
         updateLineNumberAreaWidth(0);
+    }
 }
 
 
 
-void EGS_Editor::resizeEvent(QResizeEvent *e)
-{
+void EGS_Editor::resizeEvent(QResizeEvent *e) {
     QPlainTextEdit::resizeEvent(e);
 
     QRect cr = contentsRect();
@@ -69,8 +81,7 @@ void EGS_Editor::resizeEvent(QResizeEvent *e)
 
 
 
-void EGS_Editor::highlightCurrentLine()
-{
+void EGS_Editor::highlightCurrentLine() {
     QList<QTextEdit::ExtraSelection> extraSelections;
 
     if (!isReadOnly()) {
@@ -90,18 +101,17 @@ void EGS_Editor::highlightCurrentLine()
 
 
 
-void EGS_Editor::autoComplete()
-{
-    QTextCursor cursor = textCursor();
-    int clickedPosition = cursor.position();
+void EGS_Editor::autoComplete() {
+    // Get the input structure
+    EGS_BlockInput inp = getBlockInput();
 
     // Get the text of the current line
+    QTextCursor cursor = textCursor();
     cursor.movePosition(QTextCursor::StartOfBlock);
     cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
     QString selectedText = cursor.selectedText();
 
-    if(selectedText.simplified() == "library =") {
-        //insertPlainText(selectedText);
+    if (selectedText.simplified() == "library = ") {
 
         // Init popup
         QListView *popup = new QListView;
@@ -109,21 +119,19 @@ void EGS_Editor::autoComplete()
         popup->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
         popup->setSelectionBehavior(QAbstractItemView::SelectRows);
         popup->setSelectionMode(QAbstractItemView::SingleSelection);
-        //popup->setModelColumn(d->column);
-
         popup->setParent(nullptr);
-        // This option seems to take control of mouse + key inputs
+        popup->setFocusPolicy(Qt::NoFocus);
+        popup->installEventFilter(this);
+
+        // The Qt::Popup option seems to take control of mouse + key inputs
         // essentially locking up the computer, beware!
         //popup->setWindowFlag(Qt::Popup);
         popup->setWindowFlag(Qt::ToolTip);
-        popup->setFocusPolicy(Qt::NoFocus);
-
-        popup->installEventFilter(this);
 
         QObject::connect(popup, SIGNAL(clicked(QModelIndex)),
-                        this, SLOT(insertCompletion(QModelIndex)));
+                         this, SLOT(insertCompletion(QModelIndex)));
         QObject::connect(this, SIGNAL(cursorPositionChanged()),
-                        popup, SLOT(hide()));
+                         popup, SLOT(hide()));
 //
 //         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
 //                         this, SLOT(_q_completionSelected(QItemSelection)));
@@ -133,57 +141,43 @@ void EGS_Editor::autoComplete()
         model = new QStringListModel(this);
 
         // Make data
-        QStringList List;
-        List << "egs_box" << "egs_cd_geometry" << "egs_cones";
-        model->setStringList(List);
+        QStringList itemList;
+        itemList << "egs_box" << "egs_cd_geometry" << "egs_cones" << "eii_iii";
+        model->setStringList(itemList);
 
         popup->setModel(model);
+        popup->setFont(this->font());
+
+        // Get max string length
+        int strLength = 0;
+        for (auto &item: itemList) {
+            if (item.size() > strLength) {
+                strLength = item.size();
+            }
+        }
 
         // Create a selection popup
-        QRect rect; //tmp rect
         int maxVisibleItems = 6;
         const QRect screen = this->frameRect();
-        Qt::LayoutDirection dir = this->layoutDirection();
         QPoint pos;
         int rh, w;
         int h = (popup->sizeHintForRow(0) * qMin(maxVisibleItems, popup->model()->rowCount()) + 3) + 3;
         QScrollBar *hsb = popup->horizontalScrollBar();
-        if (hsb && hsb->isVisible())
+        if (hsb && hsb->isVisible()) {
             h += popup->horizontalScrollBar()->sizeHint().height();
-
-        if (rect.isValid()) {
-            rh = rect.height();
-            w = rect.width();
-            pos = this->mapToGlobal(dir == Qt::RightToLeft ? rect.bottomRight() : rect.bottomLeft());
-        } else {
-            rh = this->height();
-            pos = this->mapToGlobal(QPoint(0, this->height() - 2));
-            w = this->width();
         }
 
-        // Constrain the box size to the window
-        if (w > screen.width())
-            w = screen.width();
-        if ((pos.x() + w) > (screen.x() + screen.width()))
-            pos.setX(screen.x() + screen.width() - w);
-        if (pos.x() < screen.x())
-            pos.setX(screen.x());
-
-        int top = pos.y() - rh - screen.top() + 2;
-        int bottom = screen.bottom() - pos.y();
-        h = qMax(h, popup->minimumHeight());
-        if (h > bottom) {
-            h = qMin(qMax(top, bottom), h);
-
-            if (top > bottom)
-                pos.setY(pos.y() - h - rh + 2);
-        }
+        rh = this->height();
+        pos = this->viewport()->mapToGlobal(this->cursorRect().bottomRight());
+        QFontMetrics fm(popup->font());
+        w = 20 + strLength * fm.horizontalAdvance('9');
 
         popup->setGeometry(pos.x(), pos.y(), w, h);
 
         // Show the popup
-        if (!popup->isVisible())
+        if (!popup->isVisible()) {
             popup->show();
+        }
     }
 }
 
@@ -192,10 +186,76 @@ void EGS_Editor::insertCompletion(QModelIndex index) {
     //insertPlainText(index);
 }
 
+// TODO: on clicking a new position in doc
+// - get nearest :start, load inputstruct (for geom/src, get library first)
+EGS_BlockInput EGS_Editor::getBlockInput() {
+    cout << "test getBlockInput " << endl;
+    shared_ptr<EGS_BlockInput> libraryBlock = inputStruct.getLibraryBlock("","");
+
+    QString library, blockTitle;
+    vector<QString> stopList;
+    for(QTextBlock block = textCursor().block(); block.isValid(); block = block.previous()) {
+        QString line = block.text().simplified();
+
+        // Get block library for input blocks based on a shared library
+        // e.g. geometries and sources
+        int pos = line.lastIndexOf("library =");
+        if(pos >= 0) {
+            pos += 9;
+            library = line.mid(pos, line.size()-pos).simplified();
+            cout << "test1 " << library.toLatin1().data() << endl;
+        }
+
+        // Get block title
+        pos = line.lastIndexOf(":start ");
+        if(pos >= 0) {
+            pos += 7;
+            int endPos = line.indexOf(":",pos);
+            if(endPos > 0) {
+                blockTitle = line.mid(pos, endPos-pos);
+                //cout << "test2 " << blockTitle.toLatin1().data() << endl;
+                if(stopList.size() > 0 && blockTitle == stopList.back()) {
+                    stopList.pop_back();
+                    blockTitle.clear();
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // Save a vector of blocks that have already been closed
+        // This means both a matching :start and :stop are above the cursor
+        // so we're not inside the block
+        pos = line.lastIndexOf(":stop ");
+        if(pos >= 0) {
+            pos += 6;
+            int endPos = line.indexOf(":",pos);
+            if(endPos > 0) {
+                QString stopTitle = line.mid(pos, endPos-pos);
+                stopList.push_back(stopTitle);
+            }
+        }
+    }
+
+    // If we got the library tag, we can directly look up this input block structure
+    shared_ptr<EGS_BlockInput> inputBlock;
+    cout << "test4a " << blockTitle.toLatin1().data() << endl;
+
+//     if(library.size() > 0) {
+//         cout << "test3a " << endl;
+//         inputBlock = inputStruct->getLibraryBlock(blockTitle.toStdString(), library.toStdString());
+//         cout << "test3b " << endl;
+//         if(inputBlock) {
+//             cout << "test3 " << inputBlock->getTitle().c_str() << endl;
+//         }
+//     }
+    cout << "test4b " << endl;
 
 
-void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event)
-{
+    return EGS_BlockInput();
+}
+
+void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event) {
     QPainter painter(lineNumberArea);
     //painter.fillRect(event->rect(), QColor(Qt::lightGray).lighter(110));
 
@@ -227,8 +287,8 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
 
         // track `Ctrl + Click` in the text edit
         if ((obj == this->viewport()) &&
-            (mouseEvent->button() == Qt::LeftButton) &&
-            (QGuiApplication::keyboardModifiers() == Qt::ControlModifier)) {
+                (mouseEvent->button() == Qt::LeftButton) &&
+                (QGuiApplication::keyboardModifiers() == Qt::ControlModifier)) {
             // open the link (if any) at the current position
             //openLinkAtCursorPosition();
             return true;

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -245,6 +245,11 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                 // Get the description for this input
                 string desc = inputPtr->getDescription();
 
+                bool isRequired = inputPtr->getRequired();
+                if(isRequired) {
+                    desc += "\nRequired.";
+                }
+
                 // Check if this input has any dependencies
                 // and then confirm that the dependencies are satisfied
                 if(inputHasDependency(inputPtr)) {
@@ -317,6 +322,9 @@ void EGS_Editor::autoComplete() {
     QString blockTitle;
     shared_ptr<EGS_BlockInput> inputBlockTemplate = getBlockInput(blockTitle);
     egsInformation("testA %s\n", blockTitle.toLatin1().data());
+    if(inputBlockTemplate) {
+        egsInformation("test foundtemplate\n");
+    }
 
     // If we aren't inside an input block, ignore this line
     if(blockTitle.size() < 1) {
@@ -657,15 +665,13 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
             }
         }
         blockEnd = getBlockEnd(blockEnd);
-        if(!blockEnd.isValid()) {
-            return nullptr;
+        if(blockEnd.isValid()) {
+            // Go to the line after the end of the current input block
+            blockEnd = blockEnd.next();
+
+            // Check for the library tag here
+            library = getInputValue("library", blockEnd, foundTag);
         }
-
-        // Go to the line after the end of the current input block
-        blockEnd = blockEnd.next();
-
-        // Check for the library tag here
-        library = getInputValue("library", blockEnd, foundTag);
 
         // If we still didn't find the library, search one block higher
         if(library.size() < 1) {
@@ -685,15 +691,13 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
                 }
             }
             blockEnd = getBlockEnd(blockEnd);
-            if(!blockEnd.isValid()) {
-                return nullptr;
+            if(blockEnd.isValid()) {
+                // Go to the line after the end of the current input block
+                blockEnd = blockEnd.next();
+
+                // Check for the library tag here
+                library = getInputValue("library", blockEnd, foundTag);
             }
-
-            // Go to the line after the end of the current input block
-            blockEnd = blockEnd.next();
-
-            // Check for the library tag here
-            library = getInputValue("library", blockEnd, foundTag);
         }
     }
 
@@ -709,6 +713,7 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
     // If we didn't get the library tag, we might be in a top-level block
     // like a geometry definition. Just return the block with the matching title
     shared_ptr<EGS_BlockInput> inputBlock = inputStruct->getBlockInput(blockTitle.toStdString());
+    egsInformation("test returning top level block\n");
 
     return inputBlock;
 }

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -196,6 +196,8 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
     // If this line contains an "=" then it should match a single input
     int equalsPos = selectedText.indexOf("=");
     if(equalsPos != -1) {
+        cursor.beginEditBlock();
+
         QString inputTag = selectedText.left(equalsPos).simplified();
         QString inputVal = selectedText.right(selectedText.size() - equalsPos - 1).simplified();
         egsInformation("test foundEquals %s\n",inputTag.toLatin1().data());
@@ -301,6 +303,7 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
             extraSelections.append(selection);
             setExtraSelections(extraSelections);
         }
+        cursor.endEditBlock();
     }
 }
 
@@ -626,8 +629,11 @@ void EGS_Editor::autoComplete() {
 }
 
 void EGS_Editor::insertCompletion(QModelIndex index) {
+    QTextCursor cursor = textCursor();
+    cursor.beginEditBlock();
     this->moveCursor(QTextCursor::EndOfBlock);
     insertPlainText(model->data(index).toString());
+    cursor.endEditBlock();
 }
 
 shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextCursor cursor) {

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -6,6 +6,8 @@
 #include <QEvent>
 #include <QModelIndex>
 
+#include "egs_input_struct.h"
+
 class QPaintEvent;
 class QResizeEvent;
 class QSize;
@@ -13,15 +15,16 @@ class QWidget;
 
 class LineNumberArea;
 
-class EGS_Editor : public QPlainTextEdit
-{
+class EGS_Editor : public QPlainTextEdit {
     Q_OBJECT
 
 public:
     EGS_Editor(QWidget *parent = 0);
+    ~EGS_Editor();
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
+    void setInputStruct(shared_ptr<EGS_InputStruct> inp);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -35,12 +38,14 @@ private slots:
     void updateLineNumberArea(const QRect &, int);
 
 private:
+    EGS_BlockInput getBlockInput();
+
     QWidget *lineNumberArea;
+    EGS_InputStruct inputStruct;
 };
 
 
-class LineNumberArea : public QWidget
-{
+class LineNumberArea : public QWidget {
 public:
     LineNumberArea(EGS_Editor *editor) : QWidget(editor) {
         egsEditor = editor;

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -5,6 +5,7 @@
 #include <QObject>
 #include <QEvent>
 #include <QModelIndex>
+#include <QtWidgets>
 
 #include "egs_input_struct.h"
 
@@ -38,10 +39,15 @@ private slots:
     void updateLineNumberArea(const QRect &, int);
 
 private:
-    EGS_BlockInput getBlockInput();
+    shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle);
+    int countStartingWhitespace(const QString &s);
 
     QWidget *lineNumberArea;
     shared_ptr<EGS_InputStruct> inputStruct;
+    QListView *popup;
+    QStringListModel *model;
+    QTextCharFormat normalFormat,
+                    invalidFormat;
 };
 
 

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -40,14 +40,17 @@ private slots:
 
 private:
     shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle);
+    QString getBlockTitle();
+    QString getInputValue(QString inp, QTextBlock currentBlock);
+    QTextBlock getBlockEnd(QTextBlock currentBlock);
+    bool inputHasDependency(shared_ptr<EGS_SingleInput> inp);
+    bool inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp);
     int countStartingWhitespace(const QString &s);
 
     QWidget *lineNumberArea;
     shared_ptr<EGS_InputStruct> inputStruct;
     QListView *popup;
     QStringListModel *model;
-    QTextCharFormat normalFormat,
-                    invalidFormat;
 };
 
 

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -6,6 +6,8 @@
 #include <QEvent>
 #include <QModelIndex>
 
+#include "egs_input_struct.h"
+
 class QPaintEvent;
 class QResizeEvent;
 class QSize;
@@ -13,15 +15,16 @@ class QWidget;
 
 class LineNumberArea;
 
-class EGS_Editor : public QPlainTextEdit
-{
+class EGS_Editor : public QPlainTextEdit {
     Q_OBJECT
 
 public:
     EGS_Editor(QWidget *parent = 0);
+    ~EGS_Editor();
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
+    void setInputStruct(shared_ptr<EGS_InputStruct> inp);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -35,12 +38,14 @@ private slots:
     void updateLineNumberArea(const QRect &, int);
 
 private:
+    EGS_BlockInput getBlockInput();
+
     QWidget *lineNumberArea;
+    shared_ptr<EGS_InputStruct> inputStruct;
 };
 
 
-class LineNumberArea : public QWidget
-{
+class LineNumberArea : public QWidget {
 public:
     LineNumberArea(EGS_Editor *editor) : QWidget(editor) {
         egsEditor = editor;

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -23,7 +23,7 @@
 #
 #  Author:          Reid Townson, 2020
 #
-#  Contributors:    
+#  Contributors:
 #
 ###############################################################################
 */
@@ -84,6 +84,7 @@ private:
     shared_ptr<EGS_InputStruct> inputStruct;
     QListView *popup;
     QStringListModel *model;
+    bool popupGrabbing;
 };
 
 

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -41,7 +41,7 @@ private slots:
 private:
     shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle);
     QString getBlockTitle();
-    QString getInputValue(QString inp, QTextBlock currentBlock);
+    QString getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag);
     QTextBlock getBlockEnd(QTextBlock currentBlock);
     bool inputHasDependency(shared_ptr<EGS_SingleInput> inp);
     bool inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp);

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -1,3 +1,33 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ egsinp editor
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2020
+#
+#  Contributors:    
+#
+###############################################################################
+*/
+
 #ifndef EGS_EDITOR_H
 #define EGS_EDITOR_H
 
@@ -26,6 +56,7 @@ public:
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
     void setInputStruct(shared_ptr<EGS_InputStruct> inp);
+    void validateEntireInput();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -34,17 +65,19 @@ protected:
 private slots:
     void updateLineNumberAreaWidth(int newBlockCount);
     void highlightCurrentLine();
+    void validateLine(QTextCursor line);
     void autoComplete();
     void insertCompletion(QModelIndex index);
     void updateLineNumberArea(const QRect &, int);
 
 private:
-    shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle);
-    QString getBlockTitle();
+    shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle, QTextCursor cursor = QTextCursor());
+    QString getBlockTitle(QTextCursor cursor = QTextCursor());
     QString getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag);
     QTextBlock getBlockEnd(QTextBlock currentBlock);
     bool inputHasDependency(shared_ptr<EGS_SingleInput> inp);
-    bool inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp);
+    bool inputDependencySatisfied(shared_ptr<EGS_SingleInput> inp, QTextCursor cursor = QTextCursor());
+    QTextBlock findSiblingBlock(QString title, QTextBlock currentBlock);
     int countStartingWhitespace(const QString &s);
 
     QWidget *lineNumberArea;

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -1,0 +1,62 @@
+#ifndef EGS_EDITOR_H
+#define EGS_EDITOR_H
+
+#include <QPlainTextEdit>
+#include <QObject>
+#include <QEvent>
+#include <QModelIndex>
+
+class QPaintEvent;
+class QResizeEvent;
+class QSize;
+class QWidget;
+
+class LineNumberArea;
+
+class EGS_Editor : public QPlainTextEdit
+{
+    Q_OBJECT
+
+public:
+    EGS_Editor(QWidget *parent = 0);
+
+    void lineNumberAreaPaintEvent(QPaintEvent *event);
+    int lineNumberAreaWidth();
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+    bool eventFilter(QObject *obj, QEvent *event);
+
+private slots:
+    void updateLineNumberAreaWidth(int newBlockCount);
+    void highlightCurrentLine();
+    void autoComplete();
+    void insertCompletion(QModelIndex index);
+    void updateLineNumberArea(const QRect &, int);
+
+private:
+    QWidget *lineNumberArea;
+};
+
+
+class LineNumberArea : public QWidget
+{
+public:
+    LineNumberArea(EGS_Editor *editor) : QWidget(editor) {
+        egsEditor = editor;
+    }
+
+    QSize sizeHint() const override {
+        return QSize(egsEditor->lineNumberAreaWidth(), 0);
+    }
+
+protected:
+    void paintEvent(QPaintEvent *event) override {
+        egsEditor->lineNumberAreaPaintEvent(event);
+    }
+
+private:
+    EGS_Editor *egsEditor;
+};
+
+#endif // EGS_EDITOR_H

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -6,8 +6,6 @@
 #include <QEvent>
 #include <QModelIndex>
 
-#include "egs_input_struct.h"
-
 class QPaintEvent;
 class QResizeEvent;
 class QSize;
@@ -15,16 +13,15 @@ class QWidget;
 
 class LineNumberArea;
 
-class EGS_Editor : public QPlainTextEdit {
+class EGS_Editor : public QPlainTextEdit
+{
     Q_OBJECT
 
 public:
     EGS_Editor(QWidget *parent = 0);
-    ~EGS_Editor();
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
-    void setInputStruct(shared_ptr<EGS_InputStruct> inp);
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -38,14 +35,12 @@ private slots:
     void updateLineNumberArea(const QRect &, int);
 
 private:
-    EGS_BlockInput getBlockInput();
-
     QWidget *lineNumberArea;
-    EGS_InputStruct inputStruct;
 };
 
 
-class LineNumberArea : public QWidget {
+class LineNumberArea : public QWidget
+{
 public:
     LineNumberArea(EGS_Editor *editor) : QWidget(editor) {
         egsEditor = editor;

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -1,0 +1,125 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ input highlighter
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2019
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+#include "egs_highlighter.h"
+
+EGS_Highlighter::EGS_Highlighter(QTextDocument *parent) : QSyntaxHighlighter(parent) {
+
+    HighlightingRule rule;
+
+    keywordFormat.setForeground(Qt::darkRed);
+    keywordFormat.setFontWeight(QFont::Bold);
+
+    QStringList keywordPatterns;
+    keywordPatterns << ":(start|stop).*\\S:";
+
+    foreach (const QString &pattern, keywordPatterns) {
+        rule.pattern = QRegularExpression(pattern);
+        rule.format = keywordFormat;
+        highlightingRules.append(rule);
+    }
+
+    attributeFormat.setForeground(Qt::darkBlue);
+    rule.pattern = QRegularExpression(".*=");
+    rule.format = attributeFormat;
+    highlightingRules.append(rule);
+
+    numberFormat.setForeground(Qt::darkGreen);
+    rule.pattern = QRegularExpression("[+-]?(\\d*\\.)?\\d");
+    rule.format = numberFormat;
+    highlightingRules.append(rule);
+
+    definitionFormat.setForeground(Qt::darkMagenta);
+    definitionFormat.setFontWeight(QFont::Bold);
+    rule.pattern = QRegularExpression(":(start|stop).*(definition|MC transport parameter|run control|scoring options):");
+    rule.format = definitionFormat;
+    highlightingRules.append(rule);
+
+    nameFormat.setForeground(Qt::darkBlue);
+    nameFormat.setFontWeight(QFont::Bold);
+    rule.pattern = QRegularExpression("name.*=.*");
+    rule.format = nameFormat;
+    highlightingRules.append(rule);
+
+    quotationFormat.setForeground(Qt::darkRed);
+    rule.pattern = QRegularExpression("\".*\"");
+    rule.format = quotationFormat;
+    highlightingRules.append(rule);
+
+    squotationFormat.setForeground(Qt::red);
+    rule.pattern = QRegularExpression("\'.*\'");
+    rule.format = squotationFormat;
+    highlightingRules.append(rule);
+
+    // Comment highlighting must come last
+    singleLineCommentFormat.setForeground(Qt::gray);
+    rule.pattern = QRegularExpression("#[^\n]*");
+    rule.format = singleLineCommentFormat;
+    highlightingRules.append(rule);
+
+    // For multi-line comments
+    //multiLineCommentFormat.setForeground(Qt::red);
+
+    //commentStartExpression = QRegularExpression("/\\*");
+    //commentEndExpression = QRegularExpression("\\*/");
+}
+
+void EGS_Highlighter::highlightBlock(const QString &text)
+{
+    foreach (const HighlightingRule &rule, highlightingRules) {
+        QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
+        while (matchIterator.hasNext()) {
+            QRegularExpressionMatch match = matchIterator.next();
+            setFormat(match.capturedStart(), match.capturedLength(), rule.format);
+        }
+    }
+    setCurrentBlockState(0);
+
+    /*
+    //For multi-line comments
+    int startIndex = 0;
+    if (previousBlockState() != 1)
+        startIndex = text.indexOf(commentStartExpression);
+
+    while (startIndex >= 0) {
+        QRegularExpressionMatch match = commentEndExpression.match(text, startIndex);
+        int endIndex = match.capturedStart();
+        int commentLength = 0;
+        if (endIndex == -1) {
+            setCurrentBlockState(1);
+            commentLength = text.length() - startIndex;
+        } else {
+            commentLength = endIndex - startIndex
+                            + match.capturedLength();
+        }
+        setFormat(startIndex, commentLength, multiLineCommentFormat);
+        startIndex = text.indexOf(commentStartExpression, startIndex + commentLength);
+    }*/
+}

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -91,7 +91,8 @@ EGS_Highlighter::EGS_Highlighter(QTextDocument *parent) : QSyntaxHighlighter(par
     //commentEndExpression = QRegularExpression("\\*/");
 }
 
-void EGS_Highlighter::highlightBlock(const QString &text) {
+void EGS_Highlighter::highlightBlock(const QString &text)
+{
     foreach (const HighlightingRule &rule, highlightingRules) {
         QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
         while (matchIterator.hasNext()) {

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -64,7 +64,7 @@ EGS_Highlighter::EGS_Highlighter(QTextDocument *parent) : QSyntaxHighlighter(par
 
     nameFormat.setForeground(Qt::darkBlue);
     nameFormat.setFontWeight(QFont::Bold);
-    rule.pattern = QRegularExpression("name.*=.*");
+    rule.pattern = QRegularExpression("( )*name( )*=.*");
     rule.format = nameFormat;
     highlightingRules.append(rule);
 

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -91,8 +91,7 @@ EGS_Highlighter::EGS_Highlighter(QTextDocument *parent) : QSyntaxHighlighter(par
     //commentEndExpression = QRegularExpression("\\*/");
 }
 
-void EGS_Highlighter::highlightBlock(const QString &text)
-{
+void EGS_Highlighter::highlightBlock(const QString &text) {
     foreach (const HighlightingRule &rule, highlightingRules) {
         QRegularExpressionMatchIterator matchIterator = rule.pattern.globalMatch(text);
         while (matchIterator.hasNext()) {

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -102,8 +102,9 @@ void EGS_Highlighter::highlightBlock(const QString &text) {
 
     //For multi-line comments
     int startIndex = 0;
-    if (previousBlockState() != 1)
+    if (previousBlockState() != 1) {
         startIndex = text.indexOf(commentStartExpression);
+    }
 
     while (startIndex >= 0) {
         QRegularExpressionMatch match = commentEndExpression.match(text, startIndex);
@@ -112,7 +113,8 @@ void EGS_Highlighter::highlightBlock(const QString &text) {
         if (endIndex == -1) {
             setCurrentBlockState(1);
             commentLength = text.length() - startIndex;
-        } else {
+        }
+        else {
             commentLength = endIndex - startIndex
                             + match.capturedLength();
         }

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -80,15 +80,14 @@ EGS_Highlighter::EGS_Highlighter(QTextDocument *parent) : QSyntaxHighlighter(par
 
     // Comment highlighting must come last
     singleLineCommentFormat.setForeground(Qt::gray);
-    rule.pattern = QRegularExpression("#[^\n]*");
+    rule.pattern = QRegularExpression("(#|//|!)[^\n]*");
     rule.format = singleLineCommentFormat;
     highlightingRules.append(rule);
 
     // For multi-line comments
-    //multiLineCommentFormat.setForeground(Qt::red);
-
-    //commentStartExpression = QRegularExpression("/\\*");
-    //commentEndExpression = QRegularExpression("\\*/");
+    multiLineCommentFormat.setForeground(Qt::gray);
+    commentStartExpression = QRegularExpression("/\\*");
+    commentEndExpression = QRegularExpression("\\*/");
 }
 
 void EGS_Highlighter::highlightBlock(const QString &text) {
@@ -101,7 +100,6 @@ void EGS_Highlighter::highlightBlock(const QString &text) {
     }
     setCurrentBlockState(0);
 
-    /*
     //For multi-line comments
     int startIndex = 0;
     if (previousBlockState() != 1)
@@ -120,5 +118,5 @@ void EGS_Highlighter::highlightBlock(const QString &text) {
         }
         setFormat(startIndex, commentLength, multiLineCommentFormat);
         startIndex = text.indexOf(commentStartExpression, startIndex + commentLength);
-    }*/
+    }
 }

--- a/HEN_HOUSE/egs++/view/egs_highlighter.h
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.h
@@ -1,0 +1,77 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ input highlighter
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+#
+#  Author:          Reid Townson, 2019
+#
+#  Contributors:
+#
+###############################################################################
+*/
+
+#ifndef EGS_HIGHLIGHTER_H
+#define EGS_HIGHLIGHTER_H
+
+#include <QSyntaxHighlighter>
+#include <QTextCharFormat>
+#include <QRegularExpression>
+
+class QTextDocument;
+
+class EGS_Highlighter : public QSyntaxHighlighter
+{
+    Q_OBJECT
+public:
+    explicit EGS_Highlighter(QTextDocument *parent = nullptr);
+
+protected:
+    void highlightBlock(const QString &text) override;
+
+private:
+    struct HighlightingRule
+    {
+        QRegularExpression pattern;
+        QTextCharFormat format;
+    };
+    QVector<HighlightingRule> highlightingRules;
+
+    QRegularExpression  commentStartExpression,
+                        commentEndExpression;
+
+    QTextCharFormat keywordFormat,
+                    attributeFormat,
+                    numberFormat,
+                    definitionFormat,
+                    nameFormat,
+                    singleLineCommentFormat,
+                    quotationFormat,
+                    squotationFormat,
+                    functionFormat;
+    //QTextCharFormat multiLineCommentFormat;
+
+signals:
+
+public slots:
+
+};
+
+#endif // EGS_HIGHLIGHTER_H

--- a/HEN_HOUSE/egs++/view/egs_highlighter.h
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.h
@@ -37,7 +37,8 @@
 
 class QTextDocument;
 
-class EGS_Highlighter : public QSyntaxHighlighter {
+class EGS_Highlighter : public QSyntaxHighlighter
+{
     Q_OBJECT
 public:
     explicit EGS_Highlighter(QTextDocument *parent = nullptr);
@@ -46,7 +47,8 @@ protected:
     void highlightBlock(const QString &text) override;
 
 private:
-    struct HighlightingRule {
+    struct HighlightingRule
+    {
         QRegularExpression pattern;
         QTextCharFormat format;
     };

--- a/HEN_HOUSE/egs++/view/egs_highlighter.h
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.h
@@ -37,8 +37,7 @@
 
 class QTextDocument;
 
-class EGS_Highlighter : public QSyntaxHighlighter
-{
+class EGS_Highlighter : public QSyntaxHighlighter {
     Q_OBJECT
 public:
     explicit EGS_Highlighter(QTextDocument *parent = nullptr);
@@ -47,8 +46,7 @@ protected:
     void highlightBlock(const QString &text) override;
 
 private:
-    struct HighlightingRule
-    {
+    struct HighlightingRule {
         QRegularExpression pattern;
         QTextCharFormat format;
     };

--- a/HEN_HOUSE/egs++/view/egs_highlighter.h
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.h
@@ -61,10 +61,10 @@ private:
                     definitionFormat,
                     nameFormat,
                     singleLineCommentFormat,
+                    multiLineCommentFormat,
                     quotationFormat,
                     squotationFormat,
                     functionFormat;
-    //QTextCharFormat multiLineCommentFormat;
 
 signals:
 

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -76,7 +76,7 @@ unix {
             message( "Static build ..." )
             DESTDIR = ../../pieces/linux
             #LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp # Fixes path to library
-            LIBS += -L$$hhouse/egs++/dso/$$my_machine -legspp                             # Relies on LD_LIBRARY_PATH
+            LIBS += -L../dso/$$my_machine -legspp # Relies on LD_LIBRARY_PATH
             UNAME = $$system(getconf LONG_BIT)
             contains( UNAME, 64 ){
                message( "-> 64 bit ($$SNAME)" )

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -37,11 +37,15 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets
 HEADERS	+= egs_visualizer.h image_window.h egs_light.h \
                  clippingplanes.h viewcontrol.h geometryview.ui.h \
                  saveimage.h egs_user_color.h egs_track_view.h \
-                 renderworker.h
+                 renderworker.h \
+    egs_highlighter.h \
+    egs_editor.h
 
 SOURCES	+= main.cpp egs_visualizer.cpp egs_track_view.cpp \
                  saveimage.cpp clippingplanes.cpp viewcontrol.cpp \
-                 renderworker.cpp image_window.cpp
+                 renderworker.cpp image_window.cpp \
+    egs_highlighter.cpp \
+    egs_editor.cpp
 
 FORMS           = saveimage.ui clippingplanes.ui viewcontrol.ui
 
@@ -50,7 +54,7 @@ win32 {
     DEFINES += WIN32
     DEFINES += VDEBUG
     RC_FILE = egs_view.rc
-    LIBS	+= ../dso/$$my_machine/egspp.lib
+    LIBS	+= ../dso/$$my_machine/egspp.lib ../dso/$$my_machine/egs_input_struct.lib
     DESTDIR = ../dso/$$my_machine
     TARGET = egs_view
 }
@@ -58,7 +62,7 @@ win32 {
 unix {
     CONFIG    += qt warn_on release $$my_build
     macx {
-        LIBS  += -L../dso/$$my_machine -legspp
+        LIBS  += -L../dso/$$my_machine -legspp -legs_input_struct
         TARGET = ../../bin/$$my_machine/egs_view
     }
     !macx {
@@ -66,13 +70,13 @@ unix {
        !contains( CONFIG, static ){
          message( "Dynamic build..." )
          TARGET = egs_view
-         LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp
+         LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp -legs_input_struct
         }
         contains( CONFIG, static ){
             message( "Static build ..." )
             DESTDIR = ../../pieces/linux
             #LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp # Fixes path to library
-            LIBS += -L$$hhouse/egs++/dso/$$my_machine -legspp                                 # Relies on LD_LIBRARY_PATH
+            LIBS += -L$$hhouse/egs++/dso/$$my_machine -legspp -legs_input_struct                                # Relies on LD_LIBRARY_PATH
             UNAME = $$system(getconf LONG_BIT)
             contains( UNAME, 64 ){
                message( "-> 64 bit ($$SNAME)" )

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -92,7 +92,7 @@ unix {
 }
 
 # Debug options
-DEFINES += VIEW_DEBUG EDITOR_DEBUG
+#DEFINES += VIEW_DEBUG EDITOR_DEBUG
 #QMAKE_CXXFLAGS+="-fsanitize=address -fno-omit-frame-pointer"
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -92,7 +92,7 @@ unix {
 }
 
 # Debug options
-#DEFINES += VIEW_DEBUG
+#DEFINES += VIEW_DEBUG EDITOR_DEBUG
 #QMAKE_CXXFLAGS+="-fsanitize=address -fno-omit-frame-pointer"
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -92,7 +92,7 @@ unix {
 }
 
 # Debug options
-#DEFINES += VIEW_DEBUG EDITOR_DEBUG
+DEFINES += VIEW_DEBUG EDITOR_DEBUG
 #QMAKE_CXXFLAGS+="-fsanitize=address -fno-omit-frame-pointer"
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -54,7 +54,7 @@ win32 {
     DEFINES += WIN32
     DEFINES += VDEBUG
     RC_FILE = egs_view.rc
-    LIBS	+= ../dso/$$my_machine/egspp.lib ../dso/$$my_machine/egs_input_struct.lib
+    LIBS	+= ../dso/$$my_machine/egspp.lib
     DESTDIR = ../dso/$$my_machine
     TARGET = egs_view
 }
@@ -62,7 +62,7 @@ win32 {
 unix {
     CONFIG    += qt warn_on release $$my_build
     macx {
-        LIBS  += -L../dso/$$my_machine -legspp -legs_input_struct
+        LIBS  += -L../dso/$$my_machine -legspp
         TARGET = ../../bin/$$my_machine/egs_view
     }
     !macx {
@@ -70,13 +70,13 @@ unix {
        !contains( CONFIG, static ){
          message( "Dynamic build..." )
          TARGET = egs_view
-         LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp -legs_input_struct
+         LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp
         }
         contains( CONFIG, static ){
             message( "Static build ..." )
             DESTDIR = ../../pieces/linux
             #LIBS += -L../dso/$$my_machine -Wl,-rpath,$$hhouse/egs++/dso/$$my_machine -legspp # Fixes path to library
-            LIBS += -L$$hhouse/egs++/dso/$$my_machine -legspp -legs_input_struct                                # Relies on LD_LIBRARY_PATH
+            LIBS += -L$$hhouse/egs++/dso/$$my_machine -legspp                             # Relies on LD_LIBRARY_PATH
             UNAME = $$system(getconf LONG_BIT)
             contains( UNAME, 64 ){
                message( "-> 64 bit ($$SNAME)" )

--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -97,7 +97,6 @@ unix {
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"
 
-QMAKE_CXXFLAGS+=-std=c++14
 UI_DIR = .ui/$$my_machine
 MOC_DIR = .moc/$$my_machine
 OBJECTS_DIR = .obj/$$my_machine

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -211,45 +211,46 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     editorLayout->addWidget(egsinpEdit);
     highlighter = new EGS_Highlighter(egsinpEdit->document());
 
-    // Load an egs++ application to parse the input file
-    string app_name;
+// TODO: This is an example of how to load an application for egs_editor inputs
+//     // Load an egs++ application to parse the input file
+//     string app_name;
     int appc = 5;
     char *appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
-
-    // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
-    if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
-        egsFatal("test fail\n\n");
-    }
-
-    string lib_dir;
-    EGS_Application::checkEnvironmentVar(appc,appv,"-e","--egs-home","EGS_HOME",lib_dir);
-    lib_dir += "bin";
-    lib_dir += fs;
-    lib_dir += CONFIG_NAME;
-    lib_dir += fs;
-
-    // Load the application library
-    // We don't require the application to be compiled, just give a warning if it isn't.
-    EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
-    bool app_loaded = true;
-    if (!app_lib.load()) {
-        egsWarning("\n%s: Failed to load the %s application library from %s\n\n", appv[0],app_name.c_str(),lib_dir.c_str());
-        app_loaded = false;
-    } else {
-        createAppFunction createApp = (createAppFunction) app_lib.resolve("createApplication");
-        if (!createApp) {
-            egsWarning("\n%s: Failed to resolve the address of the 'createApplication' function in the application library %s\n\n",appv[0],app_lib.libraryFile());
-            app_loaded = false;
-        } else {
-            EGS_Application *app = createApp(appc,appv);
-            if (!app) {
-                egsWarning("\n%s: Failed to construct the application %s\n\n",appv[0],app_name.c_str());
-                app_loaded = false;
-            }
-            egsInformation("Testapp %f\n",app->getRM());
-            delete app;
-        }
-    }
+//
+//     // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
+//     if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
+//         egsFatal("test fail\n\n");
+//     }
+//
+//     string lib_dir;
+//     EGS_Application::checkEnvironmentVar(appc,appv,"-e","--egs-home","EGS_HOME",lib_dir);
+//     lib_dir += "bin";
+//     lib_dir += fs;
+//     lib_dir += CONFIG_NAME;
+//     lib_dir += fs;
+//
+//     // Load the application library
+//     // We don't require the application to be compiled, just give a warning if it isn't.
+//     EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
+//     bool app_loaded = true;
+//     if (!app_lib.load()) {
+//         egsWarning("\n%s: Failed to load the %s application library from %s\n\n", appv[0],app_name.c_str(),lib_dir.c_str());
+//         app_loaded = false;
+//     } else {
+//         createAppFunction createApp = (createAppFunction) app_lib.resolve("createApplication");
+//         if (!createApp) {
+//             egsWarning("\n%s: Failed to resolve the address of the 'createApplication' function in the application library %s\n\n",appv[0],app_lib.libraryFile());
+//             app_loaded = false;
+//         } else {
+//             EGS_Application *app = createApp(appc,appv);
+//             if (!app) {
+//                 egsWarning("\n%s: Failed to construct the application %s\n\n",appv[0],app_name.c_str());
+//                 app_loaded = false;
+//             }
+//             egsInformation("Testapp %f\n",app->getRM());
+//             delete app;
+//         }
+//     }
 
 
 
@@ -283,27 +284,27 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // The input template structure
     inputStruct = make_shared<EGS_InputStruct>();
 
-    // Get the application level input blocks
-    if(app_loaded) {
-        getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
-        if(getAppInputs) {
-            getAppInputs(inputStruct);
-            if(inputStruct) {
-                vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputStruct->getBlockInputs();
-                for (auto &block : inputBlocks) {
-                    egsInformation("  block %s\n", block->getTitle().c_str());
-                    vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-                    for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp->getValues();
-                        egsInformation("   single %s\n", inp->getTag().c_str());
-                        for (auto&& val : vals) {
-                            egsInformation("      %s\n", val.c_str());
-                        }
-                    }
-                }
-            }
-        }
-    }
+//     // Get the application level input blocks
+//     if(app_loaded) {
+//         getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
+//         if(getAppInputs) {
+//             getAppInputs(inputStruct);
+//             if(inputStruct) {
+//                 vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputStruct->getBlockInputs();
+//                 for (auto &block : inputBlocks) {
+//                     egsInformation("  block %s\n", block->getTitle().c_str());
+//                     vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+//                     for (auto &inp : singleInputs) {
+//                         const vector<string> vals = inp->getValues();
+//                         egsInformation("   single %s\n", inp->getTag().c_str());
+//                         for (auto&& val : vals) {
+//                             egsInformation("      %s\n", val.c_str());
+//                         }
+//                     }
+//                 }
+//             }
+//         }
+//     }
 
     // Geometry definition block
     auto geomDefPtr = inputStruct->addBlockInput("geometry definition");
@@ -317,6 +318,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     auto ausDefPtr = inputStruct->addBlockInput("ausgab object definition");
     ausDefPtr->addSingleInput("simulation ausgab object", true, "The name of the ausgab object that will be used in the simulation.");
 
+#ifdef VIEW_DEBUG
+    egsInformation("Loading libraries for egs_editor...\n");
+#endif
+
     // For each library, try to load it and determine if it is geometry or source
     for (const auto &lib : libraries) {
         // Remove the extension
@@ -324,7 +329,9 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Remove the prefix (EGS_Library adds it automatically)
         libName = libName.right(libName.length() - lib_prefix.length());
 
-        egsInformation("testlib trying %s\n", libName.toLatin1().data());
+#ifdef VIEW_DEBUG
+        egsInformation("Trying %s\n", libName.toLatin1().data());
+#endif
         // Skip any library files that start with Qt
         // For dynamic builds, there may be QtCore, QtWidgets, etc. files in the dso directory
         if (lib.startsWith("Qt")) {
@@ -339,7 +346,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
         if (isGeom) {
-            egsInformation(" testgeom %s\n",libName.toLatin1().data());
+            //egsInformation(" Geometry %s\n",libName.toLatin1().data());
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -351,22 +358,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = geom->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-                        egsInformation("  single %s\n", inp->getTag().c_str());
-                        for (auto&& val : vals) {
-                            egsInformation("      %s\n", val.c_str());
-                        }
+//                         egsInformation("  single %s\n", inp->getTag().c_str());
+//                         for (auto&& val : vals) {
+//                             egsInformation("      %s\n", val.c_str());
+//                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
                     for (auto &block : inputBlocks) {
-                        egsInformation("  block %s\n", block->getTitle().c_str());
+                        //egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-                            egsInformation("   single %s\n", inp->getTag().c_str());
-                            for (auto&& val : vals) {
-                                egsInformation("      %s\n", val.c_str());
-                            }
+//                             egsInformation("   single %s\n", inp->getTag().c_str());
+//                             for (auto&& val : vals) {
+//                                 egsInformation("      %s\n", val.c_str());
+//                             }
                         }
                     }
                 }
@@ -382,7 +389,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Sources
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
         if (isSource) {
-            egsInformation(" testsrc %s\n",libName.toLatin1().data());
+            //egsInformation(" Source %s\n",libName.toLatin1().data());
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -394,22 +401,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = src->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-                        egsInformation("  single %s\n", inp->getTag().c_str());
-                        for (auto&& val : vals) {
-                            egsInformation("      %s\n", val.c_str());
-                        }
+//                         egsInformation("  single %s\n", inp->getTag().c_str());
+//                         for (auto&& val : vals) {
+//                             egsInformation("      %s\n", val.c_str());
+//                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = src->getBlockInputs();
                     for (auto &block : inputBlocks) {
-                        egsInformation("  block %s\n", block->getTitle().c_str());
+                        //egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-                            egsInformation("   single %s\n", inp->getTag().c_str());
-                            for (auto&& val : vals) {
-                                egsInformation("      %s\n", val.c_str());
-                            }
+//                             egsInformation("   single %s\n", inp->getTag().c_str());
+//                             for (auto&& val : vals) {
+//                                 egsInformation("      %s\n", val.c_str());
+//                             }
                         }
                     }
                 }
@@ -426,7 +433,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Shapes
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
         if (isShape) {
-            egsInformation(" testshape %s\n",libName.toLatin1().data());
+            //egsInformation(" Shape %s\n",libName.toLatin1().data());
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -438,22 +445,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = shape->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-                        egsInformation("  single %s\n", inp->getTag().c_str());
-                        for (auto&& val : vals) {
-                            egsInformation("      %s\n", val.c_str());
-                        }
+//                         egsInformation("  single %s\n", inp->getTag().c_str());
+//                         for (auto&& val : vals) {
+//                             egsInformation("      %s\n", val.c_str());
+//                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = shape->getBlockInputs();
                     for (auto &block : inputBlocks) {
-                        egsInformation("  block %s\n", block->getTitle().c_str());
+                        //egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-                            egsInformation("   single %s\n", inp->getTag().c_str());
-                            for (auto&& val : vals) {
-                                egsInformation("      %s\n", val.c_str());
-                            }
+//                             egsInformation("   single %s\n", inp->getTag().c_str());
+//                             for (auto&& val : vals) {
+//                                 egsInformation("      %s\n", val.c_str());
+//                             }
                         }
                     }
                 }
@@ -470,6 +477,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Ausgab Objects
         createAusgabObjectFunction isAusgabObject = (createAusgabObjectFunction) egs_lib.resolve("createAusgabObject");
         if (isAusgabObject) {
+            //egsInformation(" Ausgab %s\n",libName.toLatin1().data());
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -481,26 +489,29 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = aus->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-                        for (auto&& val : vals) {
-                            egsInformation("      %s\n", val.c_str());
-                        }
+//                         egsInformation("   single %s\n", inp->getTag().c_str());
+//                         for (auto&& val : vals) {
+//                             egsInformation("      %s\n", val.c_str());
+//                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = aus->getBlockInputs();
                     for (auto &block : inputBlocks) {
+                        //egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-                            for (auto&& val : vals) {
-                                egsInformation("      %s\n", val.c_str());
-                            }
+//                             egsInformation("   single %s\n", inp->getTag().c_str());
+//                             for (auto&& val : vals) {
+//                                 egsInformation("      %s\n", val.c_str());
+//                             }
                         }
                     }
                 }
             }
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
-                QAction *action = sourceMenu->addAction(libName);
+                QAction *action = ausgabMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
                 connect(action, &QAction::triggered, this, [this]{ insertInputExample(); });
             }

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -204,7 +204,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // Load an egs++ application to parse the input file
     string app_name;
     int appc = 5;
-    char *appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
+    char* appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
 
     // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
     if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
@@ -246,10 +246,8 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
     QStringList geomLibs, sourceLibs;
 
-    inputStruct = make_shared<EGS_InputStruct>();
-
     // For each library, try to load it and determine if it is geometry or source
-    for (const auto &lib : libraries) {
+    for(const auto& lib : libraries) {
         // Remove the extension
         QString libName = lib.left(lib.lastIndexOf("."));
         // Remove the prefix (EGS_Library adds it automatically)
@@ -284,10 +282,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
-            if (getInputs) {
+            if(getInputs) {
 
                 shared_ptr<EGS_BlockInput> geom = getInputs();
-                if (geom) {
+                if(geom) {
                     // Only add geometries to the list that have a function
                     // to get the input template
                     geomLibs.append(libName);
@@ -295,22 +293,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     geomTemplates.push_back(geom);
 
                     vector<EGS_SingleInput> singleInputs = geom->getSingleInputs();
-                    for (auto &inp : singleInputs) {
+                    for(auto& inp : singleInputs) {
                         const vector<string> vals = inp.getValues();
                         egsInformation("  single %s\n", inp.getAttribute().c_str());
-                        for (auto&& val : vals) {
+                        for(auto&& val : vals) {
                             egsInformation("      %s\n", val.c_str());
                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
-                    for (auto &block : inputBlocks) {
+                    for(auto& block : inputBlocks) {
                         egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<EGS_SingleInput> singleInputs = block->getSingleInputs();
-                        for (auto &inp : singleInputs) {
+                        for(auto& inp : singleInputs) {
                             const vector<string> vals = inp.getValues();
                             egsInformation("   single %s\n", inp.getAttribute().c_str());
-                            for (auto&& val : vals) {
+                            for(auto&& val : vals) {
                                 egsInformation("      %s\n", val.c_str());
                             }
                         }
@@ -325,12 +323,12 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
     }
 
-    inputStruct->addBlockInputs(geomTemplates);
-    egsinpEdit->setInputStruct(inputStruct);
-
     // Populate the geometry and simulation template lists
     comboBox_geomTemplate->addItems(geomLibs);
     comboBox_simTemplate->addItems(sourceLibs);
+
+    // set the widget to show near the left-upper corner of the screen
+    move(QPoint(25,25));
 }
 
 GeometryViewControl::~GeometryViewControl() {

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -247,6 +247,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                 app_loaded = false;
             }
             egsInformation("Testapp %f\n",app->getRM());
+            delete app;
         }
     }
 
@@ -413,6 +414,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
+
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = sourceMenu->addAction(libName);
@@ -522,6 +524,9 @@ GeometryViewControl::~GeometryViewControl() {
         for (int i=0; i<nobj; ++i) {
             delete EGS_AusgabObject::getObject(i);
         }
+    }
+    if(egsinpEdit) {
+        delete egsinpEdit;
     }
     if(highlighter) {
         delete highlighter;

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -278,7 +278,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = geom->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-                        egsInformation("  single %s\n", inp->getAttribute().c_str());
+                        egsInformation("  single %s\n", inp->getTag().c_str());
                         for (auto&& val : vals) {
                             egsInformation("      %s\n", val.c_str());
                         }
@@ -290,7 +290,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-                            egsInformation("   single %s\n", inp->getAttribute().c_str());
+                            egsInformation("   single %s\n", inp->getTag().c_str());
                             for (auto&& val : vals) {
                                 egsInformation("      %s\n", val.c_str());
                             }

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -204,7 +204,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // Load an egs++ application to parse the input file
     string app_name;
     int appc = 5;
-    char* appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
+    char *appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
 
     // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
     if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
@@ -246,8 +246,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
     QStringList geomLibs, sourceLibs;
 
+    inputStruct = make_shared<EGS_InputStruct>();
+
     // For each library, try to load it and determine if it is geometry or source
-    for(const auto& lib : libraries) {
+    for (const auto &lib : libraries) {
         // Remove the extension
         QString libName = lib.left(lib.lastIndexOf("."));
         // Remove the prefix (EGS_Library adds it automatically)
@@ -282,10 +284,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
-            if(getInputs) {
+            if (getInputs) {
 
                 shared_ptr<EGS_BlockInput> geom = getInputs();
-                if(geom) {
+                if (geom) {
                     // Only add geometries to the list that have a function
                     // to get the input template
                     geomLibs.append(libName);
@@ -293,22 +295,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     geomTemplates.push_back(geom);
 
                     vector<EGS_SingleInput> singleInputs = geom->getSingleInputs();
-                    for(auto& inp : singleInputs) {
+                    for (auto &inp : singleInputs) {
                         const vector<string> vals = inp.getValues();
                         egsInformation("  single %s\n", inp.getAttribute().c_str());
-                        for(auto&& val : vals) {
+                        for (auto&& val : vals) {
                             egsInformation("      %s\n", val.c_str());
                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
-                    for(auto& block : inputBlocks) {
+                    for (auto &block : inputBlocks) {
                         egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<EGS_SingleInput> singleInputs = block->getSingleInputs();
-                        for(auto& inp : singleInputs) {
+                        for (auto &inp : singleInputs) {
                             const vector<string> vals = inp.getValues();
                             egsInformation("   single %s\n", inp.getAttribute().c_str());
-                            for(auto&& val : vals) {
+                            for (auto&& val : vals) {
                                 egsInformation("      %s\n", val.c_str());
                             }
                         }
@@ -323,12 +325,12 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
     }
 
+    inputStruct->addBlockInputs(geomTemplates);
+    egsinpEdit->setInputStruct(inputStruct);
+
     // Populate the geometry and simulation template lists
     comboBox_geomTemplate->addItems(geomLibs);
     comboBox_simTemplate->addItems(sourceLibs);
-
-    // set the widget to show near the left-upper corner of the screen
-    move(QPoint(25,25));
 }
 
 GeometryViewControl::~GeometryViewControl() {
@@ -346,6 +348,9 @@ GeometryViewControl::~GeometryViewControl() {
         for (int i=0; i<nobj; ++i) {
             delete EGS_AusgabObject::getObject(i);
         }
+    }
+    if(highlighter) {
+        delete highlighter;
     }
 }
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -204,7 +204,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // Load an egs++ application to parse the input file
     string app_name;
     int appc = 5;
-    char* appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
+    char *appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
 
     // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
     if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
@@ -246,8 +246,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
     QStringList geomLibs, sourceLibs;
 
+    shared_ptr<EGS_InputStruct> inputStruct(new EGS_InputStruct);
+
     // For each library, try to load it and determine if it is geometry or source
-    for(const auto& lib : libraries) {
+    for (const auto &lib : libraries) {
         // Remove the extension
         QString libName = lib.left(lib.lastIndexOf("."));
         // Remove the prefix (EGS_Library adds it automatically)
@@ -282,10 +284,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
-            if(getInputs) {
+            if (getInputs) {
 
                 shared_ptr<EGS_BlockInput> geom = getInputs();
-                if(geom) {
+                if (geom) {
                     // Only add geometries to the list that have a function
                     // to get the input template
                     geomLibs.append(libName);
@@ -293,22 +295,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     geomTemplates.push_back(geom);
 
                     vector<EGS_SingleInput> singleInputs = geom->getSingleInputs();
-                    for(auto& inp : singleInputs) {
+                    for (auto &inp : singleInputs) {
                         const vector<string> vals = inp.getValues();
                         egsInformation("  single %s\n", inp.getAttribute().c_str());
-                        for(auto&& val : vals) {
+                        for (auto&& val : vals) {
                             egsInformation("      %s\n", val.c_str());
                         }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
-                    for(auto& block : inputBlocks) {
+                    for (auto &block : inputBlocks) {
                         egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<EGS_SingleInput> singleInputs = block->getSingleInputs();
-                        for(auto& inp : singleInputs) {
+                        for (auto &inp : singleInputs) {
                             const vector<string> vals = inp.getValues();
                             egsInformation("   single %s\n", inp.getAttribute().c_str());
-                            for(auto&& val : vals) {
+                            for (auto&& val : vals) {
                                 egsInformation("      %s\n", val.c_str());
                             }
                         }
@@ -323,12 +325,12 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
     }
 
+    inputStruct->addBlockInputs(geomTemplates);
+    egsinpEdit->setInputStruct(inputStruct);
+
     // Populate the geometry and simulation template lists
     comboBox_geomTemplate->addItems(geomLibs);
     comboBox_simTemplate->addItems(sourceLibs);
-
-    // set the widget to show near the left-upper corner of the screen
-    move(QPoint(25,25));
 }
 
 GeometryViewControl::~GeometryViewControl() {

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -80,7 +80,7 @@ typedef EGS_BaseShape *(*createShapeFunction)();
 typedef EGS_AusgabObject *(*createAusgabObjectFunction)();
 typedef void (*getAppInputsFunction)(shared_ptr<EGS_InputStruct> inpPtr);
 typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
-typedef string (*getExampleFunction)();
+typedef string(*getExampleFunction)();
 
 #ifdef WIN32
     #ifdef CYGWIN
@@ -269,7 +269,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
 
     // Create an examples drop down menu on the editor tab
-    QMenuBar* menuBar = new QMenuBar();
+    QMenuBar *menuBar = new QMenuBar();
     QMenu *exampleMenu = new QMenu("Insert example...");
     menuBar->addMenu(exampleMenu);
     QMenu *geomMenu = exampleMenu->addMenu("Geometries");
@@ -316,9 +316,8 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
     // Ausgab Object definition block
     auto ausDefPtr = inputStruct->addBlockInput("ausgab object definition");
-    ausDefPtr->addSingleInput("simulation ausgab object", true, "The name of the ausgab object that will be used in the simulation.");
 
-#ifdef VIEW_DEBUG
+#ifdef EDITOR_DEBUG
     egsInformation("Loading libraries for egs_editor...\n");
 #endif
 
@@ -329,7 +328,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Remove the prefix (EGS_Library adds it automatically)
         libName = libName.right(libName.length() - lib_prefix.length());
 
-#ifdef VIEW_DEBUG
+#ifdef EDITOR_DEBUG
         egsInformation("Trying %s\n", libName.toLatin1().data());
 #endif
         // Skip any library files that start with Qt
@@ -346,7 +345,9 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
         if (isGeom) {
-            //egsInformation(" Geometry %s\n",libName.toLatin1().data());
+#ifdef EDITOR_DEBUG
+            egsInformation(" Geometry %s\n",libName.toLatin1().data());
+#endif
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -382,14 +383,16 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             if (getExample) {
                 QAction *action = geomMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
-                connect(action,  &QAction::triggered, this, [this]{ insertInputExample(); });
+                connect(action,  &QAction::triggered, this, [this] { insertInputExample(); });
             }
         }
 
         // Sources
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
         if (isSource) {
-            //egsInformation(" Source %s\n",libName.toLatin1().data());
+#ifdef EDITOR_DEBUG
+            egsInformation(" Source %s\n",libName.toLatin1().data());
+#endif
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -426,14 +429,16 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             if (getExample) {
                 QAction *action = sourceMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
-                connect(action,  &QAction::triggered, this, [this]{ insertInputExample(); });
+                connect(action,  &QAction::triggered, this, [this] { insertInputExample(); });
             }
         }
 
         // Shapes
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
         if (isShape) {
-            //egsInformation(" Shape %s\n",libName.toLatin1().data());
+#ifdef EDITOR_DEBUG
+            egsInformation(" Shape %s\n",libName.toLatin1().data());
+#endif
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
@@ -445,22 +450,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = shape->getSingleInputs();
                     for (auto &inp : singleInputs) {
                         const vector<string> vals = inp->getValues();
-//                         egsInformation("  single %s\n", inp->getTag().c_str());
-//                         for (auto&& val : vals) {
-//                             egsInformation("      %s\n", val.c_str());
-//                         }
+                        egsInformation("  single %s\n", inp->getTag().c_str());
+                        for (auto&& val : vals) {
+                            egsInformation("      %s\n", val.c_str());
+                        }
                     }
 
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = shape->getBlockInputs();
                     for (auto &block : inputBlocks) {
-                        //egsInformation("  block %s\n", block->getTitle().c_str());
+                        egsInformation("  block %s\n", block->getTitle().c_str());
                         vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
                             const vector<string> vals = inp->getValues();
-//                             egsInformation("   single %s\n", inp->getTag().c_str());
-//                             for (auto&& val : vals) {
-//                                 egsInformation("      %s\n", val.c_str());
-//                             }
+                            egsInformation("   single %s\n", inp->getTag().c_str());
+                            for (auto&& val : vals) {
+                                egsInformation("      %s\n", val.c_str());
+                            }
                         }
                     }
                 }
@@ -470,20 +475,22 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             if (getExample) {
                 QAction *action = shapeMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
-                connect(action,  &QAction::triggered, this, [this]{ insertInputExample(); });
+                connect(action,  &QAction::triggered, this, [this] { insertInputExample(); });
             }
         }
 
         // Ausgab Objects
         createAusgabObjectFunction isAusgabObject = (createAusgabObjectFunction) egs_lib.resolve("createAusgabObject");
         if (isAusgabObject) {
-            //egsInformation(" Ausgab %s\n",libName.toLatin1().data());
+#ifdef EDITOR_DEBUG
+            egsInformation(" Ausgab %s\n",libName.toLatin1().data());
+#endif
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
             if (getInputs) {
 
                 shared_ptr<EGS_BlockInput> aus = getInputs();
-                if(aus){
+                if (aus) {
                     ausDefPtr->addBlockInput(aus);
 
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = aus->getSingleInputs();
@@ -513,7 +520,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             if (getExample) {
                 QAction *action = ausgabMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
-                connect(action, &QAction::triggered, this, [this]{ insertInputExample(); });
+                connect(action, &QAction::triggered, this, [this] { insertInputExample(); });
             }
         }
     }
@@ -536,10 +543,10 @@ GeometryViewControl::~GeometryViewControl() {
             delete EGS_AusgabObject::getObject(i);
         }
     }
-    if(egsinpEdit) {
+    if (egsinpEdit) {
         delete egsinpEdit;
     }
-    if(highlighter) {
+    if (highlighter) {
         delete highlighter;
     }
 }
@@ -2129,7 +2136,7 @@ void GeometryViewControl::changeTransparency(int t) {
 
 void GeometryViewControl::changeGlobalTransparency(int t) {
     int test = materialCB->count();
-    for (int i = 0; i <= test; i++ ) {
+    for (int i = 0; i <= test; i++) {
         int med = materialCB->count() - i;
         QRgb c = m_colors[med];
         m_colors[med] = qRgba(qRed(c), qGreen(c), qBlue(c), t);
@@ -3403,7 +3410,7 @@ void GeometryViewControl::setFontSize(int size) {
 }
 
 void GeometryViewControl::insertInputExample() {
-    QAction *pAction = qobject_cast<QAction*>(sender());
+    QAction *pAction = qobject_cast<QAction *>(sender());
 
     QTextCursor cursor(egsinpEdit->textCursor());
     egsinpEdit->insertPlainText(pAction->data().toString());

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -248,7 +248,16 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
     QStringList geomLibs, sourceLibs;
 
-    shared_ptr<EGS_InputStruct> inputStruct(new EGS_InputStruct);
+    // The input template structure
+    inputStruct = make_shared<EGS_InputStruct>();
+
+    // Geometry definition block
+    auto geomDefPtr = inputStruct->addBlockInput("geometry definition");
+    geomDefPtr->addSingleInput("simulation geometry", true, "The name of the geometry that will be used in the simulation, or to be viewed in egs_view. If you have created a composite geometry using many other geometries, name the final composite geometry here. Note that in some applications, the calculation geometry input block overrides this input, but it is still required.");
+
+    // Source definition block
+    auto srcDefPtr = inputStruct->addBlockInput("source definition");
+    srcDefPtr->addSingleInput("simulation source", true, "The name of the source that will be used in the simulation. If you have created a composite source using many other sources, name the final composite source here.");
 
     // For each library, try to load it and determine if it is geometry or source
     for (const auto &lib : libraries) {
@@ -273,7 +282,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
                 shared_ptr<EGS_BlockInput> geom = getInputs();
                 if (geom) {
-                    geomTemplates.push_back(geom);
+                    geomDefPtr->addBlockInput(geom);
 
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = geom->getSingleInputs();
                     for (auto &inp : singleInputs) {
@@ -315,7 +324,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
     }
 
-    inputStruct->addBlockInputs(geomTemplates);
     egsinpEdit->setInputStruct(inputStruct);
 
     // Populate the geometry and simulation template lists

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -74,6 +74,7 @@ typedef EGS_Application *(*createAppFunction)(int argc, char **argv);
 typedef EGS_BaseGeometry *(*createGeomFunction)();
 typedef EGS_BaseSource *(*isSourceFunction)();
 typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
+typedef string (*getExampleFunction)();
 
 #ifdef WIN32
     #ifdef CYGWIN
@@ -225,12 +226,13 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     createAppFunction createApp = (createAppFunction) egs_lib.resolve("createApplication");
     if (!createApp) egsFatal("\n%s: Failed to resolve the address of the 'createApplication' function"
                                  " in the application library %s\n\n",appv[0],egs_lib.libraryFile());
-
+/*TODO left here crash 'cause tutor7pp isn't compiled <=======================
     EGS_Application *app = createApp(appc,appv);
     if (!app) {
         egsFatal("\n%s: Failed to construct the application %s\n\n",appv[0],app_name.c_str());
     }
     egsInformation("Testapp %f\n",app->getRM());
+    */
 
     // Get a list of all the libraries in the dso directory
     string dso_dir;
@@ -264,40 +266,19 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
         createGeomFunction createGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
         if (createGeom) {
-            /*EGS_BaseGeometry *geom = createGeom();
-            EGS_BlockInput *inputBlock = geom->getInputBlock();
-
-            geomLibs.append(libName);
-
-            egsInformation("test1a\n");
-            vector<EGS_SingleInput> singleInputs = inputBlock->getSingleInputs();
-            egsInformation("test1\n");
-            for(auto& inp : singleInputs) {
-                const vector<string> vals = inp.getValues();
-                egsInformation("test %s\n", inp.getAttribute().c_str());
-                for(auto&& val : vals) {
-                    egsInformation("      %s\n", val.c_str());
-                }
-            }
-            delete inputBlock;
-            delete geom;*/
+            egsInformation(" testgeom %s\n",libName.toLatin1().data());
 
             getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
-            egsInformation(" testgeom %s\n",libName.toLatin1().data());
             if (getInputs) {
 
                 shared_ptr<EGS_BlockInput> geom = getInputs();
                 if (geom) {
-                    // Only add geometries to the list that have a function
-                    // to get the input template
-                    geomLibs.append(libName);
-
                     geomTemplates.push_back(geom);
 
-                    vector<EGS_SingleInput> singleInputs = geom->getSingleInputs();
+                    vector<shared_ptr<EGS_SingleInput>> singleInputs = geom->getSingleInputs();
                     for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp.getValues();
-                        egsInformation("  single %s\n", inp.getAttribute().c_str());
+                        const vector<string> vals = inp->getValues();
+                        egsInformation("  single %s\n", inp->getAttribute().c_str());
                         for (auto&& val : vals) {
                             egsInformation("      %s\n", val.c_str());
                         }
@@ -306,16 +287,25 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
                     for (auto &block : inputBlocks) {
                         egsInformation("  block %s\n", block->getTitle().c_str());
-                        vector<EGS_SingleInput> singleInputs = block->getSingleInputs();
+                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
                         for (auto &inp : singleInputs) {
-                            const vector<string> vals = inp.getValues();
-                            egsInformation("   single %s\n", inp.getAttribute().c_str());
+                            const vector<string> vals = inp->getValues();
+                            egsInformation("   single %s\n", inp->getAttribute().c_str());
                             for (auto&& val : vals) {
                                 egsInformation("      %s\n", val.c_str());
                             }
                         }
                     }
                 }
+            }
+
+            getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
+            if (getExample) {
+                // Only add geometries to the list that have a function
+                // to get the input example
+                geomLibs.append(libName);
+
+                geomExamples.push_back(getExample());
             }
         }
 
@@ -3149,10 +3139,12 @@ void GeometryViewControl::setFontSize(int size) {
 }
 
 void GeometryViewControl::insertGeomTemplate(int ind) {
-    QString selection = comboBox_geomTemplate->itemText(ind);
+    //QString selection = comboBox_geomTemplate->itemText(ind);
 
-    QTextCursor cursor(egsinpEdit->textCursor());
-    egsinpEdit->insertPlainText(selection);
+    if(ind > 0) {
+        QTextCursor cursor(egsinpEdit->textCursor());
+        egsinpEdit->insertPlainText(QString::fromStdString(geomExamples[ind-1]));
+    }
 }
 
 void GeometryViewControl::insertSimTemplate(int ind) {

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -223,13 +223,13 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     lib_dir += CONFIG_NAME;
     lib_dir += fs;
 
-    EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
+    /*EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
     if (!app_lib.load()) egsFatal("\n%s: Failed to load the %s application library from %s\n\n",
                                       appv[0],app_name.c_str(),lib_dir.c_str());
 
     createAppFunction createApp = (createAppFunction) app_lib.resolve("createApplication");
     if (!createApp) egsFatal("\n%s: Failed to resolve the address of the 'createApplication' function"
-                                 " in the application library %s\n\n",appv[0],app_lib.libraryFile());
+                                 " in the application library %s\n\n",appv[0],app_lib.libraryFile()); */
 /*TODO left here crash 'cause tutor7pp isn't compiled <=======================
     EGS_Application *app = createApp(appc,appv);
     if (!app) {
@@ -267,7 +267,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     inputStruct = make_shared<EGS_InputStruct>();
 
     // Get the application level input blocks
-    getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
+    /*getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
     if(getAppInputs) {
         getAppInputs(inputStruct);
         if(inputStruct) {
@@ -284,7 +284,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                 }
             }
         }
-    }
+    } */
 
     // Geometry definition block
     auto geomDefPtr = inputStruct->addBlockInput("geometry definition");
@@ -302,14 +302,19 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         libName = libName.right(libName.length() - lib_prefix.length());
 
         egsInformation("testlib trying %s\n", libName.toLatin1().data());
+        if (lib.startsWith("Qt5")) {
+            continue;
+        }
 
         EGS_Library egs_lib(libName.toLatin1().data(),dso_dir.c_str());
         if (!egs_lib.load()) {
             continue;
         }
+        egsInformation("testlib2 trying %s\n", libName.toLatin1().data());
 
         // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
+        egsInformation("testlib4 trying \n");
         if (isGeom) {
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
 
@@ -343,7 +348,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
-
+            egsInformation("testlib5 trying \n");
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = geomMenu->addAction(libName);
@@ -353,6 +358,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
 
         // Sources
+        egsInformation("testlib6 trying \n");
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
         if (isSource) {
             egsInformation(" testsrc %s\n",libName.toLatin1().data());
@@ -387,7 +393,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
-
+            //egsInformation("testlib7 trying \n");
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = sourceMenu->addAction(libName);
@@ -397,6 +403,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
 
         // Shapes
+        egsInformation("testlib8 trying \n");
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
         if (isShape) {
             egsInformation(" testshape %s\n",libName.toLatin1().data());
@@ -431,6 +438,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
+            //egsInformation("testlib9 trying \n");
 
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
@@ -440,7 +448,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             }
         }
     }
-
+    egsInformation("testlib3 trying \n");
     egsinpEdit->setInputStruct(inputStruct);
 }
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -44,6 +44,8 @@
 #include "egs_input.h"
 #include "egs_ausgab_object.h"
 #include "ausgab_objects/egs_dose_scoring/egs_dose_scoring.h"
+#include "egs_library.h"
+#include "egs_input_struct.h"
 
 #include <qmessagebox.h>
 #include <qapplication.h>
@@ -66,6 +68,25 @@ using namespace std;
 
 #ifndef M_PI
     #define M_PI 3.14159265358979323846
+#endif
+
+typedef EGS_Application *(*createAppFunction)(int argc, char **argv);
+typedef EGS_BaseGeometry *(*createGeomFunction)();
+typedef EGS_BaseSource *(*isSourceFunction)();
+typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
+
+#ifdef WIN32
+    #ifdef CYGWIN
+        const char fs = '/';
+    #else
+        const char fs = '\\';
+    #endif
+    string lib_prefix = "";
+    string lib_suffix = ".dll";
+#else
+    const char fs = '/';
+    string lib_prefix = "lib";
+    string lib_suffix = ".so";
 #endif
 
 static unsigned char standard_red[] = {
@@ -175,6 +196,137 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // Add the clipping planes widget to the designated layout
     clipLayout->addWidget(cplanes);
 
+    // Initialize the editor and syntax highlighter
+    egsinpEdit = new EGS_Editor();
+    editorLayout->addWidget(egsinpEdit);
+    highlighter = new EGS_Highlighter(egsinpEdit->document());
+
+    // Load an egs++ application to parse the input file
+    string app_name;
+    int appc = 5;
+    char* appv[] = { "egspp", "-a", "tutor7pp", "-i", "tracks1.egsinp", "-p", "tutor_data"};
+
+    // Appv: %s -a application [-p pegs_file] [-i input_file] [-o output_file] [-b] [-P number_of_parallel_jobs] [-j job_index]
+    if (!EGS_Application::getArgument(appc,appv,"-a","--application",app_name)) {
+        egsFatal("test fail\n\n");
+    }
+
+    string lib_dir;
+    EGS_Application::checkEnvironmentVar(appc,appv,"-e","--egs-home","EGS_HOME",lib_dir);
+    lib_dir += "bin";
+    lib_dir += fs;
+    lib_dir += CONFIG_NAME;
+    lib_dir += fs;
+
+    EGS_Library egs_lib(app_name.c_str(),lib_dir.c_str());
+    if (!egs_lib.load()) egsFatal("\n%s: Failed to load the %s application library from %s\n\n",
+                                      appv[0],app_name.c_str(),lib_dir.c_str());
+
+    createAppFunction createApp = (createAppFunction) egs_lib.resolve("createApplication");
+    if (!createApp) egsFatal("\n%s: Failed to resolve the address of the 'createApplication' function"
+                                 " in the application library %s\n\n",appv[0],egs_lib.libraryFile());
+
+    EGS_Application *app = createApp(appc,appv);
+    if (!app) {
+        egsFatal("\n%s: Failed to construct the application %s\n\n",appv[0],app_name.c_str());
+    }
+    egsInformation("Testapp %f\n",app->getRM());
+
+    // Get a list of all the libraries in the dso directory
+    string dso_dir;
+    EGS_Application::checkEnvironmentVar(appc,appv,"-H","--hen-house","HEN_HOUSE",dso_dir);
+    dso_dir += "egs++";
+    dso_dir += fs;
+    dso_dir += "dso";
+    dso_dir += fs;
+    dso_dir += CONFIG_NAME;
+    dso_dir += fs;
+
+    QDir directory(dso_dir.c_str());
+    QStringList libraries = directory.entryList(QStringList() << (lib_prefix+"*"+lib_suffix).c_str(), QDir::Files);
+    QStringList geomLibs, sourceLibs;
+
+    // For each library, try to load it and determine if it is geometry or source
+    for(const auto& lib : libraries) {
+        // Remove the extension
+        QString libName = lib.left(lib.lastIndexOf("."));
+        // Remove the prefix (EGS_Library adds it automatically)
+        libName = libName.right(libName.length() - lib_prefix.length());
+
+        egsInformation("testlib trying %s\n", libName.toLatin1().data());
+
+        EGS_Library egs_lib(libName.toLatin1().data(),dso_dir.c_str());
+        if (!egs_lib.load()) {
+            continue;
+        }
+
+        createGeomFunction createGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
+        if (createGeom) {
+            /*EGS_BaseGeometry *geom = createGeom();
+            EGS_BlockInput *inputBlock = geom->getInputBlock();
+
+            geomLibs.append(libName);
+
+            egsInformation("test1a\n");
+            vector<EGS_SingleInput> singleInputs = inputBlock->getSingleInputs();
+            egsInformation("test1\n");
+            for(auto& inp : singleInputs) {
+                const vector<string> vals = inp.getValues();
+                egsInformation("test %s\n", inp.getAttribute().c_str());
+                for(auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
+                }
+            }
+            delete inputBlock;
+            delete geom;*/
+
+            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
+            egsInformation(" testgeom %s\n",libName.toLatin1().data());
+            if(getInputs) {
+
+                shared_ptr<EGS_BlockInput> geom = getInputs();
+                if(geom) {
+                    // Only add geometries to the list that have a function
+                    // to get the input template
+                    geomLibs.append(libName);
+
+                    geomTemplates.push_back(geom);
+
+                    vector<EGS_SingleInput> singleInputs = geom->getSingleInputs();
+                    for(auto& inp : singleInputs) {
+                        const vector<string> vals = inp.getValues();
+                        egsInformation("  single %s\n", inp.getAttribute().c_str());
+                        for(auto&& val : vals) {
+                            egsInformation("      %s\n", val.c_str());
+                        }
+                    }
+
+                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
+                    for(auto& block : inputBlocks) {
+                        egsInformation("  block %s\n", block->getTitle().c_str());
+                        vector<EGS_SingleInput> singleInputs = block->getSingleInputs();
+                        for(auto& inp : singleInputs) {
+                            const vector<string> vals = inp.getValues();
+                            egsInformation("   single %s\n", inp.getAttribute().c_str());
+                            for(auto&& val : vals) {
+                                egsInformation("      %s\n", val.c_str());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        bool isSource = (bool) egs_lib.resolve("createSource");
+        if (isSource) {
+            sourceLibs.append(libName);
+        }
+    }
+
+    // Populate the geometry and simulation template lists
+    comboBox_geomTemplate->addItems(geomLibs);
+    comboBox_simTemplate->addItems(sourceLibs);
+
     // set the widget to show near the left-upper corner of the screen
     move(QPoint(25,25));
 }
@@ -225,7 +377,7 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     // check that the file (still) exists
     QFile file(filename);
     if (!file.exists()) {
-        egsWarning("\nFile %s does not exist anymore!\n\n",filename.toUtf8().constData());
+        egsWarning("\nInput file %s does not exist!\n\n",filename.toUtf8().constData());
         return false;
     }
 
@@ -410,6 +562,11 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     updateAusgabObjects();
     // See if any of the dose checkboxes are checked
     doseCheckbox_toggled();
+
+    // Load the egsinp file into the editor
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+        egsinpEdit->setPlainText(file.readAll());
+    }
 
     return true;
 }
@@ -1072,6 +1229,26 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     delete input;
 
     updateView(true);
+}
+
+void GeometryViewControl::saveEgsinp() {
+#ifdef VIEW_DEBUG
+    egsWarning("In saveEgsinp()\n");
+#endif
+
+    // Prompt the user for a filename and open the file for writing
+    QString newFilename = QFileDialog::getSaveFileName(this, "Save input file as...", filename);
+    QFile egsinpFile(newFilename);
+    if (!egsinpFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+        return;
+    }
+    QTextStream out(&egsinpFile);
+
+    // Write the text from the editor window
+    out << egsinpEdit->toPlainText() << flush;
+
+    // Reload the input so that the changes are recognized
+    reloadInput();
 }
 
 void GeometryViewControl::setFilename(QString str) {
@@ -2932,6 +3109,8 @@ void GeometryViewControl::enlargeFont() {
     controlsText->selectAll();
     controlsText->setFontPointSize(controlsFont.pointSize() + 1);
     controlsText->setTextCursor(cursor);
+
+    egsinpEdit->zoomIn();
 }
 
 void GeometryViewControl::shrinkFont() {
@@ -2946,6 +3125,8 @@ void GeometryViewControl::shrinkFont() {
     controlsText->selectAll();
     controlsText->setFontPointSize(controlsFont.pointSize() - 1);
     controlsText->setTextCursor(cursor);
+
+    egsinpEdit->zoomOut();
 }
 
 void GeometryViewControl::setFontSize(int size) {
@@ -2960,5 +3141,19 @@ void GeometryViewControl::setFontSize(int size) {
     controlsText->selectAll();
     controlsText->setFontPointSize(controlsFont.pointSize() + changeInSize);
     controlsText->setTextCursor(cursor);
+}
+
+void GeometryViewControl::insertGeomTemplate(int ind) {
+    QString selection = comboBox_geomTemplate->itemText(ind);
+
+    QTextCursor cursor(egsinpEdit->textCursor());
+    egsinpEdit->insertPlainText(selection);
+}
+
+void GeometryViewControl::insertSimTemplate(int ind) {
+    QString selection = comboBox_simTemplate->itemText(ind);
+
+    QTextCursor cursor(egsinpEdit->textCursor());
+    egsinpEdit->insertPlainText(selection);
 }
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -27,6 +27,7 @@
 #                   Ernesto Mainegra-Hing
 #                   Manuel Stoeckl
 #                   Reid Townson
+#                   Hannah Gallop
 #
 ###############################################################################
 */
@@ -76,6 +77,7 @@ typedef EGS_Application *(*createAppFunction)(int argc, char **argv);
 typedef EGS_BaseGeometry *(*createGeomFunction)();
 typedef EGS_BaseSource *(*createSourceFunction)();
 typedef EGS_BaseShape *(*createShapeFunction)();
+typedef EGS_AusgabObject *(*createAusgabObjectFunction)();
 typedef void (*getAppInputsFunction)(shared_ptr<EGS_InputStruct> inpPtr);
 typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
 typedef string (*getExampleFunction)();
@@ -294,6 +296,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     auto srcDefPtr = inputStruct->addBlockInput("source definition");
     srcDefPtr->addSingleInput("simulation source", true, "The name of the source that will be used in the simulation. If you have created a composite source using many other sources, name the final composite source here.");
 
+    // Ausgab Object definition block
+    auto ausDefPtr = inputStruct->addBlockInput("ausgab object definition");
+    ausDefPtr->addSingleInput("simulation ausgab object", true, "The name of the ausgab object that will be used in the simulation.");
+
     // For each library, try to load it and determine if it is geometry or source
     for (const auto &lib : libraries) {
         // Remove the extension
@@ -445,6 +451,45 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                 QAction *action = shapeMenu->addAction(libName);
                 action->setData(QString::fromStdString(getExample()));
                 connect(action,  &QAction::triggered, this, [this]{ insertInputExample(); });
+            }
+        }
+
+        // Ausgab Objects
+        createAusgabObjectFunction isAusgabObject = (createAusgabObjectFunction) egs_lib.resolve("createAusgabObject");
+        if (isAusgabObject) {
+
+            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
+            if (getInputs) {
+
+                shared_ptr<EGS_BlockInput> aus = getInputs();
+                if(aus){
+                    ausDefPtr->addBlockInput(aus);
+
+                    vector<shared_ptr<EGS_SingleInput>> singleInputs = aus->getSingleInputs();
+                    for (auto &inp : singleInputs) {
+                        const vector<string> vals = inp->getValues();
+                        for (auto&& val : vals) {
+                            egsInformation("      %s\n", val.c_str());
+                        }
+                    }
+
+                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = aus->getBlockInputs();
+                    for (auto &block : inputBlocks) {
+                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                        for (auto &inp : singleInputs) {
+                            const vector<string> vals = inp->getValues();
+                            for (auto&& val : vals) {
+                                egsInformation("      %s\n", val.c_str());
+                            }
+                        }
+                    }
+                }
+            }
+            getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
+            if (getExample) {
+                QAction *action = sourceMenu->addAction(libName);
+                action->setData(QString::fromStdString(getExample()));
+                connect(action, &QAction::triggered, this, [this]{ insertInputExample(); });
             }
         }
     }

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -222,13 +222,13 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     lib_dir += CONFIG_NAME;
     lib_dir += fs;
 
-    EGS_Library egs_lib(app_name.c_str(),lib_dir.c_str());
-    if (!egs_lib.load()) egsFatal("\n%s: Failed to load the %s application library from %s\n\n",
+    EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
+    if (!app_lib.load()) egsFatal("\n%s: Failed to load the %s application library from %s\n\n",
                                       appv[0],app_name.c_str(),lib_dir.c_str());
 
-    createAppFunction createApp = (createAppFunction) egs_lib.resolve("createApplication");
+    createAppFunction createApp = (createAppFunction) app_lib.resolve("createApplication");
     if (!createApp) egsFatal("\n%s: Failed to resolve the address of the 'createApplication' function"
-                                 " in the application library %s\n\n",appv[0],egs_lib.libraryFile());
+                                 " in the application library %s\n\n",appv[0],app_lib.libraryFile());
 /*TODO left here crash 'cause tutor7pp isn't compiled <=======================
     EGS_Application *app = createApp(appc,appv);
     if (!app) {
@@ -264,6 +264,25 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
     // The input template structure
     inputStruct = make_shared<EGS_InputStruct>();
+
+    // Get the application level input blocks
+    getInputsFunction getAppInputs = (getInputsFunction) app_lib.resolve("getAppInputs");
+    egsInformation("getInputs test0\n");
+    if(getAppInputs) {
+        egsInformation("getInputs test1\n");
+        shared_ptr<EGS_BlockInput> inpBlock = getAppInputs();
+       /*  if(inpBlock) {
+            egsInformation("getInputs test2\n");
+            for (auto &inp : inpBlock->getSingleInputs()) {
+                const vector<string> vals = inp->getValues();
+                egsInformation("  single %s\n", inp->getTag().c_str());
+                for (auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
+                }
+            }
+            inputStruct->addBlockInput(inpBlock);
+        } */
+    }
 
     // Geometry definition block
     auto geomDefPtr = inputStruct->addBlockInput("geometry definition");

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -225,20 +225,20 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     lib_dir += CONFIG_NAME;
     lib_dir += fs;
 
-    /*EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
+    EGS_Library app_lib(app_name.c_str(),lib_dir.c_str());
     if (!app_lib.load()) egsFatal("\n%s: Failed to load the %s application library from %s\n\n",
                                       appv[0],app_name.c_str(),lib_dir.c_str());
 
     createAppFunction createApp = (createAppFunction) app_lib.resolve("createApplication");
     if (!createApp) egsFatal("\n%s: Failed to resolve the address of the 'createApplication' function"
-                                 " in the application library %s\n\n",appv[0],app_lib.libraryFile()); */
-/*TODO left here crash 'cause tutor7pp isn't compiled <=======================
+                                 " in the application library %s\n\n",appv[0],app_lib.libraryFile());
+//TODO left here crash 'cause tutor7pp isn't compiled <=======================
     EGS_Application *app = createApp(appc,appv);
     if (!app) {
         egsFatal("\n%s: Failed to construct the application %s\n\n",appv[0],app_name.c_str());
     }
     egsInformation("Testapp %f\n",app->getRM());
-    */
+
 
     // Get a list of all the libraries in the dso directory
     string dso_dir;
@@ -263,13 +263,14 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     QMenu *ausgabMenu = exampleMenu->addMenu("Ausgab/Output");
     QMenu *mediaMenu = exampleMenu->addMenu("Media");
     QMenu *runMenu = exampleMenu->addMenu("Run Control");
+    QMenu *appMenu = exampleMenu->addMenu("Applications");
     editorLayout->setMenuBar(menuBar);
 
     // The input template structure
     inputStruct = make_shared<EGS_InputStruct>();
 
     // Get the application level input blocks
-    /*getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
+    getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
     if(getAppInputs) {
         getAppInputs(inputStruct);
         if(inputStruct) {
@@ -286,7 +287,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                 }
             }
         }
-    } */
+    }
 
     // Geometry definition block
     auto geomDefPtr = inputStruct->addBlockInput("geometry definition");
@@ -316,11 +317,9 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         if (!egs_lib.load()) {
             continue;
         }
-        egsInformation("testlib2 trying %s\n", libName.toLatin1().data());
 
         // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
-        egsInformation("testlib4 trying \n");
         if (isGeom) {
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
 
@@ -354,7 +353,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
-            egsInformation("testlib5 trying \n");
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = geomMenu->addAction(libName);
@@ -364,7 +362,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
 
         // Sources
-        egsInformation("testlib6 trying \n");
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
         if (isSource) {
             egsInformation(" testsrc %s\n",libName.toLatin1().data());
@@ -399,7 +396,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
-            //egsInformation("testlib7 trying \n");
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = sourceMenu->addAction(libName);
@@ -409,7 +405,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         }
 
         // Shapes
-        egsInformation("testlib8 trying \n");
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
         if (isShape) {
             egsInformation(" testshape %s\n",libName.toLatin1().data());
@@ -444,7 +439,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
                     }
                 }
             }
-            //egsInformation("testlib9 trying \n");
 
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
@@ -493,7 +487,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             }
         }
     }
-    egsInformation("testlib3 trying \n");
     egsinpEdit->setInputStruct(inputStruct);
 }
 
@@ -1015,6 +1008,8 @@ void GeometryViewControl::loadConfig(QString configFilename) {
     }
 
     // Load the particle track options
+    label_particles->hide();
+    label_particle_colours->hide();
     EGS_Input *iTracks = input->takeInputItem("tracks");
     if (iTracks) {
         int show;
@@ -1052,8 +1047,25 @@ void GeometryViewControl::loadConfig(QString configFilename) {
                 showPositronsCheckbox->setCheckState(Qt::Unchecked);
             }
         }
-
         delete iTracks;
+    }
+    else {
+        label_particles->show();
+        spin_tmaxp->hide();
+        showPositronsCheckbox->hide();
+        showPhotonsCheckbox->hide();
+        showElectronsCheckbox->hide();
+        spin_tminp->hide();
+        spin_tmine->hide();
+        spin_tmaxe->hide();
+        spin_tminpo->hide();
+        spin_tmaxpo->hide();
+
+        label_particle_colours->show();
+        cPhotonsButton->hide();
+        cElectronsButton->hide();
+        cPositronsButton->hide();
+        energyScalingCheckbox->hide();
     }
 
     // Load the overlay options
@@ -1235,6 +1247,22 @@ void GeometryViewControl::loadConfig(QString configFilename) {
 
     // Load the clipping planes
     EGS_Input *iClip = input->takeInputItem("clipping planes");
+    // Set default clipped planes, along each axis
+    cplanes->setCell(0,0,1);
+    cplanes->setCell(0,1, 0);
+    cplanes->setCell(0,2,0);
+    cplanes->setCell(0,3,0);
+    cplanes->setCell(0,4,Qt::Unchecked);
+    cplanes->setCell(1,0,0);
+    cplanes->setCell(1,1,1);
+    cplanes->setCell(1,2,0);
+    cplanes->setCell(1,3,0);
+    cplanes->setCell(1,4,Qt::Unchecked);
+    cplanes->setCell(2,0,0);
+    cplanes->setCell(2,1,0);
+    cplanes->setCell(2,2,1);
+    cplanes->setCell(2,3,0);
+    cplanes->setCell(2,4,Qt::Unchecked);
     if (iClip) {
         for (int i=0; i<cplanes->numPlanes(); i++) {
             EGS_Input *iPlane = iClip->takeInputItem("plane");
@@ -1249,6 +1277,9 @@ void GeometryViewControl::loadConfig(QString configFilename) {
             if (!err) {
                 cplanes->setCell(i,0,ax);
             }
+            /*else if (i == 0) {
+                cplanes->setCell(0, 0, 1);
+            }*/
             else {
                 cplanes->clearCell(i,0);
             }
@@ -2063,6 +2094,16 @@ void GeometryViewControl::changeTransparency(int t) {
     updateView(true);
 }
 
+void GeometryViewControl::changeGlobalTransparency(int t) {
+    int test = materialCB->count();
+    for (int i = 0; i <= test; i++ ) {
+        int med = materialCB->count() - i;
+        QRgb c = m_colors[med];
+        m_colors[med] = qRgba(qRed(c), qGreen(c), qBlue(c), t);
+    }
+    updateView(true);
+}
+
 void GeometryViewControl::changeDoseTransparency(int t) {
 #ifdef VIEW_DEBUG
     egsWarning("In changeDoseTransparency(%d)\n",t);
@@ -2242,7 +2283,6 @@ void GeometryViewControl::loadTracksDialog() {
     if (filename_tracks.isEmpty()) {
         return;
     }
-
     gview->loadTracks(filename_tracks);
 }
 
@@ -2254,6 +2294,22 @@ void GeometryViewControl::updateTracks(vector<size_t> ntracks) {
 #ifdef VIEW_DEBUG
     egsWarning("In updateTracks(%d %d %d)\n",ntracks[0], ntracks[1], ntracks[2]);
 #endif
+    label_particles->hide();
+    spin_tmaxp->show();
+    showPositronsCheckbox->show();
+    showPhotonsCheckbox->show();
+    showElectronsCheckbox->show();
+    spin_tminp->show();
+    spin_tmine->show();
+    spin_tmaxe->show();
+    spin_tminpo->show();
+    spin_tmaxpo->show();
+
+    label_particle_colours->hide();
+    cPhotonsButton->show();
+    cElectronsButton->show();
+    cPositronsButton->show();
+    energyScalingCheckbox->show();
 
     // Update maximum values for the track selection
     spin_tminp->setMaximum(ntracks[0]);

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -287,6 +287,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             continue;
         }
 
+        // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
         if (isGeom) {
             egsInformation(" testgeom %s\n",libName.toLatin1().data());
@@ -330,6 +331,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             }
         }
 
+        // Sources
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
         if (isSource) {
             egsInformation(" testsrc %s\n",libName.toLatin1().data());
@@ -373,6 +375,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             }
         }
 
+        // Shapes
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
         if (isShape) {
             egsInformation(" testshape %s\n",libName.toLatin1().data());
@@ -382,7 +385,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
                 shared_ptr<EGS_BlockInput> shape = getInputs();
                 if (shape) {
-                    inputStruct->addFloatingBlock(shape);
+                    inputStruct->addBlockInput(shape);
 
                     vector<shared_ptr<EGS_SingleInput>> singleInputs = shape->getSingleInputs();
                     for (auto &inp : singleInputs) {

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -76,6 +76,7 @@ typedef EGS_Application *(*createAppFunction)(int argc, char **argv);
 typedef EGS_BaseGeometry *(*createGeomFunction)();
 typedef EGS_BaseSource *(*createSourceFunction)();
 typedef EGS_BaseShape *(*createShapeFunction)();
+typedef void (*getAppInputsFunction)(shared_ptr<EGS_InputStruct> inpPtr);
 typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
 typedef string (*getExampleFunction)();
 
@@ -266,22 +267,23 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     inputStruct = make_shared<EGS_InputStruct>();
 
     // Get the application level input blocks
-    getInputsFunction getAppInputs = (getInputsFunction) app_lib.resolve("getAppInputs");
-    egsInformation("getInputs test0\n");
+    getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppInputs");
     if(getAppInputs) {
-        egsInformation("getInputs test1\n");
-        shared_ptr<EGS_BlockInput> inpBlock = getAppInputs();
-       /*  if(inpBlock) {
-            egsInformation("getInputs test2\n");
-            for (auto &inp : inpBlock->getSingleInputs()) {
-                const vector<string> vals = inp->getValues();
-                egsInformation("  single %s\n", inp->getTag().c_str());
-                for (auto&& val : vals) {
-                    egsInformation("      %s\n", val.c_str());
+        getAppInputs(inputStruct);
+        if(inputStruct) {
+            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputStruct->getBlockInputs();
+            for (auto &block : inputBlocks) {
+                egsInformation("  block %s\n", block->getTitle().c_str());
+                vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                for (auto &inp : singleInputs) {
+                    const vector<string> vals = inp->getValues();
+                    egsInformation("   single %s\n", inp->getTag().c_str());
+                    for (auto&& val : vals) {
+                        egsInformation("      %s\n", val.c_str());
+                    }
                 }
             }
-            inputStruct->addBlockInput(inpBlock);
-        } */
+        }
     }
 
     // Geometry definition block

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -38,6 +38,9 @@
 #include <vector>
 #include "egs_user_color.h"
 #include "egs_vector.h"
+#include "egs_highlighter.h"
+#include "egs_editor.h"
+#include "egs_advanced_application.h"
 
 #include <QMainWindow>
 
@@ -84,6 +87,7 @@ public slots:
     virtual void loadDose();
     virtual void loadConfig();
     virtual void saveConfig();
+    virtual void saveEgsinp();
     virtual void updateSimulationGeometry(int ind);
     virtual void checkboxAxes(bool toggle);
     virtual void checkboxAxesLabels(bool toggle);
@@ -143,6 +147,8 @@ public slots:
     virtual void changeTrackMaxE(int t);
     virtual void changeTrackMaxPo(int t);
     virtual void updateTracks(vector<size_t> ntracks);
+    virtual void insertGeomTemplate(int ind);
+    virtual void insertSimTemplate(int ind);
 
 private:
 
@@ -199,7 +205,11 @@ private:
             energyScaling;
     vector<vector<EGS_Float>> scoreArrays;
     vector<string> geometryNames;
+    vector<shared_ptr<EGS_BlockInput>> geomTemplates;
     EGS_BaseGeometry *origSimGeom;
+    EGS_Editor *egsinpEdit;
+    EGS_Highlighter *highlighter;
+    EGS_AdvancedApplication *egsApp;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -206,7 +206,7 @@ private:
     vector<vector<EGS_Float>> scoreArrays;
     vector<string> geometryNames;
     vector<string> geomExamples;
-    vector<shared_ptr<EGS_BlockInput>> geomTemplates;
+    vector<string> sourceExamples;
     EGS_BaseGeometry *origSimGeom;
     EGS_Editor *egsinpEdit;
     EGS_Highlighter *highlighter;

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -205,6 +205,7 @@ private:
             energyScaling;
     vector<vector<EGS_Float>> scoreArrays;
     vector<string> geometryNames;
+    vector<string> geomExamples;
     vector<shared_ptr<EGS_BlockInput>> geomTemplates;
     EGS_BaseGeometry *origSimGeom;
     EGS_Editor *egsinpEdit;

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -147,8 +147,7 @@ public slots:
     virtual void changeTrackMaxE(int t);
     virtual void changeTrackMaxPo(int t);
     virtual void updateTracks(vector<size_t> ntracks);
-    virtual void insertGeomTemplate(int ind);
-    virtual void insertSimTemplate(int ind);
+    virtual void insertInputExample();
 
 private:
 
@@ -205,12 +204,13 @@ private:
             energyScaling;
     vector<vector<EGS_Float>> scoreArrays;
     vector<string> geometryNames;
-    vector<string> geomExamples;
-    vector<string> sourceExamples;
+    vector<string> inputExamples;
     EGS_BaseGeometry *origSimGeom;
     EGS_Editor *egsinpEdit;
     EGS_Highlighter *highlighter;
     EGS_AdvancedApplication *egsApp;
+    shared_ptr<EGS_InputStruct> inputStruct;
+    QMenu *exampleMenu;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -210,7 +210,6 @@ private:
     EGS_Editor *egsinpEdit;
     EGS_Highlighter *highlighter;
     EGS_AdvancedApplication *egsApp;
-    shared_ptr<EGS_InputStruct> inputStruct;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -210,6 +210,7 @@ private:
     EGS_Editor *egsinpEdit;
     EGS_Highlighter *highlighter;
     EGS_AdvancedApplication *egsApp;
+    shared_ptr<EGS_InputStruct> inputStruct;
 
 protected slots:
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -109,6 +109,7 @@ public slots:
     virtual void phiRotation(int Phi);
     virtual void changeAmbientLight(int alight);
     virtual void changeTransparency(int t);
+    virtual void changeGlobalTransparency(int t);
     virtual void moveLightChanged(int toggle);
     virtual void setLightPosition();
     virtual void setLookAt();

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -116,7 +116,7 @@
           <item>
            <widget class="QTabWidget" name="tabWidget">
             <property name="currentIndex">
-             <number>4</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="displayTab">
              <property name="sizePolicy">
@@ -183,123 +183,6 @@
                      </size>
                     </property>
                    </spacer>
-                  </item>
-                  <item>
-                   <widget class="QGroupBox" name="groupBox10">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="minimumSize">
-                     <size>
-                      <width>0</width>
-                      <height>120</height>
-                     </size>
-                    </property>
-                    <property name="maximumSize">
-                     <size>
-                      <width>16777215</width>
-                      <height>16777215</height>
-                     </size>
-                    </property>
-                    <property name="title">
-                     <string>Particle tracks</string>
-                    </property>
-                    <layout class="QGridLayout">
-                     <item row="0" column="2">
-                      <widget class="QSpinBox" name="spin_tmaxp">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="0">
-                      <widget class="QCheckBox" name="showPositronsCheckbox">
-                       <property name="text">
-                        <string>Positrons</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0">
-                      <widget class="QCheckBox" name="showPhotonsCheckbox">
-                       <property name="text">
-                        <string>Photons</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="0">
-                      <widget class="QCheckBox" name="showElectronsCheckbox">
-                       <property name="text">
-                        <string>Electrons</string>
-                       </property>
-                       <property name="checked">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="1">
-                      <widget class="QSpinBox" name="spin_tminp">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QSpinBox" name="spin_tmine">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QSpinBox" name="spin_tmaxe">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="1">
-                      <widget class="QSpinBox" name="spin_tminpo">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="2" column="2">
-                      <widget class="QSpinBox" name="spin_tmaxpo">
-                       <property name="minimum">
-                        <number>1</number>
-                       </property>
-                       <property name="value">
-                        <number>1</number>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
                   </item>
                   <item>
                    <widget class="QGroupBox" name="groupBox15">
@@ -381,6 +264,155 @@
                    </widget>
                   </item>
                   <item>
+                   <widget class="QGroupBox" name="groupBox10">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>120</height>
+                     </size>
+                    </property>
+                    <property name="maximumSize">
+                     <size>
+                      <width>16777215</width>
+                      <height>16777215</height>
+                     </size>
+                    </property>
+                    <property name="toolTip">
+                     <string>Use egs_track_scoring to output a ptracks file</string>
+                    </property>
+                    <property name="title">
+                     <string>Particle tracks</string>
+                    </property>
+                    <layout class="QVBoxLayout" name="verticalLayout_17">
+                     <property name="leftMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>6</number>
+                     </property>
+                     <property name="bottomMargin">
+                      <number>6</number>
+                     </property>
+                     <item>
+                      <layout class="QGridLayout" name="gridLayout">
+                       <property name="leftMargin">
+                        <number>3</number>
+                       </property>
+                       <item row="1" column="0">
+                        <widget class="QCheckBox" name="showElectronsCheckbox">
+                         <property name="text">
+                          <string>Electrons</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QSpinBox" name="spin_tminp">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="2">
+                        <widget class="QSpinBox" name="spin_tmaxe">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="1" column="1">
+                        <widget class="QSpinBox" name="spin_tmine">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="2">
+                        <widget class="QSpinBox" name="spin_tmaxp">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QCheckBox" name="showPhotonsCheckbox">
+                         <property name="text">
+                          <string>Photons</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="0">
+                        <widget class="QCheckBox" name="showPositronsCheckbox">
+                         <property name="text">
+                          <string>Positrons</string>
+                         </property>
+                         <property name="checked">
+                          <bool>true</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="2">
+                        <widget class="QSpinBox" name="spin_tmaxpo">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="2" column="1">
+                        <widget class="QSpinBox" name="spin_tminpo">
+                         <property name="minimum">
+                          <number>1</number>
+                         </property>
+                         <property name="value">
+                          <number>1</number>
+                         </property>
+                        </widget>
+                       </item>
+                      </layout>
+                     </item>
+                     <item>
+                      <widget class="QLabel" name="label_particles">
+                       <property name="text">
+                        <string>No particle tracks found</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignCenter</set>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item>
                    <widget class="QGroupBox" name="groupBox_dose">
                     <property name="sizePolicy">
                      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -408,16 +440,31 @@
                       <number>6</number>
                      </property>
                      <item>
-                      <widget class="QSlider" name="slider_dose">
-                       <property name="maximum">
-                        <number>100</number>
+                      <widget class="QGroupBox" name="groupBox_7">
+                       <property name="title">
+                        <string>Opacity</string>
                        </property>
-                       <property name="value">
-                        <number>50</number>
-                       </property>
-                       <property name="orientation">
-                        <enum>Qt::Horizontal</enum>
-                       </property>
+                       <layout class="QHBoxLayout" name="horizontalLayout_15">
+                        <item>
+                         <widget class="QSlider" name="slider_dose">
+                          <property name="maximum">
+                           <number>100</number>
+                          </property>
+                          <property name="value">
+                           <number>50</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>10</number>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
                       </widget>
                      </item>
                      <item>
@@ -425,7 +472,7 @@
                        <item>
                         <widget class="QScrollArea" name="scrollArea_2">
                          <property name="frameShape">
-                          <enum>QFrame::Box</enum>
+                          <enum>QFrame::NoFrame</enum>
                          </property>
                          <property name="widgetResizable">
                           <bool>true</bool>
@@ -435,8 +482,8 @@
                            <rect>
                             <x>0</x>
                             <y>0</y>
-                            <width>297</width>
-                            <height>189</height>
+                            <width>301</width>
+                            <height>155</height>
                            </rect>
                           </property>
                           <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -448,7 +495,7 @@
                              <item>
                               <widget class="QLabel" name="label_dose">
                                <property name="text">
-                                <string>No ausgab objects found</string>
+                                <string>No dose files found</string>
                                </property>
                                <property name="alignment">
                                 <set>Qt::AlignCenter</set>
@@ -551,11 +598,39 @@
                      <item>
                       <widget class="QGroupBox" name="groupBox19">
                        <property name="title">
-                        <string>Transparency</string>
+                        <string>Opacity</string>
                        </property>
                        <layout class="QHBoxLayout" name="horizontalLayout_2">
                         <item>
                          <widget class="QSlider" name="transparency">
+                          <property name="maximum">
+                           <number>255</number>
+                          </property>
+                          <property name="value">
+                           <number>255</number>
+                          </property>
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="tickPosition">
+                           <enum>QSlider::TicksBelow</enum>
+                          </property>
+                          <property name="tickInterval">
+                           <number>25</number>
+                          </property>
+                         </widget>
+                        </item>
+                       </layout>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QGroupBox" name="groupBox_6">
+                       <property name="title">
+                        <string>Global Opacity</string>
+                       </property>
+                       <layout class="QHBoxLayout" name="horizontalLayout_9">
+                        <item>
+                         <widget class="QSlider" name="global_transparency">
                           <property name="maximum">
                            <number>255</number>
                           </property>
@@ -707,6 +782,16 @@
                   <layout class="QHBoxLayout" name="horizontalLayout_11">
                    <item>
                     <layout class="QVBoxLayout" name="verticalLayout_10">
+                     <item>
+                      <widget class="QLabel" name="label_particle_colours">
+                       <property name="text">
+                        <string>No particle tracks found</string>
+                       </property>
+                       <property name="alignment">
+                        <set>Qt::AlignCenter</set>
+                       </property>
+                      </widget>
+                     </item>
                      <item>
                       <widget class="QPushButton" name="cPhotonsButton">
                        <property name="sizePolicy">

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -1758,7 +1758,7 @@ p, li { white-space: pre-wrap; }
               </sizepolicy>
              </property>
              <attribute name="title">
-              <string>Editor</string>
+              <string>Editor (experimental)</string>
              </attribute>
              <layout class="QGridLayout" name="editorLayout"/>
             </widget>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -1675,50 +1675,7 @@ p, li { white-space: pre-wrap; }
              <attribute name="title">
               <string>Editor</string>
              </attribute>
-             <layout class="QGridLayout" name="editorLayout">
-              <item row="0" column="0">
-               <layout class="QVBoxLayout" name="editorLayout_2">
-                <item>
-                 <layout class="QHBoxLayout" name="horizontalLayout_9">
-                  <property name="sizeConstraint">
-                   <enum>QLayout::SetMaximumSize</enum>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label">
-                    <property name="sizePolicy">
-                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                      <horstretch>0</horstretch>
-                      <verstretch>0</verstretch>
-                     </sizepolicy>
-                    </property>
-                    <property name="text">
-                     <string>Insert template:</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="comboBox_geomTemplate">
-                    <item>
-                     <property name="text">
-                      <string>Geometry</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                  <item>
-                   <widget class="QComboBox" name="comboBox_simTemplate">
-                    <item>
-                     <property name="text">
-                      <string>Simulation</string>
-                     </property>
-                    </item>
-                   </widget>
-                  </item>
-                 </layout>
-                </item>
-               </layout>
-              </item>
-             </layout>
+             <layout class="QGridLayout" name="editorLayout"/>
             </widget>
            </widget>
           </item>
@@ -2475,38 +2432,6 @@ p, li { white-space: pre-wrap; }
    <signal>activated(int)</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>updateSimulationGeometry(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>comboBox_simTemplate</sender>
-   <signal>activated(int)</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>insertSimTemplate(int)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>20</x>
-     <y>20</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>comboBox_geomTemplate</sender>
-   <signal>activated(int)</signal>
-   <receiver>GeometryViewControl</receiver>
-   <slot>insertGeomTemplate(int)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>

--- a/HEN_HOUSE/egs++/view/viewcontrol.ui
+++ b/HEN_HOUSE/egs++/view/viewcontrol.ui
@@ -65,7 +65,7 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <layout class="QHBoxLayout" name="horizontalLayout_9">
+   <layout class="QVBoxLayout" name="verticalLayout_18">
     <property name="leftMargin">
      <number>0</number>
     </property>
@@ -91,7 +91,7 @@
            <x>0</x>
            <y>0</y>
            <width>671</width>
-           <height>563</height>
+           <height>567</height>
           </rect>
          </property>
          <property name="sizePolicy">
@@ -116,7 +116,7 @@
           <item>
            <widget class="QTabWidget" name="tabWidget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>4</number>
             </property>
             <widget class="QWidget" name="displayTab">
              <property name="sizePolicy">
@@ -155,7 +155,7 @@
                   <item>
                    <widget class="QGroupBox" name="groupBox_5">
                     <property name="title">
-                     <string>Simulation geometry</string>
+                     <string>View geometry</string>
                     </property>
                     <layout class="QHBoxLayout" name="horizontalLayout_14">
                      <item>
@@ -431,6 +431,14 @@
                           <bool>true</bool>
                          </property>
                          <widget class="QWidget" name="scrollAreaWidgetContents">
+                          <property name="geometry">
+                           <rect>
+                            <x>0</x>
+                            <y>0</y>
+                            <width>297</width>
+                            <height>189</height>
+                           </rect>
+                          </property>
                           <layout class="QVBoxLayout" name="verticalLayout_16">
                            <item>
                             <layout class="QVBoxLayout" name="verticalLayout_dose">
@@ -1638,20 +1646,75 @@
                       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Cantarell'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Rotate: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;hold left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Zoom:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; scroll or hold middle MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Pan: &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;Ctrl + left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Roll:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Shift + left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set rotation point:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; double left MB&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Home&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Set home:&lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt; Alt + Home&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:10pt; font-weight:600;&quot;&gt;Look along X (Y or Z): &lt;/span&gt;&lt;span style=&quot; font-size:10pt;&quot;&gt;x (y or z)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Rotate: &lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt;hold left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Zoom:&lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt; scroll or hold middle MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Pan: &lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt;Ctrl + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Roll:&lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt; Shift + left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Set rotation point:&lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt; double left MB&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Home:&lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt; Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Set home:&lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt; Alt + Home&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt; font-weight:600;&quot;&gt;Look along X (Y or Z): &lt;/span&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:10pt;&quot;&gt;x (y or z)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                      </property>
                     </widget>
                    </item>
                   </layout>
                  </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="tab">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <attribute name="title">
+              <string>Editor</string>
+             </attribute>
+             <layout class="QGridLayout" name="editorLayout">
+              <item row="0" column="0">
+               <layout class="QVBoxLayout" name="editorLayout_2">
+                <item>
+                 <layout class="QHBoxLayout" name="horizontalLayout_9">
+                  <property name="sizeConstraint">
+                   <enum>QLayout::SetMaximumSize</enum>
+                  </property>
+                  <item>
+                   <widget class="QLabel" name="label">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                    <property name="text">
+                     <string>Insert template:</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBox_geomTemplate">
+                    <item>
+                     <property name="text">
+                      <string>Geometry</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                  <item>
+                   <widget class="QComboBox" name="comboBox_simTemplate">
+                    <item>
+                     <property name="text">
+                      <string>Simulation</string>
+                     </property>
+                    </item>
+                   </widget>
+                  </item>
+                 </layout>
                 </item>
                </layout>
               </item>
@@ -1673,7 +1736,7 @@ p, li { white-space: pre-wrap; }
      <x>0</x>
      <y>0</y>
      <width>675</width>
-     <height>25</height>
+     <height>21</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -1685,6 +1748,7 @@ p, li { white-space: pre-wrap; }
     <addaction name="actionOpen_dose"/>
     <addaction name="actionOpen_settings"/>
     <addaction name="separator"/>
+    <addaction name="actionSave_egsinp"/>
     <addaction name="actionSave_image"/>
     <addaction name="actionSave_settings"/>
     <addaction name="separator"/>
@@ -1704,7 +1768,7 @@ p, li { white-space: pre-wrap; }
   </widget>
   <action name="actionOpen">
    <property name="text">
-    <string>&amp;Open...</string>
+    <string>&amp;Open egsinp...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+O</string>
@@ -1720,7 +1784,7 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionSave_image">
    <property name="text">
-    <string>Save &amp;image...</string>
+    <string>Save &amp;image</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+I</string>
@@ -1728,10 +1792,10 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionSave_settings">
    <property name="text">
-    <string>&amp;Save settings...</string>
+    <string>Save settin&amp;gs</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+S</string>
+    <string>Ctrl+G</string>
    </property>
   </action>
   <action name="actionReload">
@@ -1768,7 +1832,7 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionOpen_dose">
    <property name="text">
-    <string>Open &amp;dose...</string>
+    <string>Open 3d&amp;dose...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
@@ -1776,10 +1840,18 @@ p, li { white-space: pre-wrap; }
   </action>
   <action name="actionOpen_tracks">
    <property name="text">
-    <string>Open trac&amp;ks...</string>
+    <string>Open ptrac&amp;ks...</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+K</string>
+   </property>
+  </action>
+  <action name="actionSave_egsinp">
+   <property name="text">
+    <string>&amp;Save egsinp</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+S</string>
    </property>
   </action>
  </widget>
@@ -2175,6 +2247,22 @@ p, li { white-space: pre-wrap; }
    </hints>
   </connection>
   <connection>
+   <sender>actionSave_egsinp</sender>
+   <signal>triggered()</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>saveEgsinp()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
    <sender>showPhotonsCheckbox</sender>
    <signal>toggled(bool)</signal>
    <receiver>GeometryViewControl</receiver>
@@ -2387,6 +2475,38 @@ p, li { white-space: pre-wrap; }
    <signal>activated(int)</signal>
    <receiver>GeometryViewControl</receiver>
    <slot>updateSimulationGeometry(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>comboBox_simTemplate</sender>
+   <signal>activated(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>insertSimTemplate(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>comboBox_geomTemplate</sender>
+   <signal>activated(int)</signal>
+   <receiver>GeometryViewControl</receiver>
+   <slot>insertGeomTemplate(int)</slot>
    <hints>
     <hint type="sourcelabel">
      <x>20</x>


### PR DESCRIPTION
Add a new tab in egs_view that allows for editing and saving egsinp files for egs++.

The new code all over the egs++ library provide a structure by which an external library like egs_view can extract all of the input parameters. It's used for input validation, syntax highlighting, autocompletion, etc.

This replaces PR #710.