### PR TITLE
Fix label check causing crash

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -132,7 +132,7 @@ void EGS_DoseScoring::setApplication(EGS_Application *App) {
         return;
     }
 
-    if (d_regionString.length() > 0 && d_region.size() < 1) {
+    if (d_regionString.length() > 0) {
         getNumberRegions(d_regionString, d_region);
         getLabelRegions(d_regionString, d_region);
     }

--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -1104,7 +1104,7 @@ void EGS_BaseGeometry::getLabelRegions(const string &str, vector<int> &regs, boo
         // Precondition: regs must be pre-populated by getNumberRegions() before calling this function
         // with sanitize=false, so that each non-label token has a corresponding entry already in regs.
         // Otherwise, advancing insert_pos will walk out of bounds.
-        if (!foundLabel) {
+        if (!foundLabel && regs.size() > 0) {
             if (insert_pos >= regs.size()) {
                 egsFatal("EGS_BaseGeometry::getLabelRegions(): insert_pos out of bounds "
                         "for geometry %s. Was getNumberRegions() called before "


### PR DESCRIPTION
Fix a bug where a check in replacing labels would crash in the case that the list of regions was blank. In egs_ndgeometry a blank region list was passed intentionally, so this is an allowed behaviour.

This bug was introduced in PR #1343