### PR TITLE
Fix #1300: egs_view segmentation fault that started when we added dynamic geometries

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -242,6 +242,10 @@ public:
         return media[ind].c_str();
     };
 
+    void containsDynamic(bool &hasdynamic) {
+        hasdynamic = false;
+    };
+
     EGS_Float getMediumRho(int ind) const {
         if (ind==-1) {
             return -1;

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.h
@@ -823,25 +823,33 @@ do_checks:
 
     void getNextGeom(EGS_RandomGenerator *rndm) { //calls getNextGeom on its component geometries to update dynamic geometries in the simulation
         for (int j=0; j<bg->regions(); ++j) {
-            g[j]->getNextGeom(rndm);
+            if (g[j]) {
+                g[j]->getNextGeom(rndm);
+            }
         }
-        bg->getNextGeom(rndm);
+        if (bg) {
+            bg->getNextGeom(rndm);
+        }
     };
 
     void updatePosition(EGS_Float time) {//calls updatePosition on its component geometries to update dynamic geometries in the simulation
         for (int j=0; j<bg->regions(); j++) {
-            g[j]->updatePosition(time);
+            if (g[j]) {
+                g[j]->updatePosition(time);
+            }
         }
-        bg->updatePosition(time);
+        if (bg) {
+            bg->updatePosition(time);
+        }
     };
 
     void containsDynamic(bool &hasdynamic) {//calls containsDynamic on its component geometries (only calls if hasDynamic is false, as if it is true we already found one)
         for (int j=0; j<bg->regions(); j++) {
-            if (!hasdynamic) {
+            if (!hasdynamic && g[j]) {
                 g[j]->containsDynamic(hasdynamic);
             }
         }
-        if (!hasdynamic) {
+        if (!hasdynamic && bg) {
             bg->containsDynamic(hasdynamic);
         }
     };

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.h
@@ -529,29 +529,37 @@ public:
         // calls getNextGeom on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<n_in; j++) {
-            geometries[j]->getNextGeom(rndm);
+            if (geometries[j]) {
+                geometries[j]->getNextGeom(rndm);
+            }
         }
-        g->getNextGeom(rndm);
+        if (g) {
+            g->getNextGeom(rndm);
+        }
     };
 
     void updatePosition(EGS_Float time) {
         // calls updatePosition on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<n_in; j++) {
-            geometries[j]->updatePosition(time);
+            if (geometries[j]) {
+                geometries[j]->updatePosition(time);
+            }
         }
-        g->updatePosition(time);
+        if (g) {
+            g->updatePosition(time);
+        }
     };
 
     void containsDynamic(bool &hasdynamic) {
         // calls containsDynamic on its component geometries (only calls if
         // hasDynamic is false, as if it is true we already found one)
         for (int j=0; j<n_in; j++) {
-            if (!hasdynamic) {
+            if (!hasdynamic && geometries[j]) {
                 geometries[j]->containsDynamic(hasdynamic);
             }
         }
-        if (!hasdynamic) {
+        if (!hasdynamic && g) {
             g->containsDynamic(hasdynamic);
         }
     };

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.h
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.h
@@ -221,20 +221,23 @@ public:
     void getNextGeom(EGS_RandomGenerator *rndm) {
         // calls getNextGeom on its component geometries to update dynamic
         // geometries in the simulation
-        g->getNextGeom(rndm);
-
+        if (g) {
+            g->getNextGeom(rndm);
+        }
     };
 
     void updatePosition(EGS_Float time) {
         // calls updatePosition on its component geometries to update dynamic
         // geometries in the simulation
-        g->updatePosition(time);
+        if (g) {
+            g->updatePosition(time);
+        }
     };
 
     void containsDynamic(bool &hasdynamic) {
         // calls containsDynamic on its component geometries (only calls if
         // hasDynamic is false, as if it is true we already found one)
-        if (!hasdynamic) {
+        if (!hasdynamic && g) {
             g->containsDynamic(hasdynamic);
         }
     };

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.h
@@ -561,7 +561,9 @@ public:
         // calls getNextGeom on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<N; j++) {
-            g[j]->getNextGeom(rndm);
+            if (g[j]) {
+                g[j]->getNextGeom(rndm);
+            }
         }
     };
 
@@ -569,7 +571,9 @@ public:
         // calls updatePosition on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<N; j++) {
-            g[j]->updatePosition(time);
+            if (g[j]) {
+                g[j]->updatePosition(time);
+            }
         }
     };
 
@@ -577,7 +581,7 @@ public:
         // calls containsDynamic on its component geometries (only calls if
         // hasDynamic is false, as if it is true we already found one)
         for (int j=0; j<N; j++) {
-            if (!hasdynamic) {
+            if (!hasdynamic && g[j]) {
                 g[j]->containsDynamic(hasdynamic);
             }
         }

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.h
@@ -284,7 +284,9 @@ public:
         // calls getNextGeom on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<ng; j++) {
-            g[j]->getNextGeom(rndm);
+            if (g[j]) {
+                g[j]->getNextGeom(rndm);
+            }
         }
     };
 
@@ -292,7 +294,9 @@ public:
         // calls updatePosition on its component geometries to update dynamic
         // geometries in the simulation
         for (int j=0; j<ng; j++) {
-            g[j]->updatePosition(time);
+            if (g[j]) {
+                g[j]->updatePosition(time);
+            }
         }
     };
 
@@ -300,7 +304,7 @@ public:
         // calls containsDynamic on its component geometries (only calls if
         // hasDynamic is false, as if it is true we already found one)
         for (int j=0; j<ng; j++) {
-            if (!hasdynamic) {
+            if (!hasdynamic && g[j]) {
                 g[j]->containsDynamic(hasdynamic);
             }
         }

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -2053,6 +2053,7 @@ int GeometryViewControl::setGeometry(
             hasDynamic=hasTrackTimeIndex;
         }
     }
+
     // run timeObjectVisibility to either make visible or hide time index
     // related objects depending on input file and tracks file
     timeObjectVisibility();


### PR DESCRIPTION
Fix a segmentation fault that was occurring in egs_view due to accessing memory that was not initialized in the geometry. This occurred during a call to `containsDynamic()`, which in the composite geometries was missing a check on whether a geometry existed before propagating the `containsDynamic()` call. The result was a segmentation fault in egs_view for specific use cases of a CD geometry. I added a protective check for all composite geometries, but only detected the issue for CD geometries so far.