### PR TITLE
Zero energy deposited by track ends in vacuum.

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1770,8 +1770,7 @@ IF( medium > 0 ) [
         IF(lelec < 0) [edep = e(np) - prm;] ELSE[$POSITRON-ECUT-DISCARD;]
     ]
     ELSE [ idr = $PEGSCUTAUS; edep = e(np) - prm; ]
-] ELSE [idr = $EGSCUTAUS; edep = e(np) - prm; ]
-
+] ELSE [idr = $EGSCUTAUS; edep = 0.0; ] "zero edep in vacuum"
 
 $ELECTRON-TRACK-END; "The default replacement for this macros is "
                      "          $AUSCALL(idr);                   "

--- a/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
+++ b/HEN_HOUSE/user_codes/dosxyznrc/dosxyznrc.mortran
@@ -3008,8 +3008,10 @@ DO irl = 1,irmax-1 [
    ]
    "divide by rhor so that we do not have to store rhor in the .pardose"
    "file during parallel runs."
-   endep(irl)=endep(irl)/rhor(irl+1);
-   endep2(irl)=endep2(irl)/(rhor(irl+1)*rhor(irl+1));
+   if(rhor(irl+1)>0.0)[
+       endep(irl)=endep(irl)/rhor(irl+1);
+       endep2(irl)=endep2(irl)/(rhor(irl+1)*rhor(irl+1));
+   ]
 ]
 
 #ifdef HAVE_C_COMPILER;


### PR DESCRIPTION
Handle "rare" cases of energy deposited (edep) in vacuum due to tracks ending once particles cross into the region by immediately zeroing edep.  Requires a fix to dosxyznrc to handle the case of 0/0=NAN causing a crash.  May also require fixes to other user codes to handle similar NAN cases.

Fixes #1061 