### PR TITLE
Fix #945, #804: egs_chamber examples don't run by default

### DIFF
--- a/HEN_HOUSE/user_codes/egs_chamber/example1_co60_Pfactors.egsinp
+++ b/HEN_HOUSE/user_codes/egs_chamber/example1_co60_Pfactors.egsinp
@@ -23,18 +23,25 @@
 #
 #  Author:          Iwan Kawrakow, 2009
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 #
-#  An example input file for egs_chamber.
+#  An example input file for egs_chamber. This is an advanced example.
 #
 #  This file defines an egs_chamber simulation of a farmer type chamber at
 #  5 cm depth in a 30x30x30 cm^3 water phantom irradiated by a Co-60 beam from
-#  a BEAMnrc simulation source. The XCSE technique is used combined with
+#  a BEAMnrc simulation source. The chamber model is just an example, and does
+#  not match any particular specifications.
+#
+#  The XCSE variance reduction technique is used combined with
 #  correlated sampling for calculation in chamber geometries that do not have
 #  a stem, a central electrode, a wall, etc., to compute the various
 #  correction factors known as Pstell, Pcell, Pwall, and Prepl.
+#
+#  Run this example using 521icru.pegs4dat:
+#
+#  egs_chamber -i example1_co60_Pfactors -p 521icru
 #
 ###############################################################################
 
@@ -55,48 +62,48 @@
             thickness = 0.0417
             top radii = 0.
             bottom radii = 0.0858
-            media = C173521ICRU
+            media = 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.1283
             top radii = 0. 0.0858
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.2217
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 2.05
             top radii = 0.050 0.3125 0.35
             bottom radii = 0.050 0.3125 0.35
-            media = AL521ICRU AIR521ICRU C173521ICRU
+            media = AL521ICRU AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.3
             top radii = 0.050 0.175 0.35 0.4000
             bottom radii = 0.050 0.175 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU
         :stop layer:
         :start layer:
             thickness = 1.005
             top radii = 0.050 0.175 0.35 0.4000
             bottom radii = 0.050 0.175 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU
         :stop layer:
         :start layer:
             thickness = 0.84
             top radii = 0.050 0.35 0.4000
             bottom radii = 0.050 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU
         :stop layer:
         :start layer:
             thickness = 1.655
             top radii = 0.0750 0.3500 0.4000
             bottom radii = 0.0750 0.3500 0.4000
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU
         :stop layer:
     :stop geometry:
 
@@ -110,24 +117,24 @@
             thickness = 0.0417
             top radii = 0.
             bottom radii = 0.0858
-            media = C173521ICRU
+            media = 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.1283
             top radii = 0. 0.0858
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.2217
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 2.05
             top radii = 0.050 0.3125 0.35
             bottom radii = 0.050 0.3125 0.35
-            media = AL521ICRU AIR521ICRU C173521ICRU
+            media = AL521ICRU AIR521ICRU 170C521ICRU
         :stop layer:
     :stop geometry:
 
@@ -143,24 +150,24 @@
             thickness = 0.0417
             top radii = 0.
             bottom radii = 0.0858
-            media = C173521ICRU
+            media = 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.1283
             top radii = 0. 0.0858
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 0.2217
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         :start layer:
             thickness = 2.05
             top radii = 0.050 0.3125 0.35
             bottom radii = 0.050 0.3125 0.35
-            media = AIR521ICRU AIR521ICRU C173521ICRU
+            media = AIR521ICRU AIR521ICRU 170C521ICRU
         :stop layer:
     :stop geometry:
 
@@ -350,15 +357,6 @@
         inscribed geometries = chamber
     :stop geometry:
     #
-    # Same but for phsp scoring
-    #
-    :start geometry:
-        library = egs_genvelope
-        name = chamber_in_water
-        base geometry = cse_phantom
-        inscribed geometries = chamber
-    :stop geometry:
-    #
     # Water phantom with chamber without stem
     #
     :start geometry:
@@ -423,18 +421,27 @@
 :stop geometry definition:
 
 ########################################### The source:
-#                                           a full BEAMnrc treatment head
-#                                           simulation
+# A Co-60 collimated spectrum source, for a 10x10cm2 field at the origin.
+# The source is 100cm from the surface of the water.
+# The chamber is at 5cm depth, at z=0.
 :start source definition:
 
     :start source:
-        library = egs_beam_source
         name    = the_source
-        beam code = BEAM_co60
-        pegs file = gmora
-        input file = 10x10_20000dsb_espl_augrr_delta1.5
-        particle type = all
-        weight window = 0 1e-4 # This discards fat particles.
+        library = egs_collimated_source
+        charge  = 0
+        :start source shape:
+            type = point
+            position = 0 0 -105.000
+        :stop source shape:
+        :start target shape:
+            library = egs_rectangle
+            rectangle = -5 -5 5 5
+        :stop target shape:
+        :start spectrum:
+            type = tabulated spectrum
+            spectrum file = $HEN_HOUSE/spectra/egsnrc/mora_10x10_60co_ssd80.ensrc
+        :stop spectrum:
     :stop source:
 
     simulation source = the_source
@@ -445,7 +452,7 @@
 #
 :start run control:
 
-    ncase = 2200000000
+    ncase = 1000000 # Increase this to reduce the uncertainty
 
 :stop run control:
 
@@ -469,17 +476,6 @@
         cavity geometry = inner_phsp_object
         enhance regions = -1 # i.e. enhance everywhere except in region 0
         enhancement = 512
-        #
-        # Note: the transformation specified below is applied to particle
-        # positions before checking if the particle enters the geometry.
-        # In the case of a BEAMnrc simulation source, the particle positions
-        # are the positions when the particles cross the scoring plane
-        # i.e. at (x,y,100) in this case. The top of this geometry is at
-        # z=-5 => we must translate the particle positions by -105.
-        #
-        :start transformation:
-            translation = 0 0 -105.0001
-        :stop transformation:
     :stop calculation geometry:
 
 # -------------------------------------- the actual calculation geometries

--- a/HEN_HOUSE/user_codes/egs_chamber/example1_profile_pfactors.egsinp
+++ b/HEN_HOUSE/user_codes/egs_chamber/example1_profile_pfactors.egsinp
@@ -23,16 +23,16 @@
 #
 #  Author:          Iwan Kawrakow, 2009
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 #
-#  An example input file for egs_chamber.
+#  An example input file for egs_chamber. This is an advanced example.
 #
-# This input file defines an egs_chamber simulation to compute the
-# perturbation factors Pwall and Pcell as a function of the off-axis distance
-# at 1.5 cm depth in a water phantom irradiated by a BEAMnrc simulation
-# source. A simple cylindrical model of the NE-2571 chamber is used.
+#  This input file defines an egs_chamber simulation to compute the
+#  perturbation factors Pwall and Pcell as a function of the off-axis distance
+#  at 1.5 cm depth in a water phantom irradiated by a 6MV spectrum
+#  source. A simple cylindrical model of the NE-2571 chamber is used.
 #
 ###############################################################################
 
@@ -43,7 +43,7 @@
     # The chamber
     # simple model of a NE2571 Farmer type chamber
     # modelled as a cone-stack.
-    # Overal chamber dimensions: 2.476 cm long,
+    # Overall chamber dimensions: 2.476 cm long,
     #                            0.358 cm radius
     #############################################
     :start geometry:
@@ -175,7 +175,7 @@
         library = egs_cylinders
         type = EGS_XCylinders
         name = cav_cyls0
-	midpoint = 0 0 1.5
+        midpoint = 0 0 1.5
         radii = .321
     :stop geometry:
     :start geometry:
@@ -200,14 +200,14 @@
         library = egs_cylinders
         type = EGS_XCylinders
         name = cse_cyls0
-	 midpoint = 0 0 1.5
+        midpoint = 0 0 1.5
         radii = 1.358
     :stop geometry:
     :start geometry:
         library = egs_ndgeometry
         name = cse_0
         dimensions = cse_planes cse_cyls0
-	:start media input:
+        :start media input:
             media = H2O521ICRU
         :stop media input:
     :stop geometry:
@@ -216,24 +216,24 @@
     # put the chambers into the CSE-geometry
     #############################################
     :start geometry:
-    	library = egs_genvelope
-	name = CHAMBER_0_
-	base geometry = cse_0
-	inscribed geometries = CHAMBER_0
+        library = egs_genvelope
+        name = CHAMBER_0_
+        base geometry = cse_0
+        inscribed geometries = CHAMBER_0
     :stop geometry:
 
     :start geometry:
-    	library = egs_genvelope
-	name = CHAMBER_noel_0_
-	base geometry = cse_0
-	inscribed geometries = CHAMBER_noel_0
+        library = egs_genvelope
+        name = CHAMBER_noel_0_
+        base geometry = cse_0
+        inscribed geometries = CHAMBER_noel_0
     :stop geometry:
 
     :start geometry:
-    	library = egs_genvelope
-	name = CHAMBER_nowall_0_
-	base geometry = cse_0
-	inscribed geometries = CHAMBER_nowall_0
+        library = egs_genvelope
+        name = CHAMBER_nowall_0_
+        base geometry = cse_0
+        inscribed geometries = CHAMBER_nowall_0
     :stop geometry:
 
     ######################################################
@@ -270,19 +270,20 @@
         #
         loop variable = 1 var1 0 1
 
-	 #
-	 # translate the chambers
-	 #
+        #
+        # translate the chambers
+        #
+
         # The full chamber geometry
         :start geometry:
             library = egs_gtransformed
             my geometry = CHAMBER_0_
             name = CHAMBER_$(var1)cm
-              # i.e., the name of the geometries created in the loop will be
-              # CHAMBER_0cm, CHAMBER_1cm, CHAMBER_2cm, ...
+            # i.e., the name of the geometries created in the loop will be
+            # CHAMBER_0cm, CHAMBER_1cm, CHAMBER_2cm, ...
             :start transformation:
                 translation = 0 $(var1) 0
-                  # i.e., translations by 0 cm, 1 cm, 2 cm, etc.
+                # i.e., translations by 0 cm, 1 cm, 2 cm, etc.
             :stop transformation:
         :stop geometry:
         # The chamber without a central electrode
@@ -364,71 +365,81 @@
 
 
     :start geometry:
-    	library = egs_ndgeometry
-	type = EGS_XYZGeometry
-	name = tmpPhsp_object0
-	x-planes = -1.3 1.3
-	y-planes = -0.4 21.4
-	z-planes = 1.1 1.9
-	:start media input:
+        library = egs_ndgeometry
+        type = EGS_XYZGeometry
+        name = tmpPhsp_object0
+        x-planes = -1.3 1.3
+        y-planes = -0.4 21.4
+        z-planes = 1.1 1.9
+        :start media input:
             media = H2O521ICRU
         :stop media input:
     :stop geometry:
 
     :start geometry:
-    	library = egs_ndgeometry
-	type = EGS_XYZGeometry
-	name = tmpPhsp_object1
-	x-planes = -2.3 2.3
-	y-planes = -1.4 22.4
-	z-planes = 0.1 2.9
-	:start media input:
+        library = egs_ndgeometry
+        type = EGS_XYZGeometry
+        name = tmpPhsp_object1
+        x-planes = -2.3 2.3
+        y-planes = -1.4 22.4
+        z-planes = 0.1 2.9
+        :start media input:
             media = H2O521ICRU
-      :stop media input:
+        :stop media input:
     :stop geometry:
 
     :start geometry:
-    	library = egs_genvelope
-	name = tmpPhsp_object
-	base geometry = tmpPhsp_object1
-	inscribed geometries = tmpPhsp_object0
+        library = egs_genvelope
+        name = tmpPhsp_object
+        base geometry = tmpPhsp_object1
+        inscribed geometries = tmpPhsp_object0
     :stop geometry:
 
     :start geometry:
-    	library = egs_genvelope
-	name = PhspObject_
-	base geometry = phantom
-	inscribed geometries = tmpPhsp_object
+        library = egs_genvelope
+        name = PhspObject_
+        base geometry = phantom
+        inscribed geometries = tmpPhsp_object
     :stop geometry:
 
     :start geometry:
-       	library  = egs_cdgeometry
-	name     = PhspObject
+           library  = egs_cdgeometry
+        name     = PhspObject
         base geometry = base_planes
-	set geometry  = 0 PhspObject_
+        set geometry  = 0 PhspObject_
     :stop geometry:
 
     simulation geometry = CHAMBER_IP_0cm
 
 :stop geometry definition:
 
+########################################### The source:
+# A 6MV collimated spectrum source, for a 10x10cm2 field at the origin.
+# The source is 100cm from the surface of the water.
+# The chamber is at 5cm depth, at z=0.
 :start source definition:
-########################################### define the source:
-#
-        :start source:
-                library = egs_beam_source
-                name    = the_beam_source
-                beam code = BEAM_Elekta_nrc2
-                pegs file = my700
-                input file = elekta_6MV_40x40
-                particle type = all
-                weight window = 0 0.01    # This discards fat particles.
-        :stop source:
 
-    simulation source = the_beam_source
+    :start source:
+        name    = the_source
+        library = egs_collimated_source
+        charge  = 0
+        :start source shape:
+            type = point
+            position = 0 0 -100.000
+        :stop source shape:
+        :start target shape:
+            library = egs_rectangle
+            rectangle = -5 -5 5 5
+        :stop target shape:
+        :start spectrum:
+            type = tabulated spectrum
+            spectrum file = $HEN_HOUSE/spectra/egsnrc/mohan6.spectrum
+        :stop spectrum:
+    :stop source:
+
+    simulation source = the_source
 
 :stop source definition:
-
 
 ##################################### Scoring options
 :start scoring options:
@@ -439,92 +450,93 @@
         geometry name = PhspObject
         cavity regions = 2
         cavity mass = 1
-	cavity geometry = tmpPhsp_object0
-	enhance regions = -1
-	enhancement = 128
-	:start transformation:
-            translation = 0 0 -100
-        :stop transformation:
+        cavity geometry = tmpPhsp_object0
+        enhance regions = -1
+        enhancement = 128
     :stop calculation geometry:
 # ----
    :start input loop:
-    	loop count = 25
-	loop variable = 1 var1 0 1
+        loop count = 25
+        loop variable = 1 var1 0 1
 
-	:start calculation geometry:
-        	geometry name = CHAMBER_IP_$(var1)cm
-	        cavity regions = 5 9
-	        cavity mass = 0.000910699084	# no elec: reg 8 0.00093012
-		cavity geometry = cav_$(var1)cm
-		enhance regions = -1
-		enhancement = 128
-	        subgeometries = CHAMBER_IP_$(var1)cm CHAMBER_noel_IP_$(var1)cm CHAMBER_nowall_IP_$(var1)cm
-	        subgeom regions = 2 6 5 8 9 10 11
+        :start calculation geometry:
+            geometry name = CHAMBER_IP_$(var1)cm
+            cavity regions = 5 9
+            cavity mass = 0.000910699084    # no elec: reg 8 0.00093012
+            cavity geometry = cav_$(var1)cm
+            enhance regions = -1
+            enhancement = 128
+            subgeometries = CHAMBER_IP_$(var1)cm CHAMBER_noel_IP_$(var1)cm CHAMBER_nowall_IP_$(var1)cm
+            subgeom regions = 2 6 5 8 9 10 11
         :stop calculation geometry:
 
-    	:start calculation geometry:
-        	geometry name = CHAMBER_noel_IP_$(var1)cm
-        	cavity regions = 5 8 9
-        	cavity mass = 0.00093012
-		cavity geometry = cav_$(var1)cm
-		enhance regions = -1
-		enhancement = 128
-    	:stop calculation geometry:
+        :start calculation geometry:
+            geometry name = CHAMBER_noel_IP_$(var1)cm
+            cavity regions = 5 8 9
+            cavity mass = 0.00093012
+            cavity geometry = cav_$(var1)cm
+            enhance regions = -1
+            enhancement = 128
+        :stop calculation geometry:
 
-    	:start calculation geometry:
-        	geometry name = CHAMBER_nowall_IP_$(var1)cm
-        	cavity regions = 5 8 9
-        	cavity mass = 0.00093012
-		cavity geometry = cav_$(var1)cm
-		enhance regions = -1
-		enhancement = 128
-    	:stop calculation geometry:
+        :start calculation geometry:
+            geometry name = CHAMBER_nowall_IP_$(var1)cm
+            cavity regions = 5 8 9
+            cavity mass = 0.00093012
+            cavity geometry = cav_$(var1)cm
+            enhance regions = -1
+            enhancement = 128
+        :stop calculation geometry:
    :stop input loop:
 
 
    :start input loop:
-    	loop count = 25
-	loop variable = 1 var1 0 1
-	correlated geometries = CHAMBER_IP_$(var1)cm CHAMBER_IP_0cm
+        loop count = 25
+        loop variable = 1 var1 0 1
+        correlated geometries = CHAMBER_IP_$(var1)cm CHAMBER_IP_0cm
    :stop input loop:
    :start input loop:
-    	loop count = 25
-	loop variable = 1 var1 0 1
-	correlated geometries = CHAMBER_noel_IP_$(var1)cm CHAMBER_IP_$(var1)cm
+        loop count = 25
+        loop variable = 1 var1 0 1
+        correlated geometries = CHAMBER_noel_IP_$(var1)cm CHAMBER_IP_$(var1)cm
    :stop input loop:
    :start input loop:
-    	loop count = 25
-	loop variable = 1 var1 0 1
-	correlated geometries = CHAMBER_nowall_IP_$(var1)cm CHAMBER_noel_IP_$(var1)cm
+        loop count = 25
+        loop variable = 1 var1 0 1
+        correlated geometries = CHAMBER_nowall_IP_$(var1)cm CHAMBER_noel_IP_$(var1)cm
    :stop input loop:
 
 :stop scoring options:
 
 ####################################### variance reduction
 :start variance reduction:
-    TmpPhsp = 1			#must be devider of cse's
-    #Photon splitting = 16
+    cs enhancement = 1
+    TmpPhsp = 1   # i.e., score phase space and use it once in each specified
+                  # geometry
+
     :start range rejection:
-        rejection = 256		#this must not be larger than largest enhancement and
-        Esave     = .521
-        cavity geometry = tmpPhsp_object0
+        # The 'rejection' must be larger than the largest enhancement factor,
+        # and it should be divisible by the enhancement factors
+        rejection = 256
+        Esave     = .521 # i.e. no range rejection but Russian Roulette
+        cavity geometry = tmpPhsp_object0 # since each geometry can have its own
+                                        # cavity geometry this is just a dummy
         rejection range medium = H2O521ICRU
     :stop range rejection:
-    cs enhancement = 1
+
 :stop variance reduction:
 
 ###################################### Transport parameters
 :start MC transport parameter:
-      # You can include here any of the transport parameter options
-      # understood by EGSnrc
-	#Global ECUT = 100
-	#Atomic relaxations = Off
-	#Rayleigh Scattering = Off
-	#Bound Compton Scattering = Off
+    # You can include here any of the transport parameter options
+    # understood by EGSnrc
+    #Global ECUT = 100
+    #Atomic relaxations = Off
+    #Rayleigh Scattering = Off
+    #Bound Compton Scattering = Off
 :stop MC transport parameter:
 
 ##################################### Run control
 :start run control:
-  ncase = 2400000000
-  calculation = first
+  ncase = 1000000 # Increase this to reduce the uncertainty
 :stop run control:

--- a/HEN_HOUSE/user_codes/egs_chamber/example2_chamber_dd.egsinp
+++ b/HEN_HOUSE/user_codes/egs_chamber/example2_chamber_dd.egsinp
@@ -23,20 +23,22 @@
 #
 #  Author:          Iwan Kawrakow, 2008
 #
-#  Contributors:
+#  Contributors:    Reid Townson
 #
 ###############################################################################
 #
-#  An example input file for egs_chamber.
+#  An example input file for egs_chamber. This is an advanced example.
 #
 #  This file defines an egs_chamber simulation of a farmer type chamber
 #  positioned at different depths in and above a 30x30x30 cm water phantom. A
-#  BEAMnrc simulation source is used as a particles source. The scoring plane
+#  collimated source is used as a particle source, though a BEAMnrc shared
+#  library source is also provided as an example. The scoring plane
 #  of the BEAMnrc simulation is just below the photon jaws at z=50 cm from the
 #  target, i.e., the air between the jaws and the water surface at z=100 cm is
-#  included in the egs_chamber simulation. The XCSE technique is used combined
-#  with phase-space scoring for particles entering a rectangular 'tube' that
-#  encloses all chamber locations.
+#  included in the egs_chamber simulation.
+#
+#  The XCSE technique is used combined with phase-space scoring for particles
+#  entering a rectangular 'tube' that encloses all chamber locations.
 #
 #  Instead of using a transformed geometry to position the chamber at
 #  different depths, the chamber location is held fixed at 0 cm depth and the
@@ -93,7 +95,7 @@
             thickness    = 0.0417
             top radii    = 0.     1.35
             bottom radii = 0.0858 1.35
-            media = C173521ICRU H2O521ICRU
+            media = 170C521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 10, 11, 12: chamber body + a XCSE region
@@ -102,7 +104,7 @@
             thickness    = 0.1283
             top radii    = 0. 0.0858 1.35
             bottom radii = 0.3125 0.35 1.35
-            media = AIR521ICRU C173521ICRU H2O521ICRU
+            media = AIR521ICRU 170C521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 15, 16, 17: chamber body + a XCSE region
@@ -110,7 +112,7 @@
         :start layer:
             thickness    = 0.2217
             bottom radii = 0.3125 0.35 1.35
-            media        = AIR521ICRU C173521ICRU H2O521ICRU
+            media        = AIR521ICRU 170C521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 20, 21, 22, 23
@@ -119,7 +121,7 @@
             thickness    = 2.05
             top radii    = 0.050 0.3125 0.35 1.35
             bottom radii = 0.050 0.3125 0.35 1.35
-            media = AL521ICRU AIR521ICRU C173521ICRU H2O521ICRU
+            media = AL521ICRU AIR521ICRU 170C521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 25, 26, 27, 28, 29
@@ -132,7 +134,7 @@
             thickness    = 1.0
             top radii    = 0.050 0.175 0.35 0.4000 1.35
             bottom radii = 0.050 0.175 0.35 0.4000 1.35
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU H2O521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 30, 31, 32, 33, 34
@@ -141,7 +143,7 @@
             thickness    = 0.305
             top radii    = 0.050 0.175 0.35 0.4000 1.35
             bottom radii = 0.050 0.175 0.35 0.4000 1.35
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU H2O521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 35, 36, 37, 38
@@ -150,7 +152,7 @@
             thickness = 0.84
             top radii    = 0.050 0.35 0.4000 1.35
             bottom radii = 0.050 0.35 0.4000 1.35
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU H2O521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU H2O521ICRU
         :stop layer:
         #
         # regions 40, 41, 42, 43
@@ -159,7 +161,7 @@
             thickness    = 1.655
             top radii    = 0.0750 0.3500 0.4000 1.35
             bottom radii = 0.0750 0.3500 0.4000 1.35
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU H2O521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU H2O521ICRU
         :stop layer:
     :stop geometry:
 
@@ -179,55 +181,55 @@
             thickness = 0.0417
             top radii = 0.
             bottom radii = 0.0858
-            media = C173521ICRU
+            media = 170C521ICRU
         :stop layer:
         # regions 4, 5
         :start layer:
             thickness = 0.1283
             top radii = 0. 0.0858
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         # regions 8, 9
         :start layer:
             thickness = 0.2217
             bottom radii = 0.3125 0.35
-            media = AIR521ICRU C173521ICRU
+            media = AIR521ICRU 170C521ICRU
         :stop layer:
         # regions 12, 13, 14
         :start layer:
             thickness = 2.05
             top radii = 0.050 0.3125 0.35
             bottom radii = 0.050 0.3125 0.35
-            media = AL521ICRU AIR521ICRU C173521ICRU
+            media = AL521ICRU AIR521ICRU 170C521ICRU
         :stop layer:
         # regions 16, 17, 18, 19
         :start layer:
             thickness = 1.0
             top radii = 0.050 0.175 0.35 0.4000
             bottom radii = 0.050 0.175 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU
         :stop layer:
         # regions 20, 21, 22, 23
         :start layer:
             thickness = 0.305
             top radii = 0.050 0.175 0.35 0.4000
             bottom radii = 0.050 0.175 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU C173521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU 170C521ICRU AL521ICRU
         :stop layer:
         # regions 24, 25, 26
         :start layer:
             thickness = 0.84
             top radii = 0.050 0.35 0.4000
             bottom radii = 0.050 0.35 0.4000
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU
         :stop layer:
         # regions 28, 29, 30
         :start layer:
             thickness = 1.655
             top radii = 0.0750 0.3500 0.4000
             bottom radii = 0.0750 0.3500 0.4000
-            media = AL521ICRU PTCFE521ICRU DURAL521ICRU
+            media = AL521ICRU POLYETH521ICRU AL521ICRU
         :stop layer:
     :stop geometry:
 
@@ -306,8 +308,8 @@
         library = egs_ndgeometry
         type    = EGS_XYZGeometry
         name    = air_slab
-        x-planes = -30  30
-        y-planes = -30  30
+        x-planes = -15  15
+        y-planes = -15  15
         z-planes = -1000  1000
         :start media input:
             media = AIR521ICRU
@@ -363,8 +365,8 @@
         library = egs_ndgeometry
         type    = EGS_XYZGeometry
         name    = water_slab
-        x-planes = -30  30
-        y-planes = -30  30
+        x-planes = -15  15
+        y-planes = -15  15
         z-planes = -1000 1000
         :start media input:
             media = H2O521ICRU
@@ -598,19 +600,34 @@
 :stop geometry definition:
 
 ########################################### The source:
-#                                           a full BEAMnrc treatment head
-#                                           simulation
+# A parallel photon beam, 6MeV
+# or
+# A full BEAMnrc treatment head simulation
 :start source definition:
 
-    #:start source:
-    #    library = egs_beam_source
-    #    name    = the_source
-    #    beam code = BEAM_EX16MVp
-    #    pegs file = 700icru
-    #    input file = test
-    #    particle type = all
-    #    weight window = 0 0.1 # This discards fat particles.
-    #:stop source:
+    # A BEAMnrc shared library source
+    # This source option is commented out by default, since it requires an
+    # extra step. To compile the BEAMnrc accelerator as a shared library
+    # so that it can be used as a source, navigate to the accelerator directory
+    # on a terminal (e.g. on linux "cd $EGS_HOME/BEAM_EX16MVp")
+    # Then compile the accelerator as a shared library using "make library".
+    # Note that on Windows, the make command may be different
+    # (e.g. on windows "mingw32-make library")
+#     :start source:
+#        library = egs_beam_source
+#        name    = the_source
+#        beam code = BEAM_EX16MVp
+#        pegs file = 700icru
+#        input file = EX16MVp
+#        particle type = all
+#        weight window = 0 0.1 # This discards fat particles.
+#     :stop source:
+
+    # A parallel 10x10cm2 photon beam
+    # Note that this is defined at the origin (z=0), instead of at z=50 like the
+    # scoring plane in the BEAMnrc simulation, so we shift by 50 to line it up.
+    # In any case, this is just an example, and we don't expect the results
+    # to match the BEAMnrc source.
     :start source:
         library = egs_parallel_beam
         name    = the_source
@@ -636,7 +653,7 @@
 #
 :start run control:
 
-    ncase = 5000000
+    ncase = 100000 # Increase this to reduce the uncertainty
 
 :stop run control:
 
@@ -836,10 +853,12 @@
     TmpPhsp = 1   # i.e., score phase space and use it once in each specified
                   # geometry
     :start range rejection:
+        # The 'rejection' must be larger than the largest enhancement factor,
+        # and it should be divisible by the enhancement factors
         rejection = 512
         Esave     = 0.521 # i.e. no range rejection but Russian Roulette
         cavity geometry = cavity # since each geometry can have its own
-                                      # cavity geometry this is just a dummy
+                                 # cavity geometry this is just a dummy
         rejection range medium = H2O521ICRU
     :stop range rejection:
 :stop variance reduction:


### PR DESCRIPTION
Fix the egs_chamber examples so that they now run without needing to compile any BEAMnrc accelerators or make changes to the input file. Also fix a typo in the example2 water box size.