### PR TITLE
Fix radionuclide beta spectrum output directory

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
@@ -72,15 +72,6 @@ void EGS_TrackScoring::setApplication(EGS_Application *App) {
     if (!egsIsAbsolutePath(fname)) {
         fname = egsJoinPath(app->getAppDir(),fname);
     }
-    int i_parallel = -1;
-    if (app->getNparallel() > 1) {
-        i_parallel = app->getIparallel();
-    }
-    if (i_parallel >= 0) {
-        char buf[16];
-        sprintf(buf,"_w%d",i_parallel);
-        fname += buf;
-    }
 
     fname += ".ptracks";
 

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
@@ -208,13 +208,18 @@ public:
             // Write the spectrum to a file
             if (outputBetaSpectra == "yes") {
 
-                ostringstream ostr;
-                ostr << decays->radionuclide << "_" << emax << ".spec";
+                string fname(app->getOutputFile());
+                fname += "_" + decays->radionuclide + "_" + std::to_string(emax);
+                if (!egsIsAbsolutePath(fname)) {
+                    fname = egsJoinPath(app->getAppDir(),fname);
+                }
+                fname += ".spec";
 
-                egsInformation("EGS_RadionuclideBetaSpectrum: Outputting beta spectrum to file: %s\n", ostr.str().c_str());
+
+                egsInformation("EGS_RadionuclideBetaSpectrum: Outputting beta spectrum to file: %s\n", fname.c_str());
 
                 ofstream specStream;
-                specStream.open(ostr.str().c_str());
+                specStream.open(fname.c_str());
                 for (int ib=0; ib<nbin; ib++) {
                     spec[ib]=1/de*(spec_y[ib]/s_y);
                     specStream << e[ib] << " " << spec[ib] << endl;


### PR DESCRIPTION
Fix a bug where the beta spectra for radionuclide sources could end up in the directory where you ran the code from, rather than the application directory. Now the beta spectrum go to the app directory more robustly, and include separation by parallel jobs. 

Also fix a typo in the tracks output file where it would get a repeated job numbers (e.g. `_w2_w2`) for a parallel job.

Thanks to Patrick Saull for reporting this issue.

