### PR TITLE
Fix compilation on windows for some time zones, add lquadmath

### DIFF
--- a/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_tools.cpp
@@ -769,7 +769,7 @@ EGS_DSO::EGS_DSO(const QString &cpp_name){
 #elif defined(Q_OS_LINUX) || defined(Q_OS_UNIX)
    fpic = is_x86_64() ? "-fPIC" : QString();
 #endif
-   flibs = cpp_name.contains("g++") ? "-lgfortran" : QString();
+   flibs = cpp_name.contains("g++") ? "-lgfortran -lquadmath" : QString();
 }
 
 // Initialize default GCC compiler as gfortran
@@ -1007,7 +1007,7 @@ QString MCompiler::getFlibs2LinkCPP( const QString &f_name, const QString &a_pat
     if ( f_name.contains("g77") && name().contains("g++"))
         flibs= QString("-lg2c");
     else if ( f_name.contains("gfortran") && name().contains("g++"))
-        flibs= QString("-lgfortran");
+        flibs= QString("-lgfortran -lquadmath");
     else if ( f_name.contains("ifort") && name().contains("icpc"))
         flibs= QString("-lifport -lifcore");
     else{// using any other C++/Fortran compiler combination
@@ -1020,7 +1020,7 @@ QString MCompiler::getFlibs2LinkCPP( const QString &f_name, const QString &a_pat
 #else
   // Setting an initial guess
   if      ( f_name.contains("gfortran") && name().contains("g++") )
-          flibs="-lgfortran";
+          flibs="-lgfortran -lquadmath";
   else if ( f_name.contains("g77") )
           flibs="-lg2c";
   else if ( f_name.contains("ifort") && name().contains("icpc"))

--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -1813,7 +1813,7 @@ if test x$F77 = xg77 || test x$F77 = xgfortran; then
             if test x$F77 = xg77; then
                 SHLIB_LIBS="-lg2c"
             else
-                SHLIB_LIBS="-lgfortran"
+                SHLIB_LIBS="-lgfortran -lquadmath"
             fi
             printf $format "An OS X system with $F77 and $CC ... " >&2
             echo "using $SHLIB_FLAGS and $SHLIB_LIBS to build shared libraries" >&2

--- a/HEN_HOUSE/specs/all_common.spec
+++ b/HEN_HOUSE/specs/all_common.spec
@@ -142,7 +142,7 @@ endif
 
 COMPILE_TIME =
 ifeq ($(OS),Windows_NT)
-    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T)$(shell cmd /C time /T) $(shell cmd /C tzutil /g)\""
+    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T) $(shell cmd /C time /T)\""
 else
     COMPILE_TIME = -DCOMPILE_TIME="\"$(shell date -u +'%Y-%m-%d %H:%M:%S UTC')\""
 endif

--- a/HEN_HOUSE/specs/all_common.spec
+++ b/HEN_HOUSE/specs/all_common.spec
@@ -132,9 +132,11 @@ FEXT = f
 # The git hash and branch
 GIT_HASH =
 ifeq ($(OS),Windows_NT)
-    USING_GIT = $(shell cmd /C git rev-parse --is-inside-work-tree)
+    USING_GIT = $(shell cmd /C @ECHO OFF & git rev-parse --is-inside-work-tree 2>NUL)
     ifeq ($(USING_GIT),true)
         GIT_HASH = -DGIT_HASH="\"$(shell cmd /C git rev-parse --short=7 HEAD)\""
+    else
+        GIT_HASH = -DGIT_HASH="\"unknown\""
     endif
 else
     GIT_HASH = -DGIT_HASH="\"$(shell if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then git rev-parse --short=7 HEAD; fi)\""

--- a/HEN_HOUSE/specs/beamnrc.spec
+++ b/HEN_HOUSE/specs/beamnrc.spec
@@ -120,9 +120,11 @@ LIB_SOURCES = $(BEAM_HOME)beam_lib.macros \
 # The git hash and branch
 GIT_HASH =
 ifeq ($(OS),Windows_NT)
-    USING_GIT = $(shell cmd /C git rev-parse --is-inside-work-tree)
+    USING_GIT = $(shell cmd /C @ECHO OFF & git rev-parse --is-inside-work-tree 2>NUL)
     ifeq ($(USING_GIT),true)
         GIT_HASH = -DGIT_HASH="\"$(shell cmd /C git rev-parse --short=7 HEAD)\""
+    else
+        GIT_HASH = -DGIT_HASH="\"unknown\""
     endif
 else
     GIT_HASH = -DGIT_HASH="\"$(shell if git rev-parse --is-inside-work-tree > /dev/null 2>&1; then git rev-parse --short=7 HEAD; fi)\""

--- a/HEN_HOUSE/specs/beamnrc.spec
+++ b/HEN_HOUSE/specs/beamnrc.spec
@@ -130,7 +130,7 @@ endif
 
 COMPILE_TIME =
 ifeq ($(OS),Windows_NT)
-    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T)$(shell cmd /C time /T) $(shell cmd /C tzutil /g)\""
+    COMPILE_TIME = -DCOMPILE_TIME="\"$(shell cmd /C date /T)$(shell cmd /C time /T)\""
 else
     COMPILE_TIME = -DCOMPILE_TIME="\"$(shell date -u +'%Y-%m-%d %H:%M:%S UTC')\""
 endif


### PR DESCRIPTION
1. Fix a bug where applications would fail to compile on windows in locations where the time zone was a long string. This was due to the COMPILE_TIME flag that included some text about the time zone. To fix the issue, the time zone was removed from the variable and output.

2. Fix an issue where lquadmath was not included with lgfortran, and the compiler would fail on some systems. 

3. Fix a compiler error that occurred when the user had installed git, but then installed EGSnrc using the zip file. Users would see an error about GIT_HASH not being defined in this case.

4. Fix a minor warning that was printed about it not being a git repository.

@ftessier please check that the lquadmath changes don't cause any issues on OS X. I recommend that we cherry pick these fixes into v2023.