### PR TITLE
Fix egs_circle_perpendicular critical bug

### DIFF
--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.h
@@ -149,9 +149,8 @@ public:
         EGS_Float angleBetween = std::acos(u * perpToCircle / (perpToCircle.length() * u.length()));
 
         // We will rotate about a vector perpendicular to u and the target surface normal
-        // Check against fabs(u.z) to account for both parallel and anti-parallel cases
         EGS_Vector rotateAbout;
-        if ((fabs(u.z) - perpToCircle.z) < epsilon) {
+        if (fabs(fabs(u.z) - perpToCircle.z) < epsilon) {
             rotateAbout = perpToCircle;
         }
         else {


### PR DESCRIPTION
Fix a bug in `egs_circle_perpendicular` that made the geometry invalid for any cases where the circle was expected to face away from the z-axis. Anyone who used this geometry should check their results.

This bug persisted because testing was done on a version where a similar fix had been done, but never included in the distribution. 

Example that incorrectly produced a line target instead of a circle:
```
   :start source:
     library = egs_collimated_source
     name = isotropic_collimated_source
     :start source shape:
       type = point
       position =  900 0.000000 0.000000
     :stop source shape:
     :start target shape:
       library = egs_circle_perpendicular
       midpoint = 0 0
       radius = 25
     :stop target shape:
     charge = 0
     :start spectrum:
      type = monoenergetic
      energy = 2
     :stop spectrum:
   :stop source:
```