### PR TITLE
Add checks for gcc version when setting the default c++ standard

### DIFF
--- a/HEN_HOUSE/egs++/view/view.pro
+++ b/HEN_HOUSE/egs++/view/view.pro
@@ -93,7 +93,13 @@ unix {
 #QMAKE_CXXFLAGS+="-ggdb3"
 #QMAKE_LFLAGS+="-fsanitize=address"
 
-QMAKE_CXXFLAGS+=-std=c++14
+# Use c++14 for gcc 5 or higher
+greaterThan(QMAKE_GCC_MAJOR_VERSION, 4) {
+    QMAKE_CXXFLAGS+=-std=c++14
+} else {
+    QMAKE_CXXFLAGS+=-std=c++11
+}
+
 UI_DIR = .ui/$$my_machine
 MOC_DIR = .moc/$$my_machine
 OBJECTS_DIR = .obj/$$my_machine

--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -806,6 +806,7 @@ void MCompiler::init(){
 
 // Set options for GCC compilers
 void MCompiler::setLanguage(Language l){
+    QString majorVersion;
     switch(l){
       case F:
         the_name = "gfortran";
@@ -817,7 +818,18 @@ void MCompiler::setLanguage(Language l){
         break;
       case CPP:
         the_name = "g++";
-        optimiz = "-O2 -mtune=native -mcmodel=medium";
+
+        // Use c++14 for gcc 5 or higher
+        vopt = "-dumpversion";
+        majorVersion = getVersion();
+        majorVersion = majorVersion.split("\n").takeFirst().split(".").takeFirst();
+        vopt = "--version";
+        if(majorVersion.toInt() >= 5) {
+          optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++14";
+        } else {
+          optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++11";
+        }
+
         dso = new EGS_DSO(name());// Creates dso, sets flibs to -lgfortran literally
         dso->flibs = getFlibs2LinkCPP("gfortran",path());
         break;
@@ -940,14 +952,32 @@ void MCompiler::setUpCPPCompiler(const QString& link_to_name){
     vopt = QString();
   }
   else if ( the_name.contains("g++") ){
-    optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++14 -DWIN32";
+    // Use c++14 for gcc 5 or higher
+    vopt = "-dumpversion";
+    QString majorVersion = getVersion();
+    majorVersion = majorVersion.split("\n").takeFirst().split(".").takeFirst();
+    vopt = "--version";
+    if(majorVersion.toInt() >= 5) {
+      optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++14 -DWIN32";
+    } else {
+      optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++11 -DWIN32";
+    }
   }
   else if (the_name.toLower()== "icpc"){
     optimiz  = "-O2 -no-prec-div -fp-model fast=2 -DWIN32";
   }
 #else
   if ( the_name.contains("g++") ){
-    optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++14";
+    // Use c++14 for gcc 5 or higher
+    vopt = "-dumpversion";
+    QString majorVersion = getVersion();
+    majorVersion = majorVersion.split("\n").takeFirst().split(".").takeFirst();
+    vopt = "--version";
+    if(majorVersion.toInt() >= 5) {
+      optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++14";
+    } else {
+      optimiz  = "-O2 -mtune=native -mcmodel=medium -std=c++11";
+    }
   }
   else if (the_name.toLower()== "icpc"){
     optimiz  = "-O2 -no-prec-div -fp-model fast=2";
@@ -956,6 +986,7 @@ void MCompiler::setUpCPPCompiler(const QString& link_to_name){
     optimiz  = "-O2";
   }
 #endif
+
   _version = getVersion(); _version = _version.split("\n").takeFirst();
 
   //get_dso();

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -165,7 +165,13 @@ if test $create_config=yes; then
 
 case $CXX in
 
-    *g++*) opt="-O2 -mtune=native -mcmodel=medium -std=c++14";;# mingw32-g++ and g++4 also taken into account
+    *g++*)
+    if test $($CXX -dumpversion | cut -f1 -d.) -ge 5; then
+        std="c++14"
+    else
+        std="c++11"
+    fi
+    opt="-O2 -mtune=native -mcmodel=medium -std=$std";;# mingw32-g++ and g++4 also taken into account
     icpc)  opt="-O2 -no-prec-div -fp-model fast=2";;
     icc)   opt="-O2 -no-prec-div -fp-model fast=2";;
     cl)    opt="-Ox -Ob2 -MD -GX -GR -nologo";;


### PR DESCRIPTION
Add checks to the configure script, configuration GUI, and egs_view profile before setting `std=c++14` as the default c++ standard. If the gcc version is 4 or less, then `std=c++11` is used as the default. This just helps protect against failed installations for users with older gcc versions using the default config settings.

Very old versions of gcc might still crash, but the user can easily change the `std=` flag as necessary.