### PR TITLE
Fix #1340: qt5 egs_view compiler error for QMainWindow

### DIFF
--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -211,7 +211,7 @@ private:
     bool showElectronTracks;
     bool showPositronTracks;
     bool hasDynamic; //boolean to track whether or not to make time objects visible or hidden
-    char head_inctime[20] = "include time index="; // must match the same in egs_particle_track.h
+    char head_inctime[20] = {'i','n','c','l','u','d','e',' ','t','i','m','e',' ','i','n','d','e','x','='}; // must match the same in egs_particle_track.h
     bool hasTrackTimeIndex;
     bool isPlaying;
     vector<bool> show_regions;


### PR DESCRIPTION
Fix a compiler error for egs_view in qt5 reported here: https://github.com/nrc-cnrc/EGSnrc/issues/1340

Since it didn't occur for me, it may only happen when stricter compiler flags are used. Regardless, it will help with the eventual move to qt6.