### PR TITLE
Fix #1004: beamdp axis labels are confusing

### DIFF
--- a/HEN_HOUSE/doc/src/pirs3100-g-app/g_template.f
+++ b/HEN_HOUSE/doc/src/pirs3100-g-app/g_template.f
@@ -5832,7 +5832,7 @@ C> @cond
             IPLOTE=0
             MEDIUM=i
             XAXIS = 'kinetic energy / MeV'
-            YAXISE = 'dE/drhoX MeV/g/cm\\S2\\N'
+            YAXISE = 'dE/drhoX MeV/g/cm\S2\N'
             YAXISEmfp = 'mean free path / cm'
             YAXISPmfp = 'mean free path / cm'
             write(GRAPHTITLE,'(24a1)')(media(j,i),j=1,24)

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -853,7 +853,7 @@ void EGS_PlanarFluence::ouputResults() {
         spe_output << "@    xaxis  label char size 1.560000\n";
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
-        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+        spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";
         spe_output << "@    yaxis  ticklabel font 4\n";
@@ -1551,10 +1551,10 @@ void EGS_VolumetricFluence::ouputResults() {
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
         if (src_norm == 1 || normLabel == "primary history") {
-            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
         }
         else {
-            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\S-1\"\n";
         }
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";

--- a/HEN_HOUSE/omega/progs/beamdp/beamdp.mortran
+++ b/HEN_HOUSE/omega/progs/beamdp/beamdp.mortran
@@ -1460,8 +1460,8 @@ IF(CHOICE1>0 & CHOICE1<10)[
     YPLOTT=FLOAT(IPARANOT-1);"this is the total number of particles read"
     IF(CHOICE1=1)[
        GRAPHTITLE='fluence vs position';
-       IF(FLUTYPE=1)[ YTITLE='planar fluence/incident particle /cm\\S-2\\N'; ]
-       ELSE[ YTITLE='fluence/incident particle /cm\\S-2\\N'; ]
+       IF(FLUTYPE=1)[ YTITLE='planar fluence/incident particle /cm\S-2\N'; ]
+       ELSE[ YTITLE='fluence/incident particle /cm\S-2\N'; ]
        IF(MSMFXY=0)["circular field"
           XTITLE='R /cm ';
           DO II=1,NFIELD[
@@ -1559,10 +1559,10 @@ IF(CHOICE1>0 & CHOICE1<10)[
     IF(CHOICE1=2)[
        GRAPHTITLE='energy fluence vs position';
        IF(FLUTYPE=1)[
-          YTITLE='planar energy fluence/incident particle /MeV cm\\S-2\\N)';
+          YTITLE='planar energy fluence/incident particle /MeV cm\S-2\N';
        ]
        ELSE[
-          YTITLE='energy fluence/incident particle /MeV cm\\S-2\\N)';
+          YTITLE='energy fluence/incident particle /MeV cm\S-2\N';
        ]
        IF(MSMFXY=0)["circular field"
           XTITLE='R /cm';
@@ -1649,10 +1649,10 @@ IF(CHOICE1>0 & CHOICE1<10)[
     ELSEIF(CHOICE1=3)[
        GRAPHTITLE='spectral distribution';
        IF(FLUTYPE=1)[
-          YTITLE='planar fluence/MeV/incident particle /cm\\S-2\\N MeV\\S-1\\N';
+          YTITLE='planar fluence/MeV/incident particle /cm\S-2\N MeV\S-1\N';
        ]
        ELSE[
-          YTITLE='fluence/MeV/incident particle /cm\\S-2\\N MeV\\S-1\\N';
+          YTITLE='fluence/MeV/incident particle /cm\S-2\N MeV\S-1\N';
        ]
        XTITLE='energy /MeV';
        DO II=1,NSMFEE[
@@ -1677,10 +1677,10 @@ IF(CHOICE1>0 & CHOICE1<10)[
     ELSEIF(CHOICE1=4)[
        GRAPHTITLE='energy fluence distribution';
        IF(FLUTYPE=1)[
-          YTITLE='planar energy fluence/MeV/incident particle  /cm\\S-2\\N';
+          YTITLE='planar energy fluence/MeV/incident particle  /cm\S-2\N';
        ]
        ELSE[
-          YTITLE='energy fluence/MeV/incident particle  /cm\\S-2\\N';
+          YTITLE='energy fluence/MeV/incident particle  /cm\S-2\N';
        ]
        XTITLE='energy /MeV';
        DO II=1,NSMFEE[

--- a/HEN_HOUSE/src/get_media_inputs.mortran
+++ b/HEN_HOUSE/src/get_media_inputs.mortran
@@ -1642,7 +1642,7 @@ DO i=1,nmed[
     :got_outfile:
     IFLAG1=0;IFLAG2=0;IPLOTE=0;MEDIUM=i;
     XAXIS = 'kinetic energy / MeV';
-    YAXISE = 'dE/drhoX MeV/g/cm\\S2\\N';
+    YAXISE = 'dE/drhoX MeV/g/cm\S2\N';
     YAXISEmfp = 'mean free path / cm';
     YAXISPmfp = 'mean free path / cm';
     write(GRAPHTITLE,'(24a1)')(media(j,i),j=1,24);

--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -1507,7 +1507,7 @@ public:
             spe_output << "@    xaxis  label char size 1.560000\n";
             spe_output << "@    xaxis  label font 4\n";
             spe_output << "@    xaxis  ticklabel font 4\n";
-            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
             spe_output << "@    yaxis  label char size 1.560000\n";
             spe_output << "@    yaxis  label font 4\n";
             spe_output << "@    yaxis  ticklabel font 4\n";

--- a/HEN_HOUSE/user_codes/edknrc/edknrc.mortran
+++ b/HEN_HOUSE/user_codes/edknrc/edknrc.mortran
@@ -3885,9 +3885,9 @@ IF (IOPLOT > 0)["plotting requested"
    	 "XVGRPLOT.MORTRAN"
 
    	 NPTS=NR;	     "number of points per graph"
-   	 SERIESTITLE='\\8q\\0 =' // ch_var(ini:fin) // '\\So';
+   	 SERIESTITLE='\\8q\\0 =' // ch_var(ini:fin) // '\So';
    	 XTITLE='radius r /cm';
-   	 YTITLE='dose per particle D(r)*r\\S2 \\N / Gy*cm\\S2\\N';
+   	 YTITLE='dose per particle D(r)*r\S2 \N / Gy*cm\S2\N';
    	 SUBTITLE='energy fraction vs. radius on '// time_and_date;
    	 UNITNUM=IPLTUNX;	 "Output file"
    	 "PLTYPE=1;		    histogram=1, XY-plot=0"

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -762,7 +762,7 @@ public:
         spe_output << "@    xaxis  label char size 1.560000\n";
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
-        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
+        spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";
         spe_output << "@    yaxis  ticklabel font 4\n";

--- a/HEN_HOUSE/user_codes/examin/examin.mortran
+++ b/HEN_HOUSE/user_codes/examin/examin.mortran
@@ -208,7 +208,7 @@
  YAXISPcom = 'fractional component of photon cross section';
  YAXISPmfp = 'mean free path / cm';
  YAXISEmfp = 'mean free path / cm';
- YAXISE = 'dE/drhoX MeV/g/cm\\S2\\N';
+ YAXISE = 'dE/drhoX MeV/g/cm\S2\N';
 
  XAXIS = 'kinetic energy / MeV';
 
@@ -853,4 +853,3 @@ END;
 
 SUBROUTINE AUSGAB(IARG);RETURN;END;
 SUBROUTINE HOWFAR;RETURN;END;  "DUMMIES TO FOOL LINKER";
-

--- a/HEN_HOUSE/user_codes/sprrznrc/sprrznrc.mortran
+++ b/HEN_HOUSE/user_codes/sprrznrc/sprrznrc.mortran
@@ -4603,7 +4603,7 @@ IF(ISPRREG=1)["create the .plotdat file"
 
     IF(ISOURC=3|ISOURC=21|ISOURC=22|ISOURC=23)[
            YTITLE='dose per incident particle/Gy'; ]
-    ELSE[ YTITLE='dose per incident fluence/Gy cm\\S2\\N'; ]
+    ELSE[ YTITLE='dose per incident fluence/Gy cm\S2\N'; ]
     HISTXMIN=BIN_CUT;       "value of lower X-bin (histograms only)"
     AXISTYPE=0;             "0 for no logs"
     DO IZ=1, NZ [
@@ -4663,7 +4663,7 @@ IF(ISPRREG=1)["create the .plotdat file"
 
     IF(ISOURC=3|ISOURC=21|ISOURC=22|ISOURC=23)[
          YTITLE='dose per incident particle/Gy'; ]
-    ELSE[ YTITLE='dose per incident fluence/Gy cm\\S2\\N'; ]
+    ELSE[ YTITLE='dose per incident fluence/Gy cm\S2\N'; ]
      " --------------------- >
      " SUBTITLE='dose vs radius at ' // TIMEN // ' on ' // DATEN;
     HISTXMIN=BIN_CUT;       "value of lower X-bin (histograms only)"


### PR DESCRIPTION
Addresses #1004.

Note: I find our method for specifying axis units in beamdp using a backslash in front of the unit (i.e., '/unit') confusing, especially for quantities which may also have a unit in the denominator (e.g., '/MeV cm^-2').  I wonder if we should move to just using brackets instead. 