### PR TITLE
Add missing include in egs_focal_spot_source

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.h
@@ -41,6 +41,7 @@
 #include "egs_base_source.h"
 #include "egs_vector.h"
 #include "egs_rndm.h"
+#include "egs_transformations.h"
 
 
 #ifdef WIN32


### PR DESCRIPTION
The egs_focal_spot_source.h file was missing an include of egs_transformations, which made it fail to compile.