### PR TITLE
Fix bug in UBS/BCSE EII photon splitting block in BEAMnrc

### DIFF
--- a/HEN_HOUSE/makefiles/beam_makefile
+++ b/HEN_HOUSE/makefiles/beam_makefile
@@ -162,6 +162,12 @@ clean:
 	@$(MAKE) -s WHAT=_noopt execlean
 	@$(MAKE) -s WHAT= execlean
 
+libclean:
+	@echo "$(REMOVE) mortjob.mortran $(LIB_FORTRAN_FILE).$(FEXT) $(LIB_FORTRAN_FILE).mortlst"
+	@$(REMOVE) mortjob.mortran $(LIB_FORTRAN_FILE).$(FEXT) $(LIB_FORTRAN_FILE).mortlst
+	@echo "$(REMOVE) $(LIB_FORTRAN_FILE).$(FOBJE) $(LIB_FILE)"
+	$(REMOVE) $(LIB_FILE) $(LIB_FORTRAN_FILE).$(FOBJE)
+
 execlean:
 	@echo "$(REMOVE) $(EXE_FILE)"
 	$(REMOVE) $(EXE_FILE)

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -5748,7 +5748,7 @@ IF( use_bcse & ibrspl < 2 ) [
     ]
 ]
 
-IRL = IR(NP);  "Local region number"
+IRL = IR(NP);"  Local region number"
 
 " The following splits eii photons both for UBS & BCSE whether the two       "
 " are used individually or in conjunction with each other. Not automatically "

--- a/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
+++ b/HEN_HOUSE/omega/beamnrc/beamnrc.mortran
@@ -5748,6 +5748,7 @@ IF( use_bcse & ibrspl < 2 ) [
     ]
 ]
 
+IRL = IR(NP);  "Local region number"
 
 " The following splits eii photons both for UBS & BCSE whether the two       "
 " are used individually or in conjunction with each other. Not automatically "
@@ -5775,7 +5776,6 @@ $USER-AUSGAB;
 
 " Check if particle is leaving the transport geometry
 " ***************************************************
-IRL = IR(NP);  "Local region number"
 IF(IRL =  1)[
    IF(IARG ~= 3 & IARG ~=5)[
        "if properly coded we should only get IRL=1 when being discarded"


### PR DESCRIPTION
BUG: Commit 8023cd01 labels fluorescent photons after EII as secondary.
         The pertinent block for UBS and/or BCSE requires knowledge of the local
         region number IRL, which is only set later in AUSGAB.

FIX: Set IRL above the UBS/BCSE block in the AUSGAB routine.

This PR also adds the libclean target to the standard BEAMnrc Makefile.