### PR TITLE
Fix #1131: clarify comment about ms conditional

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1246,8 +1246,10 @@ $start_new_particle;
                 is_ch_step = .false.;
                 IF((tustep <= tperp) & ((~exact_bca) | (tustep > skindepth)))
                 [
-                    "We are further way from a boundary than a skindepth, so
-                    "perform a normal condensed-history step
+                    "We are further away from a boundary than a skindepth and
+                    "either: we are not using exact boundary-crossing, or the
+                    "requested condensed-history step is greater than the
+                    "skindepth. So perform a normal condensed-history step
                     callhowfar = .false.; "Do not call HAWFAR
                     domultiple = .false.; "Multiple scattering done here
                     dosingle   = .false.; "MS => no single scattering


### PR DESCRIPTION
Clarify that multiple-scattering transport is triggered only if the intended electron step is longer than a skin depth, even in bulk media away from any region boundaries. This improves efficiency, because a multiple-scattering step costs about the same as 3 single-scattering steps (the default skin depth is 3 mean free paths). Below a skin depth, it is more efficient (and more accurate) to use single-scattering.