### PR TITLE
Fix git branch logging and egs_home vs HEN_HOUSE code comparisons

### DIFF
--- a/HEN_HOUSE/gui/egs_configure/egs_install.h
+++ b/HEN_HOUSE/gui/egs_configure/egs_install.h
@@ -655,8 +655,6 @@ static const char machine_macros[]={
 "\n"\
 "REPLACE {$GIT_HASH} WITH \n"\
 "  {'$git_hash'}; \n"\
-"REPLACE {$GIT_BRANCH} WITH \n"\
-"  {'$git_branch'}; \n"\
 "REPLACE {$CONFIG_TIME} WITH \n"\
 "  {'$config_time'}; \n"\
 "\n"\

--- a/HEN_HOUSE/makefiles/cpp_makefile
+++ b/HEN_HOUSE/makefiles/cpp_makefile
@@ -46,11 +46,20 @@ $(target): $(user_objects) $(egs_objects)
 $(lib_target): $(user_lib_objects) $(egs_lib_objects)
 	$(CXX) $(opt) $(shared) $(lib_link1) $^ $(extra) $(link2_prefix)egspp$(link2_suffix) $(fortran_libs) $(user_libs)
 
+EXISTS =
+ifeq ($(OS),Windows_NT)
+	EXISTS := $(shell if exist $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).cpp echo Exists)
+else
+	EXISTS := $(shell test -f $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).cpp && echo "Exists")
+endif
+
 CMP =
+ifeq ($(EXISTS),Exists)
 ifeq ($(OS),Windows_NT)
 	CMP := $(shell FC $(USER_CODE).cpp $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).cpp >NUL 2>&1 && echo Same || echo Different)
 else
 	CMP := $(shell cmp --version 2> /dev/null)
+endif
 endif
 
 compare:
@@ -95,7 +104,7 @@ egs_interface2_$(my_machine).$(obje): $(dep_egs_interface)
 	$(object_rule)
 
 egsnrc_$(my_machine).$(obje): egsnrc_$(my_machine).F array_sizes.h
-	$(F77) -cpp $(FC_FLAGS) $(FDEFS) $(COMPILE_TIME) $(GIT_HASH) $(GIT_BRANCH) -c $(FOUT)$@ $<
+	$(F77) -cpp $(FC_FLAGS) $(FDEFS) $(COMPILE_TIME) $(GIT_HASH) -c $(FOUT)$@ $<
 
 egsnrc_$(my_machine).F: $(CPP_SOURCES)
 	@echo "Mortran compiling EGSnrc sources ..."

--- a/HEN_HOUSE/makefiles/standard_makefile
+++ b/HEN_HOUSE/makefiles/standard_makefile
@@ -86,8 +86,8 @@ failed_message = "______Operation failed______"
 $(EXECUTABLE): $(FORTRAN_FILE).$(FEXT) $(EGS_EXTRA_OBJECTS) $(EXE_DIR) compare
 	@echo $(empty)
 	@echo $(empty)
-	@echo "Fortran compiling $(FORTRAN_FILE).$(FEXT) using flags '-cpp $(EGS_EXTRA_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(GIT_BRANCH)' and extra objects/libs '$(EGS_EXTRA_OBJECTS) $(EGS_EXTRA_LIBS)'"
-	@$(F77) -cpp $(EGS_EXTRA_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(GIT_BRANCH) $(FOUT)$@ $(FORTRAN_FILE).$(FEXT) $(EGS_EXTRA_OBJECTS) $(EGS_EXTRA_LIBS) 2>&1
+	@echo "Fortran compiling $(FORTRAN_FILE).$(FEXT) using flags '-cpp $(EGS_EXTRA_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH)' and extra objects/libs '$(EGS_EXTRA_OBJECTS) $(EGS_EXTRA_LIBS)'"
+	@$(F77) -cpp $(EGS_EXTRA_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(FOUT)$@ $(FORTRAN_FILE).$(FEXT) $(EGS_EXTRA_OBJECTS) $(EGS_EXTRA_LIBS) 2>&1
 
 # The following 2 rules are to make sure that the user executable directory
 # exists.
@@ -147,11 +147,20 @@ $(USER_CODE).mortran: $(depend)
 check:
 	@$(CHECK_USER_CODE)
 
+EXISTS =
+ifeq ($(OS),Windows_NT)
+	EXISTS := $(shell if exist $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).mortran echo Exists)
+else
+	EXISTS := $(shell test -f $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).mortran && echo "Exists")
+endif
+
 CMP =
+ifeq ($(EXISTS),Exists)
 ifeq ($(OS),Windows_NT)
 	CMP := $(shell FC $(USER_CODE).mortran $(HEN_HOUSE)$(DSEP)user_codes$(DSEP)$(USER_CODE)$(DSEP)$(USER_CODE).mortran >NUL 2>&1 && echo Same || echo Different)
 else
 	CMP := $(shell cmp --version 2> /dev/null)
+endif
 endif
 
 compare:

--- a/HEN_HOUSE/specs/all_common.spec
+++ b/HEN_HOUSE/specs/all_common.spec
@@ -140,16 +140,6 @@ else
     GIT_HASH = -DGIT_HASH="\"$(shell if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then git rev-parse --short=7 HEAD; fi)\""
 endif
 
-GIT_BRANCH =
-ifeq ($(OS),Windows_NT)
-    USING_GIT = $(shell cmd /C git rev-parse --is-inside-work-tree)
-    ifeq ($(USING_GIT),true)
-        GIT_BRANCH = -DGIT_BRANCH="\"$(shell cmd /C git rev-parse --abbrev-ref HEAD)\""
-    endif
-else
-    GIT_BRANCH = -DGIT_BRANCH="\"$(shell if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then git rev-parse --abbrev-ref HEAD; fi)\""
-endif
-
 COMPILE_TIME =
 ifeq ($(OS),Windows_NT)
     COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T)$(shell cmd /C time /T) $(shell cmd /C tzutil /g)\""

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -430,9 +430,6 @@ IF( lnblnk1(tmp_string) > lnblnk1(pegs_file) ) [
 ]
 pos2 = min(pos2,80-lnblnk1(tmp_string));
 pos2 = min(pos2,80-lnblnk1(host_name));
-#ifdef GIT_BRANCH;
-    pos2 = min(pos2,80-lnblnk1(GIT_BRANCH));
-#endif;
 pos2 = min(pos2,80-lnblnk1($CONFIG_TIME));
 IF( have_input ) pos2 = min(pos2,80-lnblnk1(input_file));
 pos2 = min(pos2,80-lnblnk1(output_file));
@@ -441,10 +438,6 @@ IF( pos2 < pos1+2 ) pos2 = pos1 + 2;
 $write_description('configuration'); $egs_info('(a)',$CONFIGURATION_NAME);
 $write_description('configuration time'); $egs_info('(a)',$CONFIG_TIME);
 $write_description('app compile time'); $egs_info('(a)',COMPILE_TIME);
-#ifdef GIT_BRANCH;
-    $write_description('git commit hash'); $egs_info('(a)',GIT_HASH);
-    $write_description('git branch'); $egs_info('(a)',GIT_BRANCH);
-#endif;
 $write_description('application'); $egs_info('(a)',$cstring(user_code));
 $write_description('pegs file'); $egs_info('(a)',$cstring(tmp_string));
 $write_description('using host'); $egs_info('(a)',$cstring(host_name));


### PR DESCRIPTION
Fix an issue with long branch names where the fortran code would fail to compile because of exceeding the line length. This isn't completely fixed, but now a few more characters are allowed before it crashes. Correct me if I'm wrong, but I think it's not possible to fix completely, because it seems like the DEFINE replacement means that we can't use mortrans usual automatic line wrapping.

Fix the comparisons between egs_home and HEN_HOUSE/user_code applications, so that it doesn't report a difference when the HEN_HOUSE version doesn't exist to start with.

This fixes minor issues introduced in PR #414.