### PR TITLE
Fix #894: revert egsphant to egs_brachy encoding

### DIFF
--- a/HEN_HOUSE/omega/progs/ctcreate/ctcreate.mortran
+++ b/HEN_HOUSE/omega/progs/ctcreate/ctcreate.mortran
@@ -2040,6 +2040,8 @@ REAL    xbnd($IMAX+1),             "voxel x boundaries"
         rho($MXREG),               "linear array of densities"
         estepe($MXMED);            "linear array of estepe values"
 
+character  encoding*62;
+encoding = $ENCODING;
 
 REPLACE {$IR(#,#,#)} WITH {(1 + {P1} + ({P2}-1)*iimax + ({P3}-1)*iimax*jjmax)}
 
@@ -2074,7 +2076,8 @@ WRITE(15,*) (ybnd(jj),jj=1,jjmax+1);
 WRITE(15,*) (zbnd(kk),kk=1,kkmax+1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
-        WRITE(15,1399) (achar(MOD((med($IR(ii,jj,kk))+16),95) + 32),ii=1,iimax);
+        WRITE(15,1399)
+        (encoding(med($IR(ii,jj,kk))+1:med($IR(ii,jj,kk))+1),ii=1,iimax);
     ]
     WRITE(15,*);
 ]

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -1353,6 +1353,7 @@ REAL z_score_tmp; "dummy variable passed to IAEA phsp file opening macro"
 external combine_results;
 
 character medChar($IMAX);
+character encoding*62;
 
 #ifdef HAVE_C_COMPILER;
 $REAL   part_dose, part2_dose, current_result, current_uncertainty;
@@ -1371,6 +1372,8 @@ $DECLARE_TIMING_VARIABLES;
 "cput1 is cputime at start of simulations"
 "cput2 is cputime when asked for so elapsed cpu is cput2-cput0 or -cput1"
 
+"define the ascii encoding string for media in egsphant file"
+encoding = $ENCODING;
 
 call egs_init; "initialize EGSnrc system"
 
@@ -1524,7 +1527,7 @@ IF(NMED = 0)[ "Input data from CT data file as processed by the code ctcreate"
           read($CTUnitNumber,:medformat:) (medChar(i),i=1,IMAX);
           "Convert from ASCII to a number"
           DO i=1,IMAX[
-            med($IR(i,j,k)) = mod((iachar(medChar(i)) + 47), 95);
+            med($IR(i,j,k)) = index(encoding, medChar(i)) - 1;
           ]
        ]
        read($CTUnitNumber,*);
@@ -4535,6 +4538,8 @@ REAL    xbnd($IMAX+1),             "voxel x boundaries"
         estepe($MXMED);            "linear array of estepe values"
 $REAL rho($MXREG);
 
+character  encoding(62);
+encoding = $ENCODING;
 
 REPLACE {$IRWP(#,#,#)} WITH {(1 + {P1} + ({P2}-1)*iimax + ({P3}-1)*iimax*jjmax)}
 
@@ -4551,8 +4556,8 @@ WRITE(iunit,*) (ybnd(jj),jj=1,jjmax+1);
 WRITE(iunit,*) (zbnd(kk),kk=1,kkmax+1);
 DO kk=1,kkmax[
     DO jj=1,jjmax[
-        WRITE(iunit,1399) (achar(MOD((med($IRWP(ii,jj,kk))+16),95) + 32),
-            ii=1,iimax);
+        WRITE(iunit,1399)
+        (encoding(med($IRWP(ii,jj,kk))+1:med($IRWP(ii,jj,kk))+1),ii=1,iimax);
     ]
     WRITE(iunit,*);
 ]

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc_user_macros.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc_user_macros.mortran
@@ -110,6 +110,10 @@ REPLACE {$MXANG} WITH {60000};
 "default directory in which to output phase space files"
 REPLACE {$DIRECTORY-FOR-PHSP} WITH {$cstring(egs_home)//$cstring(user_code)};
 
+"Encoding of the egsphant material types"
+REPLACE {$ENCODING} WITH {
+'0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'};
+
 "*******************************************************************"
 "   These macros define the null macros related to BEAM MODELS      "
 "*******************************************************************"


### PR DESCRIPTION
Revert to the `egs_brachy` encoding for `.egsphant` files, allowing for 63 media encoded with the set of alphanumeric characters (where 0 is reserved for vacuum).

Briefly, #633 expanded the number of media in `.egsphant` files to 95, using all printable ascii characters. However, the number of media was also independently expanded in `egs_glib` for the development of `egs_brachy`, but using a different encoding consisting of only the 63 alphanumeric ascii characters. This leads to inconsistent egsphant files that are no longer interchangeable.

This issue was originally reported and discussed in https://github.com/clrp-code/egs_brachy/issues/22.