### PR TITLE
Change configure script to overwrite existing .conf

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -855,7 +855,7 @@ void EGS_PlanarFluence::ouputResults() {
         spe_output << "@    xaxis  label char size 1.560000\n";
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
-        spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+        spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";
         spe_output << "@    yaxis  ticklabel font 4\n";
@@ -1557,10 +1557,10 @@ void EGS_VolumetricFluence::ouputResults() {
         spe_output << "@    xaxis  label font 4\n";
         spe_output << "@    xaxis  ticklabel font 4\n";
         if (src_norm == 1 || normLabel == "primary history") {
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
         }
         else {
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\"\n";
         }
         spe_output << "@    yaxis  label char size 1.560000\n";
         spe_output << "@    yaxis  label font 4\n";

--- a/HEN_HOUSE/scripts/configure.expect
+++ b/HEN_HOUSE/scripts/configure.expect
@@ -36,16 +36,34 @@ expect "Input libraries that your compiler may need:"   { send "\n" }
 expect "Input C compiler:"                              { send "\n" }
 expect "Input C compiler flags to use:"                 { send "\n" }
 
-# Configuration
-expect "Input path to EGSnrc HEN_HOUSE directory:"      { send "\n" }
-expect "Choose a configuration name:"                   { send "$confname\n" }
-set timeout 1
-expect "Do you want to overwrite ?"                     { puts "no\n"; exit }
-set timeout -1
+expect {
+    # Configuration
+    "Input path to EGSnrc HEN_HOUSE directory:" {
+        send "\n"
+        exp_continue
+    }
+    "Choose a configuration name:" {
+        send "$confname\n"
+        exp_continue
+    }
+    "Do you want to overwrite ?" {
+        send "yes\n"
+        exp_continue
+    }
 
-# C++ compiler
-expect "Input C++ compiler:"                            { send "\n" }
-expect "Input option to change, or enter to proceed:"   { send "\n" }
+    # C++ compiler
+    "Input C++ compiler:" {
+        send "\n"
+        exp_continue
+    }
+    "Do you want to overwrite?" {
+        send "yes\n"
+        exp_continue
+    }
+    "Input option to change, or enter to proceed:" {
+        send "\n"
+    }
+}
 
 # Finalize for user
 expect "Do you want to finalize"                        { send "yes\n" }

--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -1508,7 +1508,7 @@ public:
             spe_output << "@    xaxis  label char size 1.560000\n";
             spe_output << "@    xaxis  label font 4\n";
             spe_output << "@    xaxis  ticklabel font 4\n";
-            spe_output << "@    yaxis  label \"fluence / MeV\S-1\Ncm\S-2\"\n";
+            spe_output << "@    yaxis  label \"fluence / MeV\\S-1\\Ncm\\S-2\"\n";
             spe_output << "@    yaxis  label char size 1.560000\n";
             spe_output << "@    yaxis  label font 4\n";
             spe_output << "@    yaxis  ticklabel font 4\n";


### PR DESCRIPTION
Change the configure.expect script so that existing configurations of the same name are overwritten. This avoids user confusing when they are following the installation instructions to re-configure, but the expect script refuses to continue due to a configuration of the same name already existing.