### PR TITLE
Fix egs_cbct combining crashed runs

### DIFF
--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -2726,6 +2726,8 @@ if(K_min)
         bfile->writeBinary(0);
         delete bfile;
      }
+
+     printScans();
 }
 
 /*! Output egsmap or profile if requested. */
@@ -2996,7 +2998,7 @@ int EGS_CBCT::finishSimulation() {
     err = combineResults(); if (egsdat) outputData();
     if( err ) return err;
     run->finishSimulation();
-    outputResults(); printScans();
+    outputResults();
     egsInformation("\n Running %d parallel jobs!!!\n\n",getNparallel());
     finishRun();
     return 0;


### PR DESCRIPTION
Fix an issue where egs_cbct wouldn't output the scans when combining a crashed parallel job where there was a missing .egsdat file.