### PR TITLE
Fix egs kerma diff flu ouput for log-scale

### DIFF
--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -237,19 +237,20 @@ public:
 
                     }
                 }
-                /* Mark photon inside cavity */
-                latch = 1;
+                /* Mark photon inside cavity <= why did I need this?*/
+                //latch = 1;
             }
             /* Mark photons in exclusion regions */
-            else if (is_excluded[ig][ir]) {
-                latch = -1;
+            else if (is_excluded[ig][ir] && latch >= 0 ){
+                latch *= -1;
+                the_stack->latch[np] = latch;
             }
-            /* photon outside cavity and has not been in any exclusion zone */
+            /* photon outside cavity and has not been in any exclusion zone <= why?
             else if (latch >= 0) {
                 latch = 0;
-            }
+            }*/
 
-            the_stack->latch[np] = latch;
+            //the_stack->latch[np] = latch; <= if commented blocks above used
         }
         return 0;
     }
@@ -270,7 +271,7 @@ public:
             Nel     += p.wt;
             p.E += the_useful->rm;// source provides K.E.
         }
-        p.latch = 0; // Reset to 0
+        //p.latch = 0; // Reset to 0
         //if ( p.q != 0 )
         //   egsInformation("q = %d E = %g RM = %g wt = %g \n",p.q,p.E,the_useful->rm,p.wt);
 

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -113,8 +113,10 @@ public:
         EGS_AdvancedApplication(argc,argv), ngeom(0),
         kerma(0), kerma_r(0), scg(0), fd_geom(0),
         ncg(0), flug(0),flugT(0) {
-        Eph_ave = 0.0; Nph = 0.0;
-        Eph_sc  = 0.0; Nsc = 0.0;
+        Eph_ave = 0.0;
+        Nph = 0.0;
+        Eph_sc  = 0.0;
+        Nsc = 0.0;
         Eel_ave = 0.0, Nel = 0.0;
     };
 
@@ -241,7 +243,7 @@ public:
                 //latch = 1;
             }
             /* Mark photons in exclusion regions */
-            else if (is_excluded[ig][ir] && latch >= 0 ){
+            else if (is_excluded[ig][ir] && latch >= 0) {
                 latch *= -1;
                 the_stack->latch[np] = latch;
             }
@@ -528,8 +530,8 @@ public:
             }
         }
 
-        (*data_out) << Eph_ave << " " << Nph << " " 
-                    << Eel_ave << " " << Nel << " "  
+        (*data_out) << Eph_ave << " " << Nph << " "
+                    << Eel_ave << " " << Nel << " "
                     << Eph_sc  << " " << Nsc << endl;
         if (!data_out->good()) {
             return 1031;
@@ -603,10 +605,13 @@ public:
             }
         }
 
-        Eph_sc  = 0; Nsc = 0;
-        Eph_ave = 0; Nph = 0; 
-        Eel_ave = 0; Nel = 0; 
-        
+        Eph_sc  = 0;
+        Nsc = 0;
+        Eph_ave = 0;
+        Nph = 0;
+        Eel_ave = 0;
+        Nel = 0;
+
     };
 
     /*! Add simulation results */
@@ -661,7 +666,7 @@ public:
         }
 
         Eph_sc  += aux_Eph_sc;
-        Nsc     += aux_Nsc; 
+        Nsc     += aux_Nsc;
         Eph_ave += aux_Eph_ave;
         Nph     += aux_Nph;
         Eel_ave += aux_Eel_ave;
@@ -678,38 +683,38 @@ public:
 
         EGS_Float F = current_case/getFluence();
 
-        if (Eph_sc > kermaEpsilon && Nsc > kermaEpsilon ){
+        if (Eph_sc > kermaEpsilon && Nsc > kermaEpsilon) {
             Eph_sc /= Nsc;
             egsInformation(" Mean scoring photon energy <Epsc> = %g MeV\n\n",Eph_sc);
         }
 
-        if (Eph_ave > kermaEpsilon && Nph > kermaEpsilon ){
+        if (Eph_ave > kermaEpsilon && Nph > kermaEpsilon) {
             Eph_ave /= Nph;
             egsInformation(" Mean source photon energy <Ep> = %g MeV\n\n",Eph_ave);
         }
 
-        if (Eel_ave > kermaEpsilon && Nel > kermaEpsilon ){
+        if (Eel_ave > kermaEpsilon && Nel > kermaEpsilon) {
             Eel_ave /= Nel;
             egsInformation(" Mean source electron energy <Ee> = %g MeV\n\n",Eel_ave);
         }
 
-        outputKermaResults( F );
+        outputKermaResults(F);
 
         if (flug || flugT) {
-            outputFluenceResults( F );
+            outputFluenceResults(F);
         }
 
     };
 
     /*! Output the dosimetry results of a simulation. */
-    void outputKermaResults(const EGS_Float & F) {
+    void outputKermaResults(const EGS_Float &F) {
         /************************************************************/
         /* Print out kerma in scoring volume regions and the total. */
         /************************************************************/
-        
+
         /* Normalize to actual source fluence */
         EGS_Float MeVtoJgtokg = 1.6021773e-10, // energy and mass conversion
-                        normD = MeVtoJgtokg*F;
+                  normD = MeVtoJgtokg*F;
         int irmax_digits = getDigits(max_sc_reg),
             max_medl     = getMaxMedLength();
         int count = 0;
@@ -720,7 +725,7 @@ public:
         int imed = -1, nreg = 0;
         /* Compute deposited energy and dose */
         for (int j=0; j<ngeom; j++) {
-            if ( F == 1 ) {
+            if (F == 1) {
                 egsInformation("\n\n==> Calculation summary (per particle) in geometry: %s\n\n",
                                geoms[j]->getName().c_str());
                 if (flug) {
@@ -772,21 +777,21 @@ public:
                         else {
                             dr=100.0;
                         }
-                        if (flug){
-                           flugT[j]->currentResult(ir,fe,dfe);
-                           if (fe > 0) {
-                               dfe = 100*dfe/fe;
-                           }
-                           else {
-                               dfe = 100;
-                           }
-                           egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%%\n",
-                                          irmax_digits, ir, m, r*F, dr, r*normD/m, dr,
-                                          fe*F*rho/m, dfe, r/(fe*rho)/Eph_sc, sqrt(dr*dr+dfe*dfe));
+                        if (flug) {
+                            flugT[j]->currentResult(ir,fe,dfe);
+                            if (fe > 0) {
+                                dfe = 100*dfe/fe;
+                            }
+                            else {
+                                dfe = 100;
+                            }
+                            egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%%\n",
+                                           irmax_digits, ir, m, r*F, dr, r*normD/m, dr,
+                                           fe*F*rho/m, dfe, r/(fe*rho)/Eph_sc, sqrt(dr*dr+dfe*dfe));
                         }
-                        else{
-                           egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%%\n",
-                                          irmax_digits, ir, m, r*F, dr, r*normD/m, dr);
+                        else {
+                            egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%% %12.6e +/- %-8.4f%%\n",
+                                           irmax_digits, ir, m, r*F, dr, r*normD/m, dr);
 
                         }
                     }
@@ -843,7 +848,7 @@ public:
     }
 
     /*! Output the fluence results of a simulation. */
-    void outputFluenceResults(const EGS_Float & F) {
+    void outputFluenceResults(const EGS_Float &F) {
 
         string spe_name = constructIOFileName(".agr",true);
         ofstream spe_output(spe_name.c_str());
@@ -884,56 +889,56 @@ public:
                 line.append(count,'-');
                 egsInformation("  %s\n",line.c_str());
 
-               for (int ir = 0; ir < nreg; ir++) {
-                   if (is_sensitive[j][ir]) {
-                      int imed = getMedium(ir);
-                      /* Per volume */
-                      EGS_Float m = mass[j][ir];
-                      EGS_Float normT = F*getMediumRho(imed)/m;
-                      flugT[j]->currentResult(ir,fe,dfe);
-                      if (fe > 0) {
-                          dfe = 100*dfe/fe;
-                      }
-                      else {
-                          dfe = 100;
-                      }
-                      egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%%\n",
-                                             irmax_digits, ir, m,fe*normT, dfe);
-                   }                        
-               }
+                for (int ir = 0; ir < nreg; ir++) {
+                    if (is_sensitive[j][ir]) {
+                        int imed = getMedium(ir);
+                        /* Per volume */
+                        EGS_Float m = mass[j][ir];
+                        EGS_Float normT = F*getMediumRho(imed)/m;
+                        flugT[j]->currentResult(ir,fe,dfe);
+                        if (fe > 0) {
+                            dfe = 100*dfe/fe;
+                        }
+                        else {
+                            dfe = 100;
+                        }
+                        egsInformation("  %*d  %12.6e %12.6e +/- %-8.4f%%\n",
+                                       irmax_digits, ir, m,fe*normT, dfe);
+                    }
+                }
             }
 
-            if (flug){ 
-               /* Diff. fluence currently in whole scoring volume */
-               EGS_Float normV = F/(mass_cv[j]/rho_cv[j]);//per unit volume
-               EGS_Float norm, expbw, DE;
-               if ( flu_s ){
-                  expbw = exp(1.0/flu_a);// exp{log(Emax/Emin)/Nbin}
-               }
-               else{
-                 norm = normV*flu_a; //per unit bin width (linear scale)
-               }
-               spe_output<<"@    s"<<j<<" errorbar linestyle 0\n";
-               spe_output<<"@    s"<<j<<" legend \""<<
-                         geoms[j]->getName().c_str()<<"\"\n";
-               spe_output<<"@target G0.S"<<j<<"\n";
-               spe_output<<"@type xydy\n";
-               egsInformation("\n\n"
-                              "   Emid/MeV    dFlu/dE/[MeV-1/cm2]   DFlu/[MeV-1/cm2]\n"
-                              "   --------------------------------------------------\n");
-               for (int i=0; i<flu_nbin; i++) {
-                   flug[j]->currentResult(i,fe,dfe);
-                   EGS_Float e = (i+0.5-flu_b)/flu_a;
-                   if (flu_s) {
-                       e = exp(e);
-                       DE    = exp(flu_xmin)*pow(expbw,i)*(expbw-1);
-                       norm  = normV/DE; //per unit bin width (log scale)
-                   }
-                   spe_output<<e<<" "<<fe *norm<<" "<<dfe *norm<< "\n";
-                   egsInformation("%11.6f  %14.6e      %14.6e\n",
-                                  e,fe*norm,dfe*norm);
-               }
-               spe_output << "&\n";
+            if (flug) {
+                /* Diff. fluence currently in whole scoring volume */
+                EGS_Float normV = F/(mass_cv[j]/rho_cv[j]);//per unit volume
+                EGS_Float norm, expbw, DE;
+                if (flu_s) {
+                    expbw = exp(1.0/flu_a);// exp{log(Emax/Emin)/Nbin}
+                }
+                else {
+                    norm = normV*flu_a; //per unit bin width (linear scale)
+                }
+                spe_output<<"@    s"<<j<<" errorbar linestyle 0\n";
+                spe_output<<"@    s"<<j<<" legend \""<<
+                          geoms[j]->getName().c_str()<<"\"\n";
+                spe_output<<"@target G0.S"<<j<<"\n";
+                spe_output<<"@type xydy\n";
+                egsInformation("\n\n"
+                               "   Emid/MeV    dFlu/dE/[MeV-1/cm2]   DFlu/[MeV-1/cm2]\n"
+                               "   --------------------------------------------------\n");
+                for (int i=0; i<flu_nbin; i++) {
+                    flug[j]->currentResult(i,fe,dfe);
+                    EGS_Float e = (i+0.5-flu_b)/flu_a;
+                    if (flu_s) {
+                        e = exp(e);
+                        DE    = exp(flu_xmin)*pow(expbw,i)*(expbw-1);
+                        norm  = normV/DE; //per unit bin width (log scale)
+                    }
+                    spe_output<<e<<" "<<fe *norm<<" "<<dfe *norm<< "\n";
+                    egsInformation("%11.6f  %14.6e      %14.6e\n",
+                                   e,fe*norm,dfe*norm);
+                }
+                spe_output << "&\n";
             }
         }
     }
@@ -1411,7 +1416,7 @@ int EGS_KermaApplication::initScoring() {
                         cavity_masses.push_back(m_g);
                         n_cavity_masses.push_back(cmass.size());
                         transformations.push_back(
-                                           EGS_AffineTransform::getTransformation(aux));
+                            EGS_AffineTransform::getTransformation(aux));
                         /* excluded regions */
                         if (!err4 && apert.size() > 0) {
                             int *ap = new int [apert.size()];

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -253,7 +253,9 @@ public:
     int simulateSingleShower() {
         last_case = current_case;
         EGS_Vector x,u;
+
         current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
+
         if (p.q == 0) {
             Eph_ave += p.wt*p.E;
             Nph += p.wt;
@@ -261,13 +263,13 @@ public:
         else {
             Eel_ave += p.wt*p.E;
             Nel     += p.wt;
-            p.E += the_useful->rm;// source provides K.E.
         }
 
         int err = startNewShower();
         if (err) {
             return err;
         }
+
         EGS_BaseGeometry *save_geometry = geometry;
         for (ig=0; ig<ngeom; ig++) {
             geometry = geoms[ig];

--- a/HEN_HOUSE/user_codes/egs_kerma/example_20MeV_e-_Pb-shield_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_20MeV_e-_Pb-shield_FD.egsinp
@@ -152,6 +152,8 @@
     :stop fluence scoring:
 
     ### E*muen file (could also be E*mutr): absolute or relative file path
+
+    # Calculated with the g application and the mcdf-xcom photon cross section option
     emuen file = $EGS_HOME/egs_kerma/emuen_rho_air_1keV-20MeV.data
 
     ### geometry for forced-detection (if omitted, score ONLY when reaching scoring region)

--- a/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
@@ -219,6 +219,8 @@
 
     ### E*muen file (could also be E*mutr): absolute or relative file path
     ### Use absolute path when submitting parallel jobs!!!
+
+    # Calculated with the g application and the mcdf-xcom photon cross section option
     emuen file = $EGS_HOME/egs_kerma/emuen_rho_air_1keV-1.5MeV.data
 
     ### geometry for forced-detection (if omitted, score ONLY when reaching scoring region)

--- a/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
@@ -219,7 +219,7 @@
 
     ### E*muen file (could also be E*mutr): absolute or relative file path
     ### Use absolute path when submitting parallel jobs!!!
-    emuen file = $EGS_HOME/egs_kerma/emuen_icru90_1.5MeV.data
+    emuen file = $EGS_HOME/egs_kerma/emuen_rho_air_1keV-1.5MeV.data
 
     ### geometry for forced-detection (if omitted, score ONLY when reaching scoring region)
     Default FD geometry = sphere

--- a/HEN_HOUSE/user_codes/egs_kerma/example_5keV_H2O_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_5keV_H2O_FD.egsinp
@@ -153,6 +153,8 @@
 
 
     ### E*muen file (could also be E*mutr): absolute or relative file path
+
+    # Calculated with the g application and the mcdf-xcom photon cross section option
     emuen file = $EGS_HOME/egs_kerma/emuen_rho_water_1keV-1.5MeV.data
 
 :stop scoring options:


### PR DESCRIPTION
## Bugs fixed in this PR

- Fixes diff fluence normalization to proper bin width when using log-scale.
- Fixes bug printing out average source energies and number of particles to egsdat file causing combining parallel jobs to fail.
- Fixes bug introduced to preserve latch and only multiply it by -1 when entering an exclusion region. Now photon is killed rather than relying on latch. Speeds up example calculation `example_1m_40keV_FD.egsinp` by 40 %
- Veryfies that scoring regions are not define as exclusion regions.

## Keep source latch

The latch of particles was reset to 0 and now is accepted as it comes from the source. This can be useful for VRT AOs such as radiative splitting.

## Verifying approach killing photons entering exclusion regions

| Case      | Kerma / Gy/particle | wall contribution| histories / h |
| ----------- | ----------- |---|---|
| latch = -1      |   3.530745e-18 +/- 0.0074  %     | 1.0134794   +/- 0.003971  % | 2.06299e+09 |
| kill photon   | 3.530758e-18 +/- 0.0077  %       | 1.0135483   +/- 0.004152  % | 2.81407e+09 |

