### PR TITLE
Fix egs xyzrepeater bug

### DIFF
--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -1866,7 +1866,7 @@ public:
                         for (int iiz=iz-1; iiz<=iz+1; ++iiz) {
                             if (iiz >= 0 && iiz < nz) {
                                 if (iix != ix || iiy != iy || iiz != iz) {
-                                    int cell1 = iix+iiy*nx+iiz*nz;
+                                    int cell1 = iix+iiy*nx+iiz*nxy;
                                     EGS_Vector tmp(x-translation[cell1]);
                                     EGS_Float t1 = g->hownear(-1,tmp);
                                     if (t1 < t) {


### PR DESCRIPTION
    Fix bug in EGS_XYZRepeater hownear
    
    - Typo in hownear when particle in bounding box determining which of
      the repeated geometries to check:
    
      Using nz rather than nxy when computing index of repeated geometry array
      results in addressing array index out of bounds with subsequent segfault error.
    
      Showed when eletron transport turned ON up during dose calculations around
      a CivaDot source using egs_dose_scoring and egs_app and 2 microns regions.
    
      It did not affect photon-only nor egs_kerma calculations since there is no
      call to hownear. ;-)
