### PR TITLE
Fix #949: compiler errors of egs_mesh on mac

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.h
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.h
@@ -59,6 +59,7 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include <array>
 
 #include "egs_base_geometry.h"
 #include "egs_vector.h"


### PR DESCRIPTION
Fix a missing include of the `array` class library in egs_mesh.h. This avoids compiler errors that occurred on mac.