### PR TITLE
Fix #1018: Number of brems events miscounted for DBS in BEAMnrc

### DIFF
--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -6423,7 +6423,7 @@ ELSEIF(IBRSPL=2) ["directional bremsstrahlung splitting"
          ]
        ]
 
-       IF(IARG=6) NUM_BREM=NUM_BREM+nbr_split;
+       NUM_BREM=count_nbrem;
 
        " now put a zero weight particle on top of the stack thus forcing "
        " a return to shower. "

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -6422,6 +6422,9 @@ ELSEIF(IBRSPL=2) ["directional bremsstrahlung splitting"
            ZLAST(I)=Z(I);
          ]
        ]
+
+       IF(IARG=6) NUM_BREM=NUM_BREM+nbr_split;
+
        " now put a zero weight particle on top of the stack thus forcing "
        " a return to shower. "
        np=np+1;


### PR DESCRIPTION
Fix the output message in the egslst file for BEAMnrc simulations about the number of brems events the took place. When DBS was turned on, it would always read zero.

Just to be clear, there was nothing wrong with the splitting or the simulation. This is just a small bug in the counter variable that is only used to print to the egslst file.

@blakewalters please double check this change.