### PR TITLE
Fix #1192: Compiler error when MXSTACK increased

### DIFF
--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -6010,7 +6010,8 @@ REPLACE {$CHECK-RELAX-STACK(#,#);} WITH {;
        ' min_E = ', min_E,' iq = ',iqf);
 ;  "---------- BUFFER FLUSH SEMICOLON ----------"
       $egs_fatal('(//,3a,/,2(a,i9),/,a)',' In subroutine ',{P2},
-          ' stack size exceeded! ',' $MXSTACK = ',$MXSTACK,' np = ',{P1},
+          ' stack size exceeded! ',' $MXSTACK = ',
+          $MXSTACK,' np = ',{P1},
           ' Increase $MXSTACK and try again ');
   ]
 };


### PR DESCRIPTION
Fix a compiler error that occurred when MXSTACK was increased to 1e7 or higher. This was due to the line length of an output statement flowing over 80 characters. The fix was just to split the line, so that more characters are available.