### PR TITLE
Add some minor documentation about input loops

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -45,6 +45,8 @@
 <li> \ref common_rco </li>
 <li> \ref common_rng </li>
 <li> \ref common_mc </li>
+<li> \ref common_inputloops </li>
+<li> \ref common_example </li>
 </ul>
 
 \section common_intro Introduction
@@ -349,6 +351,11 @@ Default values may often only add time to your calculation. One can speed
 things up by turning them off. The user is referred to section 2.6
 of the PIRS-702 manual for a detailed description
 of these parameters.
+
+\section common_inputloops Input loops
+Sometimes it is necessary to repeat a geometry or other part of the input file, while just changing one parameter in a loop. If you are a programmer and comfortable with scripting (e.g. python), feel free to generate input files from a script - this is the most flexible and powerful method. However, there is a basic loop and variable replacement functionality built into egs++ input files, called \link EGS_InputLoopVariable <b><code>input loops</code></b>\endlink.
+
+For a complete description of input loops, see the documentation linked above.
 
 \section common_example A simple example
 Putting together the examples suggested above, we have a complete input file. Note that we are using default transport parameters. This input file will work with any egs++ application that doesn't require additional inputs. For example, it will work with \c tutor7pp.

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -607,10 +607,10 @@ Now one can have in the input file the following construct:
 Then, everything in the input loop block except for
 the definition of <b><em>loop count</em></b> and
 <b><em>loop variable</em></b> will be repeated
-<em>N</em> times, replacing all occurences of <em>\$(var1)</em>
+<em>N</em> times, replacing all occurrences of <em>\$(var1)</em>
 with <em>v1min+v1delta*i</em>,
 of <em>\$(var2)</em> with <em>v2min+v2delta*i</em> and of <em>\$(var3)</em>
-with <em>v3_1, v3_2 ... v3_N</em>.
+with <em>v3_1, v3_2 ... v3_N</em>. The index <em>i</em> runs from <em>0</em> to <em>N-1</em>.
 
 For real input variable (type 1), one can add a c style printf format string at the end of the
 loop variable input line to specify the format to use when replacing the variable with


### PR DESCRIPTION
This just adds some text referring to input loops on the `Common input syntax` documentation page for egs++. It also fixes a typo on the input loop page.