### PR TITLE
Add getLastTime to egs_radionuclide_source

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
@@ -24,6 +24,7 @@
 #  Author:          Reid Townson, 2016
 #
 #  Contributors:    Martin Martinov
+#                   Patrick Saull
 #
 ###############################################################################
 */
@@ -1020,6 +1021,11 @@ public:
     /*! \brief Returns the emission time of the most recent particle */
     double getTime() const {
         return time;
+    };
+
+    /*! \brief Returns the time of the last emission for decay */
+    double getLastTime() const {
+        return lastDisintTime;
     };
 
     /*! \brief Get the total possible length of the experiment that is being modelled


### PR DESCRIPTION
Add a getter function to egs_radionuclide_source to get the last disintegration time. Contributed by Patrick Saull.