### PR TITLE
Fix radiative splitting AO

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -257,10 +257,11 @@ void EGS_DoseScoring::setApplication(EGS_Application *App) {
         description += " - Medium dose will be calculated\n";
     }
     description += "\n--------------------------------------\n";
-    sprintf(buf,"%*s  rho (g/cm^3)\n",max_medl,"medium");
+    sprintf(buf,"%*s %*s rho/(g/cm^3)\n",max_medl/2,"medium",max_medl/2," ");
     description += buf;
     description += "--------------------------------------\n";
     for (imed=0; imed < nmedia; imed++) {
+        sprintf(buf,"%-*s",max_medl,app->getMediumName(imed));
         description += buf;
         description += "  ";
         sprintf(buf,"%11.8f",app->getMediumRho(imed));
@@ -638,7 +639,7 @@ extern "C" {
         // Check if one volume for each group requested.
         // If not just pass the volumes read and if there
         // is a mismatch, then the first volume element
-        // or 1g/cm3 will be used.
+        // or 1 g/cm3 will be used.
         //=================================================
         vector <EGS_Float> volin;
         // groups of regions with same volume

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -200,7 +200,7 @@ protected:
 
     /* Regions flags */
     vector<bool> is_sensitive;     // flag scoring regions
-    vector<bool> is_source;        // Flag regions such as brems target or radiactive source
+    vector<bool> is_source;        // Flag regions such as brems target or radioactive source
     // Interacting particles not subjected to classification
     vector <int> f_start, f_stop;  // Markers for group regions input
     vector <int> f_region;         // Input list of scoring regions

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
@@ -67,15 +67,31 @@ void EGS_RadiativeSplitting::setApplication(EGS_Application *App) {
 
     char buf[32];
 
-    // Set EGSnrc internal radiative splitting number .
-    app->setRadiativeSplitting(nsplit);
-
+    // Set EGSnrc internal UBS + RR
+    if ( i_play_RR ){
+       app->setRussianRoulette(nsplit);
+      i_play_RR = true;
+    }
+    // Set EGSnrc internal radiative splitting number.
+    else if ( nsplit > 0 ){
+       app->setRadiativeSplitting(nsplit);
+       i_play_RR = false;
+    }
+      
     description = "\n===========================================\n";
     description +=  "Radiative splitting Object (";
     description += name;
     description += ")\n";
     description += "===========================================\n";
-    if (nsplit > 1) {
+    if ( i_play_RR ){
+        description +="\n - Splitting radiative events in ";
+        sprintf(buf,"%d",nsplit);
+        description += buf;
+        description +="\n - Play RR with higher order e-/e+ with probability 1/";
+        sprintf(buf,"%d\n\n",nsplit);
+        description += buf;
+    }
+    else if (nsplit > 1) {
         description +="\n - Splitting radiative events in ";
         sprintf(buf,"%d\n\n",nsplit);
         description += buf;
@@ -104,6 +120,7 @@ extern "C" {
         }
 
         EGS_Float nsplit = 1.0;
+        /*! Switch for splitting + RR. Negative nsplit value switches OFF RR. */
         int err = input->getInput("splitting",nsplit);
 
         //=================================================

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
@@ -106,21 +106,71 @@ public:
     ~EGS_RadiativeSplitting();
 
     void setApplication(EGS_Application *App);
-
+    /*! Switch for splitting + RR. Negative nsplit value switches OFF RR. */
     void setSplitting(const int &n_s) {
         nsplit = n_s;
+       if ( nsplit < 0 ){
+          nsplit *= -1;
+          i_play_RR = false;
+       }
+       else if ( nsplit > 1 ){
+          i_play_RR = true;
+       }
+       /* Avoid zero division. A zero value turns off brems */
+       wthin = nsplit ? 1./nsplit : 1.0;
+    };
+
+    bool needsCall(EGS_Application::AusgabCall iarg) const {
+        if (
+             iarg == EGS_Application::BeforeBrems       ||
+             iarg == EGS_Application::BeforeAnnihFlight ||
+             iarg == EGS_Application::BeforeAnnihRest   ||
+             iarg == EGS_Application::AfterBrems        ||
+             iarg == EGS_Application::AfterAnnihFlight  ||
+             iarg == EGS_Application::AfterAnnihRest    ||
+             iarg == EGS_Application::FluorescentEvent  ){
+            return true;
+        }
+        else {
+            return false;
+        }
     };
 
     int processEvent(EGS_Application::AusgabCall iarg) {
-        return 0;
-    };
-    int processEvent(EGS_Application::AusgabCall iarg, int ir) {
+
+        /* A fat particle's weight is larger than a thin particle's max weight */
+        bool is_phat = (app->top_p.wt - wthin) > epsilon;
+        bool is_primary = app->top_p.latch == 0 ? true : false;
+
+        /* Split primary and fat electrons */
+        if ( iarg == EGS_Application::BeforeBrems && (is_primary || is_phat) ){
+           app->setRadiativeSplitting(nsplit);
+        }
+        else if ( iarg == EGS_Application::AfterBrems ){
+           app->setRadiativeSplitting(1);
+           app->setLatch(app->getNpOld()+1,1);
+        }
+       /* Fluorescent photons created by charged particles surviving RR
+          when radiative splitting ON should be split to avoid having heavy photons.
+          This should happen in EGSnrc, but it is not implemented yet, so do it here!
+          Note that when this is implemented in EGSnrc, the weight check will make sure
+          photons aren't split again!
+       */
+        if (iarg == EGS_Application::FluorescentEvent && is_phat && nsplit > 1 ){
+           app->splitTopParticleIsotropically(nsplit);
+        }
+
+
         return 0;
     };
 
 protected:
-    /* Maximum splitting limited to 2,147,483,647 */
+    /* Max weight of thin particles */
+    EGS_Float wthin;
+    /* Maximum splitting limited to 2,147,483,647. Negative value switches OFF RR. */
     int nsplit;
+    /* Switch for Russian Roulette */
+    bool i_play_RR;
 
 };
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.h
@@ -142,11 +142,17 @@ public:
         bool is_phat = (app->top_p.wt - wthin) > epsilon;
         bool is_primary = app->top_p.latch == 0 ? true : false;
 
-        /* Split primary and fat electrons */
-        if ( iarg == EGS_Application::BeforeBrems && (is_primary || is_phat) ){
+        /* Split radiative events ONLY for primary and fat electrons */
+        if ( iarg == EGS_Application::BeforeBrems       ||
+             iarg == EGS_Application::BeforeAnnihFlight ||
+             iarg == EGS_Application::BeforeAnnihRest   && 
+             (is_primary || is_phat)                    ){
            app->setRadiativeSplitting(nsplit);
         }
-        else if ( iarg == EGS_Application::AfterBrems ){
+        /* Avoids higher order splitting of radiative events */        
+        else if ( iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest   ){
            app->setRadiativeSplitting(1);
            app->setLatch(app->getNpOld()+1,1);
         }

--- a/HEN_HOUSE/egs++/egs_advanced_application.cpp
+++ b/HEN_HOUSE/egs++/egs_advanced_application.cpp
@@ -1213,9 +1213,79 @@ EGS_Float EGS_AdvancedApplication::getPcut() {
 EGS_Float EGS_AdvancedApplication::getRM() {
     return the_useful->rm;
 }
-// Turns ON/OFF radiative splitting
+
+//************************************************************
+// Utility functions for fluence scoring objects
+//************************************************************
+
+// Turns ON/OFF EGSnrc internal radiative splitting (UBS)
 void EGS_AdvancedApplication::setRadiativeSplitting(const EGS_Float &nsplit) {
     the_egsvr->nbr_split = nsplit;
+}
+
+// Turns ON/OFF EGSnrc internal Russian Roulette + UBS
+void EGS_AdvancedApplication::setRussianRoulette(const EGS_Float &iSwitchRR) {
+    if ( iSwitchRR > 1.0){
+       the_egsvr->i_play_RR = 1;
+       the_egsvr->prob_RR = 1.0/iSwitchRR;
+       the_egsvr->nbr_split = iSwitchRR;
+    }
+    else{
+       the_egsvr->i_play_RR = 0;
+       the_egsvr->nbr_split = 1;
+    }
+}
+
+// Splits top particle into nsplit particles uniformly in 4Pi
+void EGS_AdvancedApplication::splitTopParticleIsotropically(const EGS_Float &fsplit){
+     // Reset particle pointer
+     the_stack->npold = the_stack->np;
+     /* Initialize local variables */
+     int np = the_stack->np-1,
+         the_latch = the_stack->latch[np],
+         ir = the_stack->ir[np],
+         iq = the_stack->iq[np];
+     the_stack->wt[np] /= fsplit; double E = the_stack->E[np];
+     EGS_Float x = the_stack->x[np], y = the_stack->y[np], z = the_stack->z[np],
+               wthin = the_stack->wt[np], dnear = the_stack->dnear[np];
+     EGS_Float u,v,w;
+    /* If fsplit is a non-integer, sample between int(fsplit) and int(split)+1 */
+     int nsplit = int(fsplit); EGS_Float dsplit = fsplit - nsplit;
+     if ( dsplit > 0 ){// non-integer splitting number
+          if( rndm->getUniform() < dsplit ) ++nsplit;
+     }
+     for( int i=0; i < nsplit; i++ ){
+             np++;
+             if( np >= MXSTACK ){
+                 egsFatal("\n\n******************************************\n"
+                        "ERROR: In EGS_AdvancedApplication::splitTopParticleIsotropically() :\n"
+                         "max. stack depth MXSTACK=%d < np=%d\n"
+                         "Stack overflow due to splitting!\n"
+                         "******************************************\n"
+                         ,MXSTACK,np);
+             }
+             the_stack->x[np] = x; the_stack->y[np] = y; the_stack->z[np] = z;
+             the_stack->iq[np]= iq; the_stack->dnear[np] = dnear; the_stack->latch[np] = the_latch;
+             the_stack->ir[np]= ir; the_stack->E[np] = E; the_stack->wt[np]=wthin;
+             // Particles isotropically distributed in space
+             w = 2*rndm->getUniform()-1;
+             EGS_Float sinz = 1-w*w;
+             if (sinz > epsilon) {
+                sinz = sqrt(sinz);
+                EGS_Float cphi, sphi;
+                EGS_Float phi = 2*M_PI*rndm->getUniform();
+                cphi = cos(phi); sphi = sin(phi);
+               u = sinz*cphi; v = sinz*sphi;
+             }
+             else {
+                 u = 0; v = 0;
+             }
+
+             the_stack->u[np] = u; the_stack->v[np] = v; the_stack->w[np] = w;
+
+     }
+
+     the_stack->np = np+1;
 }
 
 //************************************************************

--- a/HEN_HOUSE/egs++/egs_advanced_application.h
+++ b/HEN_HOUSE/egs++/egs_advanced_application.h
@@ -229,8 +229,16 @@ public:
 
     /* Needed by some sources */
     EGS_Float getRM();
-    /* Turn ON/OFF radiative splitting */
-    void setRadiativeSplitting(const EGS_Float &nsplit);
+
+    //************************************************
+    // For use with ausgab radiative splitting objects
+    //************************************************
+
+    /* Turn ON/OFF EGSnrc internal radiative splitting (UBS) */
+    void setRadiativeSplitting( const EGS_Float &nsplit );
+    /* Turn ON/OFF EGSnrc internal Russian Roultette + UBS */
+    void setRussianRoulette( const EGS_Float &iSwitchRR );
+    void splitTopParticleIsotropically( const EGS_Float &fsplit );
 
 protected:
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -1148,7 +1148,13 @@ public:
     virtual EGS_Float getRM() {
         return -1.0;
     };
+
+    //************************************************
+    // For use with ausgab radiative splitting objects
+    //************************************************
     virtual void setRadiativeSplitting(const EGS_Float &nsplit) {};
+    virtual void setRussianRoulette(const EGS_Float &iSwitchRR) {};
+    virtual void splitTopParticleIsotropically(const EGS_Float &fsplit){}
 
     //************************************************************
     // Utility functions for use with ausgab fluence scoring objects

--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -1473,8 +1473,8 @@ void EGS_CBCT::initOutput() {
                 delete bs;
                 egsFatal(
                 "\n\n***  Wrong blank scan file size = %d bytes\n"
-                "     It should be %d bytes"
-                "     This is a fatal error.\n\n",
+                "     It should be %d bytes\n"
+                "     Check that the blank scan 'z-rotation' is set to 0\n\n",
                 fileSize,Nx*Ny*sizeof(float));
               }
               else{
@@ -3579,14 +3579,14 @@ do_interaction:
 }
 
 bool EGS_CBCT::checkVector(const EGS_Vector &v, const string & msg){
-if (isnan(v.x) || isnan(v.y)||isnan(v.z)){
+if (std::isnan(v.x) || std::isnan(v.y)||std::isnan(v.z)){
  egsWarning("%s \n "
           "=> NaN value: case = %d stack position = %d\n"
           "x = %g y = %g z = %g\n", msg.c_str(),current_case, the_stack->np-1,
            v.x, v.y, v.z);
  return false;
 }
-if (isinf(v.x)||isinf(v.y)||isinf(v.z)){
+if (std::isinf(v.x)||std::isinf(v.y)||std::isinf(v.z)){
  egsWarning("%s \n"
           "=> Infinite value in :\n case = %d stack position = %d\n"
           "x = %g y = %g z = %g\n", msg.c_str(), current_case, the_stack->np-1,

--- a/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
+++ b/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
@@ -159,7 +159,7 @@
 :start cbct setup:
         orbit = 360.0
         step  = -45
-        z-rotation = -90
+        z-rotation = 0
 :stop cbct setup:
 
 :start scoring options:

--- a/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
+++ b/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
@@ -246,8 +246,8 @@ int EGS_FACApplication::ausgab(int iarg) {
                 //    regions being CV.
                 EGS_Float dE = (the_stack->E[np]-the_epcont->edep-the_useful->rm)*
                                 the_stack->wt[np];
-                if( isnan(dE) || isnan(the_extra_stack->expmfp[np]) ||
-                    isinf(dE) || isinf(the_extra_stack->expmfp[np]) )
+                if( std::isnan(dE) || std::isnan(the_extra_stack->expmfp[np]) ||
+                    std::isinf(dE) || std::isinf(the_extra_stack->expmfp[np]) )
                     egsInformation("\nAdding a NaN in imbalance: %g %g\n",dE,the_extra_stack->expmfp[np]);
                 else sim[ig]->addEnergyImbalance(ir,irnew,the_extra_stack->expmfp[np],dE);
             }
@@ -261,7 +261,7 @@ int EGS_FACApplication::ausgab(int iarg) {
                             the_stack->wt[np],the_stack->iq[np],the_stack->latch[np],the_extra_stack->is_fat[np]);
                 }
             }
-            if( isnan(edep) || isinf(edep) )
+            if( std::isnan(edep) || std::isinf(edep) )
                 egsInformation("\nAdding a NaN in energy: %g %g\n",the_stack->wt[np],the_epcont->edep);
             else sim[ig]->addEnergyDeposition(ir,the_stack->latch[np],edep);
         }
@@ -433,7 +433,7 @@ void EGS_FACApplication::getCurrentResult(double &sum, double &sum2, double &nor
     count = current_case; double flu = source->getFluence();
     norm = flu > 0 ? 1.6022e-10*count/(flu*sim[0]->cmass) : 0;
     sum = sim[0]->dose[2]; sum2 = sim[0]->dose2[2];
-    if( isnan(sum) || isinf(sum) ) egsInformation("\nBad result? sum=%g sum2=%g\n",sum,sum2);
+    if( std::isnan(sum) || std::isinf(sum) ) egsInformation("\nBad result? sum=%g sum2=%g\n",sum,sum2);
 }
 
 void EGS_FACApplication::selectPhotonMFP(EGS_Float &dpmfp) {


### PR DESCRIPTION
Initial radiative splitting implementation naively just turned ON EGSnrc internal flag `nbr_split` to split brems and annihilation events uniformly. However no charged particle RR was played after pair production (`i_play_RR`) nor were secondary photons, produced by charged particles surviving RR after bremsstrahlung, split.

Implement radiative splitting + RR
--------------------------------------
- Now turned ON before a radiative event for a primary or a fat charged particle. 
  Turned OFF after the event to avoid higher order splitting. Fluorescent fat photons, 
  generated by fat charged particles (survived RR) are also split.

- RR is turned ON using EGSnrc internal flag `i_play_RR` so that RR is played after pair events. 
  RR can be turned OFF by entering a negative splitting number. 

**NOTE2:** Brems events play RR intrinsically hence it can't be turned OFF.
           Setting `i_play_RR` affects pair production ONLY.

Other minor changes:
------------------------
- Last commit to `egs_dose_scoring.cpp` removed the statement printing media names during dose output to the screen for dose to medium calculations. I have re-added the line.
- First commit to `egs_dose_scoring.cpp` changed the header formatting when outputting media doses which misaligned it.