### PR TITLE
Fix egs_cbct, egs_fac compilation and egs_cbct example

### DIFF
--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -1473,8 +1473,8 @@ void EGS_CBCT::initOutput() {
                 delete bs;
                 egsFatal(
                 "\n\n***  Wrong blank scan file size = %d bytes\n"
-                "     It should be %d bytes"
-                "     This is a fatal error.\n\n",
+                "     It should be %d bytes\n"
+                "     Check that the blank scan 'z-rotation' is set to 0\n\n",
                 fileSize,Nx*Ny*sizeof(float));
               }
               else{
@@ -3579,14 +3579,14 @@ do_interaction:
 }
 
 bool EGS_CBCT::checkVector(const EGS_Vector &v, const string & msg){
-if (isnan(v.x) || isnan(v.y)||isnan(v.z)){
+if (std::isnan(v.x) || std::isnan(v.y)||std::isnan(v.z)){
  egsWarning("%s \n "
           "=> NaN value: case = %d stack position = %d\n"
           "x = %g y = %g z = %g\n", msg.c_str(),current_case, the_stack->np-1,
            v.x, v.y, v.z);
  return false;
 }
-if (isinf(v.x)||isinf(v.y)||isinf(v.z)){
+if (std::isinf(v.x)||std::isinf(v.y)||std::isinf(v.z)){
  egsWarning("%s \n"
           "=> Infinite value in :\n case = %d stack position = %d\n"
           "x = %g y = %g z = %g\n", msg.c_str(), current_case, the_stack->np-1,

--- a/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
+++ b/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
@@ -159,7 +159,7 @@
 :start cbct setup:
         orbit = 360.0
         step  = -45
-        z-rotation = -90
+        z-rotation = 0
 :stop cbct setup:
 
 :start scoring options:

--- a/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
+++ b/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
@@ -246,8 +246,8 @@ int EGS_FACApplication::ausgab(int iarg) {
                 //    regions being CV.
                 EGS_Float dE = (the_stack->E[np]-the_epcont->edep-the_useful->rm)*
                                 the_stack->wt[np];
-                if( isnan(dE) || isnan(the_extra_stack->expmfp[np]) ||
-                    isinf(dE) || isinf(the_extra_stack->expmfp[np]) )
+                if( std::isnan(dE) || std::isnan(the_extra_stack->expmfp[np]) ||
+                    std::isinf(dE) || std::isinf(the_extra_stack->expmfp[np]) )
                     egsInformation("\nAdding a NaN in imbalance: %g %g\n",dE,the_extra_stack->expmfp[np]);
                 else sim[ig]->addEnergyImbalance(ir,irnew,the_extra_stack->expmfp[np],dE);
             }
@@ -261,7 +261,7 @@ int EGS_FACApplication::ausgab(int iarg) {
                             the_stack->wt[np],the_stack->iq[np],the_stack->latch[np],the_extra_stack->is_fat[np]);
                 }
             }
-            if( isnan(edep) || isinf(edep) )
+            if( std::isnan(edep) || std::isinf(edep) )
                 egsInformation("\nAdding a NaN in energy: %g %g\n",the_stack->wt[np],the_epcont->edep);
             else sim[ig]->addEnergyDeposition(ir,the_stack->latch[np],edep);
         }
@@ -433,7 +433,7 @@ void EGS_FACApplication::getCurrentResult(double &sum, double &sum2, double &nor
     count = current_case; double flu = source->getFluence();
     norm = flu > 0 ? 1.6022e-10*count/(flu*sim[0]->cmass) : 0;
     sum = sim[0]->dose[2]; sum2 = sim[0]->dose2[2];
-    if( isnan(sum) || isinf(sum) ) egsInformation("\nBad result? sum=%g sum2=%g\n",sum,sum2);
+    if( std::isnan(sum) || std::isinf(sum) ) egsInformation("\nBad result? sum=%g sum2=%g\n",sum,sum2);
 }
 
 void EGS_FACApplication::selectPhotonMFP(EGS_Float &dpmfp) {


### PR DESCRIPTION
Fix a compiler error that occurred with newer compiler settings due to ambiguous declaration of isinf and isnan, by adding `std::`.  

Also change the z-rotation parameter in the example input file to be 0 so that it calculates the first projection instead of a later projection. This avoids a common user error when trying to produce the blank scan for the first time, as reported here: https://www.reddit.com/r/EGSnrc/comments/z36841/query_fatal_error_message_egs_cbct_blank_scan/
