### PR TITLE
Fix parallel phsp source partition

### DIFF
--- a/HEN_HOUSE/egs++/egs_application.cpp
+++ b/HEN_HOUSE/egs++/egs_application.cpp
@@ -798,9 +798,9 @@ int EGS_Application::initSimulation() {
     return 0;
 }
 
-void EGS_Application::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
+void EGS_Application::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
     if (source) {
-        source->setSimulationChunk(nstart,nrun);
+        source->setSimulationChunk(nstart,nrun,npar,nchunk);
     }
 }
 

--- a/HEN_HOUSE/egs++/egs_application.h
+++ b/HEN_HOUSE/egs++/egs_application.h
@@ -316,11 +316,12 @@ public:
 
       Tells the application that the next chunk of particles to be
       simulated starts at \a nstart and will consist of \a nrun particles.
+      It also provides the source with the parallel run parameters, \a npar and \a nchunk.
       This is necessary for parallel runs using phase space files. The default
       implementation simply calls the EGS_BaseSource::setSimulationChunk()
       method.
     */
-    virtual void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun);
+    virtual void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk);
 
     /*! \brief Runs an EGSnrc simulation.
 

--- a/HEN_HOUSE/egs++/egs_base_source.h
+++ b/HEN_HOUSE/egs++/egs_base_source.h
@@ -140,7 +140,7 @@ public:
       It may also be re-implemented, if one wanted to use some sort of
       a systematic sampling of the phase space.
     */
-    virtual void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) { };
+    virtual void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) { };
 
     /*! \brief Get the charge of the source.
      *

--- a/HEN_HOUSE/egs++/egs_run_control.cpp
+++ b/HEN_HOUSE/egs++/egs_run_control.cpp
@@ -781,7 +781,7 @@ EGS_I64 EGS_JCFControl::getNextChunk() {
         nrun = nleft;
     }
     if (nrun > 0) {
-        app->setSimulationChunk(ntot,nrun);
+        app->setSimulationChunk(ntot,nrun,npar,nchunk);
     }
     nleft -= nrun;
     ntot += nrun;

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.h
@@ -287,8 +287,8 @@ public:
         return (valid && source != 0);
     };
 
-    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
-        source->setSimulationChunk(nstart, nrun);
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
+        source->setSimulationChunk(nstart, nrun, npar, nchunk);
     };
 
 protected:

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -336,16 +336,20 @@ union __egs_data32 {
 };
 #endif
 
-void EGS_PhspSource::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
-    if (nstart < 0 || nrun < 1 || nstart + nrun > Nparticle) {
-        egsWarning("EGS_PhspSource::setSimulationChunk(): illegal attempt "
-                   "to set the simulation chunk between %lld and %lld ignored\n",
-                   nstart+1,nstart+nrun);
-        return;
+void EGS_PhspSource::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
+
+    //determine the simulation chunk and use this to calculate first/last particles
+    //in the phase space chunk
+    EGS_I64 particlesPerChunk = Nparticle/(npar*nchunk);
+    int ichunk = nstart/nrun;
+    Nfirst = ichunk*particlesPerChunk+1;
+    Nlast = Nfirst-1+particlesPerChunk;
+    if (Nparticle - Nlast < particlesPerChunk)
+    {
+        //throw the remaining particles into the last phsp chunk
+        Nlast = Nparticle;
     }
-    Nfirst = nstart+1;
-    Nlast = nstart + nrun;
-    Npos = nstart;
+    Npos = Nfirst-1; //we increment Npos before attempting to read a particle
     istream::off_type pos = Nfirst*recl;
     the_file.seekg(pos,ios::beg);
     egsInformation("EGS_PhspSource: using phsp portion between %lld and %lld\n",

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.h
@@ -146,7 +146,7 @@ public:
     EGS_I64 getNextParticle(EGS_RandomGenerator *rndm,
                             int &q, int &latch, EGS_Float &E, EGS_Float &wt,
                             EGS_Vector &x, EGS_Vector &u);
-    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun);
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk);
     EGS_Float getEmax() const {
         return Emax;
     };

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.h
@@ -250,9 +250,9 @@ public:
         return (nsource > 0);
     };
 
-    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
         for (int j=0; j<nsource; j++) {
-            sources[j]->setSimulationChunk(nstart, nrun);
+            sources[j]->setSimulationChunk(nstart, nrun, npar, nchunk);
         }
     };
 

--- a/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.h
@@ -186,8 +186,8 @@ public:
         return (source != 0);
     };
 
-    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
-        source->setSimulationChunk(nstart, nrun);
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
+        source->setSimulationChunk(nstart, nrun, npar, nchunk);
     };
 
 protected:

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -423,16 +423,19 @@ union __egs_data32 {
 };
 #endif
 
-void IAEA_PhspSource::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun) {
-    if (nstart < 0 || nrun < 1 || nstart + nrun > Nparticle) {
-        egsWarning("IAEA_PhspSource::setSimulationChunk(): illegal attempt "
-                   "to set the simulation chunk between %lld and %lld ignored\n",
-                   nstart+1,nstart+nrun);
-        return;
+void IAEA_PhspSource::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk) {
+    //determine the simulation chunk and use this to calculate first/last particles
+    //in the phase space chunk
+    EGS_I64 particlesPerChunk = Nparticle/(npar*nchunk);
+    int ichunk = nstart/nrun;
+    Nfirst = ichunk*particlesPerChunk+1;
+    Nlast = Nfirst-1+particlesPerChunk;
+    if (Nparticle - Nlast < particlesPerChunk)
+    {
+        //throw the remaining particles into the last phsp chunk
+        Nlast = Nparticle;
     }
-    Nfirst = nstart+1;
-    Nlast = nstart + nrun;
-    Npos = nstart;
+    Npos = Nfirst-1;
     iaea_set_record(&iaea_fileid,&Nfirst,&iaea_iostat);
     if (iaea_iostat<0) {
         egsWarning("IAEA_PhspSource::setSimulationChunk(): error setting phase space chunk\n");

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -428,12 +428,22 @@ void IAEA_PhspSource::setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar,
     //in the phase space chunk
     EGS_I64 particlesPerChunk = Nparticle/(npar*nchunk);
     int ichunk = nstart/nrun;
-    Nfirst = ichunk*particlesPerChunk+1;
-    Nlast = Nfirst-1+particlesPerChunk;
-    if (Nparticle - Nlast < particlesPerChunk)
+    if (ichunk > npar*nchunk-1)
     {
-        //throw the remaining particles into the last phsp chunk
+        //remainder of histories, reuse the last chunk of the phsp
+        //there may be a more clever strategy
+        egsInformation("IAEA_PhspSource: Remainder of histories will reuse the last chunk of the phase space source.\n");
+        ichunk = npar*nchunk-1;
+    }
+    Nfirst = ichunk*particlesPerChunk+1;
+    if (ichunk == npar*nchunk-1)
+    {
+        //last chunk of the phsp file, just go to the end of the file
         Nlast = Nparticle;
+    }
+    else
+    {
+        Nlast = Nfirst-1+particlesPerChunk;
     }
     Npos = Nfirst-1;
     iaea_set_record(&iaea_fileid,&Nfirst,&iaea_iostat);

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.h
@@ -152,7 +152,7 @@ public:
     EGS_I64 getNextParticle(EGS_RandomGenerator *rndm,
                             int &q, int &latch, EGS_Float &E, EGS_Float &wt,
                             EGS_Vector &x, EGS_Vector &u);
-    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun);
+    void setSimulationChunk(EGS_I64 nstart, EGS_I64 nrun, int npar, int nchunk);
     EGS_Float getEmax() const {
         return Emax;
     };


### PR DESCRIPTION
This fix divides phase space sources used in parallel runs into npar\*nchunk equal segments, where npar is the no. of parallel runs and nchunk is the no. of chunks (defaults to 10).  Each chunk of the parallel run is then assigned its own segment of the phase space source outside of which it will not sample.  This scheme, identical to that used in the Mortran codes, should ensure relatively even sampling of the phase space source over the entire parallel run.  Note that any remaining histories after completion of npar*nchunk chunks are assigned to the last segment. 

Fixes issue #1117 and #1156