### PR TITLE
Fix dynamic geometry critical bug in some apps

### DIFF
--- a/HEN_HOUSE/egs++/view/egs_track_view.cpp
+++ b/HEN_HOUSE/egs++/view/egs_track_view.cpp
@@ -214,6 +214,9 @@ EGS_TrackView::EGS_TrackView(const char *filename, vector<size_t> &ntracks,vecto
     int mem_rcnt[3] = {0,0,0};
     int ind_rcnt[3] = {0,0,0};
 
+    float min_timeIndex = 999;
+    float max_timeIndex = -1;
+
     // Compression routine!
     for (int i=0; i<tot_tracks; i++) {
         char *start;
@@ -291,6 +294,13 @@ EGS_TrackView::EGS_TrackView(const char *filename, vector<size_t> &ntracks,vecto
                 else if (type==2) {
                     timelist_po.push_back(timeindex);
                 }
+
+                if(timeindex < min_timeIndex) {
+                    min_timeIndex = timeindex;
+                }
+                if(timeindex > max_timeIndex) {
+                    max_timeIndex = timeindex;
+                }
             }
         }
     }
@@ -328,6 +338,12 @@ EGS_TrackView::EGS_TrackView(const char *filename, vector<size_t> &ntracks,vecto
     egsInformation("%s: Tracks compressed: %d (%d %d %d)\n", func_name,
                    ind_rcnt[0]+ind_rcnt[1]+ind_rcnt[2],
                    ind_rcnt[0], ind_rcnt[1], ind_rcnt[2]);
+
+    if (incltime) {
+        egsInformation("%s: Minimum time index: %f\n", func_name, min_timeIndex);
+        egsInformation("%s: Maximum time index: %f\n", func_name, max_timeIndex);
+    }
+
     m_failed = false;
     data.close();
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -596,6 +596,10 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
     EGS_Library *existingApp = nullptr;
     for (const auto &lib : binLibraries) {
+#ifdef VIEW_DEBUG
+        egsWarning("GeometryViewControl:: Checking if we can load %s/%s\n", dso_dir.c_str(), lib.toLatin1().data());
+#endif
+
         // Remove the extension
         QString libName = lib.left(lib.lastIndexOf("."));
 
@@ -605,13 +609,14 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
         // Check if the application has the getAppSpecificInputs, and only add it to the drop-down menu if it does
         EGS_Library* app_lib = new EGS_Library(libName.toLatin1().data(), lib_dir.c_str());
-        if(!existingApp) {
-            existingApp = app_lib;
-        }
         if (app_lib->load()) {
             getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib->resolve("getAppSpecificInputs");
 
             if (getAppInputs) {
+                if(!existingApp) {
+                    existingApp = app_lib;
+                }
+
                 // Adds the button to the menu
                 QAction *action = exampleMenu2->addAction(libName);
                 action->setData(libName);
@@ -628,6 +633,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     // Application level inputs (but not app specific)
     if(existingApp) {
         getAppInputsFunction getAppInputs = (getAppInputsFunction) existingApp->resolve("getAppInputs");
+
         if(getAppInputs) {
 
             // before this was a BlockInput, now it is a InputStruct

--- a/HEN_HOUSE/user_codes/cavity/cavity.cpp
+++ b/HEN_HOUSE/user_codes/cavity/cavity.cpp
@@ -771,7 +771,15 @@ public:
     int simulateSingleShower() {
         last_case = current_case;
         EGS_Vector x,u;
+
+        setTimeIndex(-1);
+
         current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
+
+        // For dynamic geometries, update positions according to the current
+        // time index, which may have been set by getNextParticle
+        geometry->getNextGeom(rndm);
+
         //egsInformation("particle: E=%g q=%d x=(%g,%g,%g)\n",p.E,p.q,x.x,x.y,x.z);
         int err = startNewShower(); if( err ) return err;
         EGS_BaseGeometry *save_geometry = geometry;

--- a/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
+++ b/HEN_HOUSE/user_codes/egs_cbct/egs_cbct.cpp
@@ -2250,7 +2250,14 @@ int EGS_CBCT::ausgab(int iarg) {
 int EGS_CBCT::simulateSingleShower() {
         last_case = current_case;
         EGS_Vector x,u;
+
+        setTimeIndex(-1);
+
         current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
+
+        // For dynamic geometries, update positions according to the current
+        // time index, which may have been set by getNextParticle
+        geometry->getNextGeom(rndm);
 
         /* if desired, rotate particles around x-axis (CBCT calculations)*/
 /*        if (cbctR){

--- a/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
+++ b/HEN_HOUSE/user_codes/egs_chamber/egs_chamber.cpp
@@ -2227,8 +2227,16 @@ int EGS_ChamberApplication::simulateSingleShower() {
     last_case = current_case;
     EGS_Vector x,u;
     the_egsvr->nbr_split = csplit;
+
+    setTimeIndex(-1);
+
     current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
     //egsInformation("Got particle: q=%d E=%g wt=%g latch=%d x=(%g,%g,%g) u=(%g,%g,%g)\n",p.q,p.E,p.wt,p.latch,x.x,x.y,x.z,u.x,u.y,u.z);
+
+    // For dynamic geometries, update positions according to the current
+    // time index, which may have been set by getNextParticle
+    geometry->getNextGeom(rndm);
+
     the_extra_stack->nbr_splitting[0] = 0;
     int err = startNewShower(); if( err ) return err;
     //*HB_start************************

--- a/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
+++ b/HEN_HOUSE/user_codes/egs_fac/egs_fac.cpp
@@ -310,7 +310,15 @@ int EGS_FACApplication::ausgab(int iarg) {
 int EGS_FACApplication::simulateSingleShower() {
     last_case = current_case;
     EGS_Vector x,u;
+
+    setTimeIndex(-1);
+
     current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
+
+    // For dynamic geometries, update positions according to the current
+    // time index, which may have been set by getNextParticle
+    geometry->getNextGeom(rndm);
+
     if( p.q ) egsFatal("Got particle with q=%d.\n"
         "This application only works for photons\n",p.q);
     int err = startNewShower(); if( err ) return err;

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -260,7 +260,13 @@ public:
         last_case = current_case;
         EGS_Vector x,u;
 
+        setTimeIndex(-1);
+
         current_case = source->getNextParticle(rndm,p.q,p.latch,p.E,p.wt,x,u);
+
+        // For dynamic geometries, update positions according to the current
+        // time index, which may have been set by getNextParticle
+        geometry->getNextGeom(rndm);
 
         if (p.q == 0) {
             Eph_ave += p.wt*p.E;


### PR DESCRIPTION
Fix a critical bug where dynamic geometries were visualized in egs_view, but the particles were transported in a static geometry. This was always the case in `egs_cbct`, `egs_chamber`, `egs_fac`, `egs_kerma`, and `cavity`. It was due to those applications overwriting the `simulateSingleShower` function, and thus not including the new changes to move geometries.

Any users with custom applications that overwrite (and don't call) the application class `simulateSingleShower` function should be updated to support motion (it's two lines to add).

Simulations in other applications were not affected.

Thanks to Patricia Oliver for reporting this!
