### PR TITLE
Fix fluence label compiler error caused by PR #1170

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -855,7 +855,7 @@ void EGS_PlanarFluence::ouputResults() {
         spe_output << "@    xaxis  label char size 1.560000\n";
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
-        spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";
         spe_output << "@    yaxis  ticklabel font 4\n";
@@ -1557,10 +1557,10 @@ void EGS_VolumetricFluence::ouputResults() {
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
         if (src_norm == 1 || normLabel == "primary history") {
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
         }
         else {
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
         }
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";

--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -1508,7 +1508,7 @@ public:
             spe_output << "@    xaxis  label char size 1.560000\n";
             spe_output << "@    xaxis  label font 4\n";
             spe_output << "@    xaxis  ticklabel font 4\n";
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
             spe_output << "@    yaxis  label char size 1.560000\n";
             spe_output << "@    yaxis  label font 4\n";
             spe_output << "@    yaxis  ticklabel font 4\n";


### PR DESCRIPTION
Revert changes to units in the output of egs_fluence_scoring and cavity. The units were already correct before the change, because the C++ compilers interpreted the escaping differently than the fortran compilers.

This fix was also needed to avoid compiler errors when using newer compilers. Due to this, recent installation of the `develop` branch would not work on gcc-13.
