### PR TITLE
Add support for Linux aarch64 architecture (ARM)

### DIFF
--- a/HEN_HOUSE/scripts/config.guess
+++ b/HEN_HOUSE/scripts/config.guess
@@ -830,6 +830,9 @@ EOF
     sparc:Linux:*:* | sparc64:Linux:*:*)
 	echo ${UNAME_MACHINE}-unknown-linux-gnu
 	exit 0 ;;
+	aarch64:Linux:*:*)
+	echo aarch64-unknown-linux-gnu
+	exit 0 ;;
     x86_64:Linux:*:*)
 	echo x86_64-unknown-linux-gnu
 	exit 0 ;;

--- a/HEN_HOUSE/scripts/configure
+++ b/HEN_HOUSE/scripts/configure
@@ -135,6 +135,9 @@ if test "x$system_name" = xdarwin; then
 fi
 echo "$canonical_system" >&2
 is_x86_64=$(echo $canonical_system | grep x86_64)
+if echo "$canonical_system" | grep "aarch64" > /dev/null; then
+  memory_model=""
+fi
 
 printf $format "Checking for make ... " >&2
 have_make=no

--- a/HEN_HOUSE/scripts/configure_c++
+++ b/HEN_HOUSE/scripts/configure_c++
@@ -172,6 +172,9 @@ system_name=$(uname -s | sed ":/:_:g" | tr '[:upper:]' '[:lower:]')
 if test "x$system_name" = xdarwin; then
     memory_model=""
 fi
+if echo "$canonical_system" | grep "aarch64" > /dev/null; then
+  memory_model=""
+fi
 
 case $CXX in
 
@@ -260,6 +263,10 @@ case $canonical_system in
         #
     *ibm-aix*)
         shared="-G -Wl,-brtl"; lib_link1="-L\$(abs_dso) -Wl,-brtl,-bexpall";;
+    *aarch64-*-linux*)
+        fpic="-fPIC";
+        opt="$opt -Wno-narrowing"
+        ;;
     *) echo Unsupported architecture $canonical_system; fpic="-fPIC";;
 esac
 


### PR DESCRIPTION
This adds support for building on Linux aarch64

I was specifically testing in Docker on MacOS with Apple Silicon. I tested with Debian and Ubuntu base images.


* [`HEN_HOUSE/scripts/config.guess`](diffhunk://#diff-8eb1825d07f152323a716762643133f58e783dff2708dbe0394743e7a20da225R833-R835): Added a new case for `aarch64` in the Linux environment to return the machine type as `aarch64-unknown-linux-gnu`.
* [`HEN_HOUSE/scripts/configure`](diffhunk://#diff-1fcddaf8748e652b20e5ac55635f6908417fe57d57dc0cca699fa2f1df7fe822R136-R138): Set the `memory_model` to an empty string if the `canonical_system` is `aarch64`.
* [`HEN_HOUSE/scripts/configure_c++`](diffhunk://#diff-26bdc3f68325c49956643e7ea0f4de41040771e60c11cd9c8420ef9508d2b8cfR171-R173): Set the `memory_model` to an empty string if the `canonical_system` is `aarch64`. Also, added a new case for `aarch64` in the Linux environment to set the `fpic` flag to `-fPIC` and add `-Wno-narrowing` to `opt`. [[1]](diffhunk://#diff-26bdc3f68325c49956643e7ea0f4de41040771e60c11cd9c8420ef9508d2b8cfR171-R173) [[2]](diffhunk://#diff-26bdc3f68325c49956643e7ea0f4de41040771e60c11cd9c8420ef9508d2b8cfR262-R265)