### PR TITLE
Fix #1312: egs_phd bug for radionuclide and phsp

### DIFF
--- a/HEN_HOUSE/user_codes/egs_phd/egs_phd.h
+++ b/HEN_HOUSE/user_codes/egs_phd/egs_phd.h
@@ -89,9 +89,6 @@ private:
     // initialize scoring
     int initScoring();
 
-    // simulate a single shower
-    int simulateSingleShower();
-
     // accumulate quantities of interest at run time
     int ausgab(int iarg);
 


### PR DESCRIPTION
Fix a bug in egs_phd where sources that provide secondary particles directly from the source are not scored properly into the egs_phd spectrum. This impacted radionuclide and phase-space sources that provide secondary particles. The issue manifested as some particles being counted twice into the spectrum, because the scoring arrays only got reset between histories but were used for the PHD after every source particle.