### PR TITLE
Fix #904: avoid gcc -mcmodel flag on macos systems

### DIFF
--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -123,11 +123,13 @@ _ACEOF
 
 read response
 
+memory_model="-mcmodel=medium"
 printf $format "Checking system type ... " >&2
 canonical_system=$($my_dir/config.guess)
 system_name=$(uname -s | sed ":/:_:g" | tr '[:upper:]' '[:lower:]')
 if test "x$system_name" = xdarwin; then
     system_name="osx"
+    memory_model=""
 fi
 echo "$canonical_system" >&2
 is_x86_64=$(echo $canonical_system | grep x86_64)
@@ -343,7 +345,7 @@ for test_arg in -v; do
             junk=$(echo $f_test_output | grep "GNU Fortran")
             if test "x$junk" != x; then
                 f_version=$(echo $junk | grep -o -m1 'GNU Fortran [^\s]* version [0-9.]*'| head -1)
-                f_oflags="-O2 -mtune=native -mcmodel=medium"
+                f_oflags="-O2 -mtune=native $memory_model"
                 f_dflags="-g"
                 if test ! x$is_x86_64 = x; then
                     f_fflags="-fPIC"
@@ -367,7 +369,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 junk=$(echo $junk | sed 's/.*GNU F95 version//g' | awk '{print $1}')
                 f_version="GNU F95 version $junk"
-                f_oflags="-O2 -mtune=native -mcmodel=medium"
+                f_oflags="-O2 -mtune=native $memory_model"
                 f_dflags="-g"
                 if test ! x$is_x86_64 = x; then
                     f_fflags="-fPIC"
@@ -426,7 +428,7 @@ for test_arg in -v; do
             if test "x$junk" != x; then
                 junk=$(echo $junk | sed 's/.*D__INTEL_COMPILER=//g' | awk '{print $1}')
                 f_version="Intel(R) Fortran Compiler Version $junk"
-                f_oflags="-O2 -mtune=native -mcmodel=medium"
+                f_oflags="-O2 -mtune=native $memory_model"
                 f_dflags="-g -CB"
                 need_fool_optimizer=yes
                 break
@@ -1424,7 +1426,7 @@ else
   have_c_compiler=yes
 
   default_cflags="-O2"
-  if test ! "x$is_x86_64" = x; then default_cflags="-O2 -fPIC -mtune=native -mcmodel=medium"; fi
+  if test ! "x$is_x86_64" = x; then default_cflags="-O2 -fPIC -mtune=native $memory_model"; fi
   printf $format "Input C compiler flags to use: " >&2
   printf "[$default_cflags] " >&2
   read response

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -163,6 +163,12 @@ fi
 
 if test $create_config=yes; then
 
+memory_model="-mcmodel=medium"
+system_name=$(uname -s | sed ":/:_:g" | tr '[:upper:]' '[:lower:]')
+if test "x$system_name" = xdarwin; then
+    memory_model=""
+fi
+
 case $CXX in
 
     *g++*)
@@ -171,7 +177,7 @@ case $CXX in
     else
         std="c++11"
     fi
-    opt="-O2 -mtune=native -mcmodel=medium -std=$std";;# mingw32-g++ and g++4 also taken into account
+    opt="-O2 -mtune=native $memory_model -std=$std";;# mingw32-g++ and g++4 also taken into account
     icpc)  opt="-O2 -no-prec-div -fp-model fast=2";;
     icc)   opt="-O2 -no-prec-div -fp-model fast=2";;
     cl)    opt="-Ox -Ob2 -MD -GX -GR -nologo";;


### PR DESCRIPTION
Add tests in the configure scripts to avoid setting the gcc memory model flag `-mdmodel=medium` if a darwin (macOS) system is detected. This flag causes compilation failures at the linking stage.