### PR TITLE
Fix logging of git hash and compile time for BEAMnrc

### DIFF
--- a/HEN_HOUSE/makefiles/beam_makefile
+++ b/HEN_HOUSE/makefiles/beam_makefile
@@ -93,8 +93,8 @@ EXE_DIR = $(EGS_HOME)bin$(DSEP)$(my_machine)
 $(EXE_FILE): $(FORTRAN_FILE).$(FEXT) $(EXE_DIR)
 	@echo $(empty)
 	@echo $(empty)
-	@echo "Fortran compiling $(FORTRAN_FILE).$(FEXT) using flags '$(FCFLAGS) $(OPTLEVEL_F)' and extra objects/libs '$(BEAM_EXTRA_OBJECTS) $(FLIBS)'"
-	@$(F77) $(FCFLAGS) $(OPTLEVEL_F) $(FOUT)$@ $(FORTRAN_FILE).$(FEXT) $(BEAM_EXTRA_OBJECTS) $(FLIBS)
+	@echo "Fortran compiling $(FORTRAN_FILE).$(FEXT) using flags '-cpp $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH)' and extra objects/libs '$(BEAM_EXTRA_OBJECTS) $(FLIBS)'"
+	@$(F77) -cpp $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(FOUT)$@ $(FORTRAN_FILE).$(FEXT) $(BEAM_EXTRA_OBJECTS) $(FLIBS)
 
 #$(LIB_FILE): $(LIB_FORTRAN_FILE).$(FEXT)
 #	@$(F77) $(FCFLAGS) $(OPTLEVEL_F)
@@ -117,10 +117,10 @@ $(FORTRAN_FILE).$(FEXT): $(SOURCES) sources.make
 library: $(LIB_FILE)
 
 $(LIB_FILE): $(LIB_FORTRAN_FILE).$(FOBJE)
-	$(F77_LINK) $(SHLIB_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FOBJE) $(BEAM_EXTRA_OBJECTS) $(FLIBS) $(SHLIB_LIBS)
+	$(F77_LINK) $(SHLIB_FLAGS) $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FOBJE) $(BEAM_EXTRA_OBJECTS) $(FLIBS) $(SHLIB_LIBS)
 
 $(LIB_FORTRAN_FILE).$(FOBJE): $(LIB_FORTRAN_FILE).$(FEXT)
-	$(F77) -c $(FCFLAGS) $(OPTLEVEL_F) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FEXT)
+	$(F77) -c $(FCFLAGS) $(OPTLEVEL_F) $(COMPILE_TIME) $(GIT_HASH) $(FOUT)$@ $(LIB_FORTRAN_FILE).$(FEXT)
 
 $(LIB_FORTRAN_FILE).$(FEXT): $(LIB_SOURCES) sources.make
 	@echo "Mortran compilation for $@"

--- a/HEN_HOUSE/specs/beamnrc.spec
+++ b/HEN_HOUSE/specs/beamnrc.spec
@@ -116,3 +116,21 @@ LIB_SOURCES = $(BEAM_HOME)beam_lib.macros \
           $(EGS_SOURCEDIR)egs_parallel.mortran \
           $(EGS_SOURCEDIR)pegs4_routines.mortran \
           $(EGS_SOURCEDIR)egsnrc.mortran
+
+# The git hash and branch
+GIT_HASH =
+ifeq ($(OS),Windows_NT)
+    USING_GIT = $(shell cmd /C git rev-parse --is-inside-work-tree)
+    ifeq ($(USING_GIT),true)
+        GIT_HASH = -DGIT_HASH="\"$(shell cmd /C git rev-parse --short=7 HEAD)\""
+    endif
+else
+    GIT_HASH = -DGIT_HASH="\"$(shell if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then git rev-parse --short=7 HEAD; fi)\""
+endif
+
+COMPILE_TIME =
+ifeq ($(OS),Windows_NT)
+    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T)$(shell cmd /C time /T) $(shell cmd /C tzutil /g)\""
+else
+    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell date -u +'%Y-%m-%d %H:%M:%S UTC')\""
+endif

--- a/HEN_HOUSE/src/egs_utilities.mortran
+++ b/HEN_HOUSE/src/egs_utilities.mortran
@@ -439,6 +439,7 @@ IF( pos2 < pos1+2 ) pos2 = pos1 + 2;
 $write_description('configuration'); $egs_info('(a)',$CONFIGURATION_NAME);
 $write_description('configuration time'); $egs_info('(a)',$CONFIG_TIME);
 $write_description('app compile time'); $egs_info('(a)',COMPILE_TIME);
+$write_description('git commit hash'); $egs_info('(a)',GIT_HASH);
 $write_description('application'); $egs_info('(a)',$cstring(user_code));
 $write_description('pegs file'); $egs_info('(a)',$cstring(tmp_string));
 $write_description('using host'); $egs_info('(a)',$cstring(host_name));


### PR DESCRIPTION
Fix compilation failure of BEAMnrc accelerators since the addition of git has logging and compile time logging in PR #414. 

This also adds back printing of the git hash, which was mistakenly removed in PR #898.
