### PR TITLE
Update the astyle options file to be compatible with newer versions of astyle

### DIFF
--- a/HEN_HOUSE/egs++/egs_shapes.cpp
+++ b/HEN_HOUSE/egs++/egs_shapes.cpp
@@ -189,11 +189,11 @@ EGS_Object *EGS_CylinderShape::createObject(EGS_Input *input) {
     bool has_A = (err2 == 0 && A.size() == 3);
     EGS_CylinderShape *result;
     if (has_Xo && has_A) result = new EGS_CylinderShape(r,H,
-                EGS_Vector(Xo[0],Xo[1],Xo[2]),EGS_Vector(A[0],A[1],A[2]));
+            EGS_Vector(Xo[0],Xo[1],Xo[2]),EGS_Vector(A[0],A[1],A[2]));
     else if (has_Xo) result = new EGS_CylinderShape(r,H,
-                EGS_Vector(Xo[0],Xo[1],Xo[2]));
+            EGS_Vector(Xo[0],Xo[1],Xo[2]));
     else if (has_A) result = new EGS_CylinderShape(r,H,
-                EGS_Vector(0,0,0),EGS_Vector(A[0],A[1],A[2]));
+            EGS_Vector(0,0,0),EGS_Vector(A[0],A[1],A[2]));
     else {
         result = new EGS_CylinderShape(r,H);
     }

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
@@ -892,9 +892,9 @@ void EGS_ASwitchedEnvelope::activateByIndex(int inscribed_index) {
 
 void EGS_ASwitchedEnvelope::deactivateByIndex(int inscribed_index) {
     vector<EGS_BaseGeometry *>::iterator loc = find(
-                active_inscribed.begin(), active_inscribed.end(),
-                inscribed_geoms[inscribed_index]
-            );
+            active_inscribed.begin(), active_inscribed.end(),
+            inscribed_geoms[inscribed_index]
+        );
     if (loc != active_inscribed.end()) {
         active_inscribed.erase(loc);
     }

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.h
@@ -63,7 +63,7 @@ template <class T>
 class EGS_CONEZ_EXPORT EGS_ConezT : public EGS_BaseGeometry {
 protected:
 
-    EGS_Float *theta,*cos_t,*cos2_t,*sin_t,*sin2_t;
+    EGS_Float *theta, *cos_t, *cos2_t, *sin_t, *sin2_t;
     // for conc-cones, all apices coincide
     EGS_Vector xo;
     // projection operator

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -319,7 +319,7 @@ void EGS_EnvelopeGeometry::printInfo() const {
                    g->getType().c_str());
     egsInformation(" inscribed geometries:\n");
     for (int j=0; j<n_in; j++) egsInformation("   %s (type %s)\n",
-                geometries[j]->getName().c_str(),geometries[j]->getType().c_str());
+            geometries[j]->getName().c_str(),geometries[j]->getType().c_str());
     egsInformation(
         "=======================================================\n");
 }
@@ -330,7 +330,7 @@ void EGS_FastEnvelope::printInfo() const {
                    g->getType().c_str());
     egsInformation(" inscribed geometries:\n");
     for (int j=0; j<n_in; j++) egsInformation("   %s (type %s)\n",
-                geometries[j]->getName().c_str(),geometries[j]->getType().c_str());
+            geometries[j]->getName().c_str(),geometries[j]->getType().c_str());
     egsInformation(
         "=======================================================\n");
 }

--- a/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.h
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.h
@@ -365,9 +365,9 @@ public:
         const auto &node_indices = elt_node_indices_.at(element);
         return Nodes {
             nodes_.at(node_indices[0]),
-            nodes_.at(node_indices[1]),
-            nodes_.at(node_indices[2]),
-            nodes_.at(node_indices[3])
+                  nodes_.at(node_indices[1]),
+                  nodes_.at(node_indices[2]),
+                  nodes_.at(node_indices[3])
         };
     }
 

--- a/HEN_HOUSE/egs++/geometry/egs_mesh/mesh_neighbours.h
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/mesh_neighbours.h
@@ -159,8 +159,8 @@ SharedNodes elements_around_nodes(const std::vector<mesh_neighbours::Tetrahedron
 
 // Given a list of tetrahedrons, returns the indices of neighbouring tetrahedrons.
 std::vector<std::array<int, 4>> tetrahedron_neighbours(
-                                 const std::vector<mesh_neighbours::Tetrahedron> &elements,
-egs_mesh::internal::PercentCounter &progress) {
+    const std::vector<mesh_neighbours::Tetrahedron> &elements,
+    egs_mesh::internal::PercentCounter &progress) {
     progress.start(elements.size());
     const std::size_t NUM_FACES = 4;
     const auto shared_nodes = mesh_neighbours::internal::elements_around_nodes(elements);

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -1342,7 +1342,7 @@ extern "C" {
                        "construct a ND geometry with a single dimension?\n");
             input->print(0,cerr);
             for (int j=0; j<gnames.size(); j++) egsWarning("dimension %d: %s\n",
-                        j+1,gnames[j].c_str());
+                    j+1,gnames[j].c_str());
         }
         int n_concav = 0;
         for (int j=0; j<dims.size(); j++) if (!dims[j]->isConvex()) {

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -129,11 +129,11 @@ extern "C" {
         }
         EGS_BaseGeometry *g;
         if (type == "EGS_Xplanes") g = new EGS_PlanesX(pos,"",
-                    EGS_XProjector(xproj_type));
+                EGS_XProjector(xproj_type));
         else if (type == "EGS_Yplanes") g = new EGS_PlanesY(pos,"",
-                    EGS_YProjector(yproj_type));
+                EGS_YProjector(yproj_type));
         else if (type == "EGS_Zplanes") g = new EGS_PlanesZ(pos,"",
-                    EGS_ZProjector(zproj_type));
+                EGS_ZProjector(zproj_type));
         else if (type == "EGS_Planes") {
             vector<EGS_Float> a;
             err = input->getInput("normal",a);

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
@@ -137,13 +137,13 @@ extern "C" {
         EGS_BaseGeometry *g;
         if (type == "EGS_RoundRectCylindersXY")
             g = new EGS_RoundRectCylindersT<EGS_XProjector,EGS_YProjector>(x_widths,y_widths,radii,xo,"",
-                    EGS_XProjector("X"),EGS_YProjector("Y"));
+                EGS_XProjector("X"),EGS_YProjector("Y"));
         else if (type == "EGS_RoundRectCylindersXZ")
             g = new EGS_RoundRectCylindersT<EGS_XProjector,EGS_ZProjector>(x_widths,y_widths,radii,xo,"",
-                    EGS_XProjector("X"),EGS_ZProjector("Z"));
+                EGS_XProjector("X"),EGS_ZProjector("Z"));
         else if (type == "EGS_RoundRectCylindersYZ")
             g = new EGS_RoundRectCylindersT<EGS_YProjector,EGS_ZProjector>(x_widths,y_widths,radii,xo,"",
-                    EGS_YProjector("Y"),EGS_ZProjector("Z"));
+                EGS_YProjector("Y"),EGS_ZProjector("Z"));
         else {
             vector<EGS_Float> ax, ay;
             err = input->getInput("x-axis",ax);
@@ -159,8 +159,8 @@ extern "C" {
                 return 0;
             }
             g = new EGS_RoundRectCylindersT<EGS_Projector,EGS_Projector>(x_widths,y_widths,radii,xo,"",
-                    EGS_Projector(EGS_Vector(ax[0],ax[1],ax[2]),"Any"),
-                    EGS_Projector(EGS_Vector(ay[0],ay[1],ay[2]),""));
+                EGS_Projector(EGS_Vector(ax[0],ax[1],ax[2]),"Any"),
+                EGS_Projector(EGS_Vector(ay[0],ay[1],ay[2]),""));
         }
         g->setName(input);
         g->setLabels(input);

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -223,9 +223,9 @@ void EGS_SmartEnvelope::printInfo() const {
                    g->getType().c_str());
     egsInformation(" inscribed geometries:\n");
     for (int j=0; j<n_in; j++) egsInformation("   %s (type %s) in region=%d, "
-                " itype=%d\n",
-                geometries[j]->getName().c_str(),geometries[j]->getType().c_str(),
-                reg_to_base[j],(int)itype[j]);
+            " itype=%d\n",
+            geometries[j]->getName().c_str(),geometries[j]->getType().c_str(),
+            reg_to_base[j],(int)itype[j]);
     egsInformation(
         "=======================================================\n");
 }

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -712,7 +712,7 @@ extern "C" {
             int tb_med = EGS_BaseGeometry::addMedium(tb_medium);
             int bm_med = EGS_BaseGeometry::addMedium(bm_medium);
             EGS_TestMicro *result = new EGS_TestMicro(vs[0],vs[1],vs[2],bsc_t,
-                    tb_med,bm_med,micro_data.c_str());
+                tb_med,bm_med,micro_data.c_str());
             result->setName(input);
             result->setBoundaryTolerance(input);
             result->setLabels(input);

--- a/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
@@ -75,7 +75,7 @@ extern "C" {
             }
         }
         EGS_EllipseShape *shape = new EGS_EllipseShape(pos[0],pos[1],
-                axis[0],axis[1],"",f);
+            axis[0],axis[1],"",f);
         shape->setName(input);
         shape->setTransformation(input);
         return shape;

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -119,7 +119,7 @@ extern "C" {
         err = input->getInput("inner rectangle",posi);
         if (!err && posi.size() == 4) {
             EGS_RectangularRing *s = new EGS_RectangularRing(pos[0],pos[2],pos[1],
-                    pos[3],posi[0],posi[2],posi[1],posi[3],"",f);
+                pos[3],posi[0],posi[2],posi[1],posi[3],"",f);
             if (!s->isValid()) {
                 egsWarning("createShape(rectangle): your input did not result in"
                            " a valid \"rectangular ring\"\n");

--- a/HEN_HOUSE/scripts/egs_style_standard
+++ b/HEN_HOUSE/scripts/egs_style_standard
@@ -1,5 +1,7 @@
 ### usage:
 ### astyle --options=$HEN_HOUSE/scripts/egs_coding_standard "*.cpp" "*.h"
+# Options compatible with: Artistic Style Version 3.4.11
+# Older versions may require instances of  "braces" to be replaced with "brackets"
 
 --convert-tabs              # convert all tabs to spaces
 --indent=spaces=4           # indent is 4 spaces
@@ -7,6 +9,6 @@
 --unpad-paren               # remove extra space padding around parenthesis on the inside and outside
 --pad-header                # space padding between a header and the following parenthesis
 --align-pointer=name        # attach pointer or reference to variable name
---break-closing-brackets    # breaks closing headers from their immediately preceding closing brackets
---add-brackets              # add brackets to unbracketed one line conditional statements
+--break-closing-braces      # breaks closing headers from their immediately preceding closing brackets
+--add-braces                # add brackets to unbracketed one line conditional statements
 --indent-preproc-block      # indent preprocessor blocks


### PR DESCRIPTION
Tested on Artistic Style Version 3.4.11. This was required because the option names changed slightly between versions. A comment was made at the top of the options file describing what changed. 

Also ran astyle on egs++. There were a handful of minor changes.