### PR TITLE
Fix #1213: add shape DSOs with compatibility

### DIFF
--- a/HEN_HOUSE/doc/src/getting-started/getting-started.tex
+++ b/HEN_HOUSE/doc/src/getting-started/getting-started.tex
@@ -619,7 +619,7 @@ Create a new file named \,\Verb|slab.egsinp|\, in the application directory,
             energy = 20 # in MeV
         :stop spectrum:
         :start shape:
-            type     = point
+            library  = egs_point_shape
             position = 0 0 -10 # in cm
         :stop shape:
     :stop source:
@@ -1279,7 +1279,7 @@ definition input to the source definition block
     name     = my_collimated_source
     distance = 100
     :start source shape:
-         type     = point
+         library  = egs_point_shape
          position = 0 0 -100
     :stop source shape:
     :start target shape:
@@ -2139,7 +2139,7 @@ you will need to replace this with a \href{http://nrc-cnrc.github.io/EGSnrc/doc/
         library = egs_collimated_source
         charge  = 0
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 -100
         :stop source shape:
         :start target shape:

--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -204,7 +204,7 @@ Here is an example, which was created using the \ref EGS_CollimatedSource docume
         library = egs_collimated_source
         name = my_source
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 5
         :stop source shape:
         :start target shape:
@@ -414,7 +414,7 @@ Putting together the examples suggested above, we have a complete input file. No
         library = egs_collimated_source # See the collimated source documentation
         name = my_source # A name of your choosing
         :start source shape: # Origin is a point
-            type = point
+            library = egs_point_shape
             position = 0 0 5 # Distances in cm
         :stop source shape:
         :start target shape: # Target shape for collimated source

--- a/HEN_HOUSE/doc/src/pirs898-egs++/egs_cbct.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/egs_cbct.doxy
@@ -142,7 +142,7 @@ Here is an example for a collimated point source of 60 keV photons:
     name = the_zero_collimated_source
     distance = 80
     :start source shape:
-        type = point
+        library = egs_point_shape
         position = 0, 0, -100
     :stop source shape:
     :start target shape:
@@ -704,7 +704,7 @@ see PIRS-877 for more details on running EGSnrc applications.
     name = the_zero_collimated_source
     distance = 80
     :start source shape:
-      type = point
+      library = egs_point_shape
       position = 0, 0, -100
     :stop source shape:
     :start target shape:

--- a/HEN_HOUSE/doc/src/pirs898-egs++/egs_chamber.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/egs_chamber.doxy
@@ -1488,7 +1488,7 @@ dose uncertainty:
         library = egs_collimated_source
         name = the_source
         :start source shape:
-                type = point
+                library = egs_point_shape
                 position = 0, 0, -100
         :stop source shape:
         :start target shape:

--- a/HEN_HOUSE/doc/src/pirs898-egs++/egs_gammaspec.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/egs_gammaspec.doxy
@@ -518,7 +518,7 @@ The output files are automatically named \c ${basename}-spec.txt and \c ${baseme
         charge              = 0
         geometry            = water_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 4.5
             height   = 4
             axis     = 0 0 1
@@ -548,7 +548,7 @@ The output files are automatically named \c ${basename}-spec.txt and \c ${baseme
         charge              = 0
         geometry            = soil_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 3
             height   = 2
             axis     = 0 0 1
@@ -578,7 +578,7 @@ The output files are automatically named \c ${basename}-spec.txt and \c ${baseme
         charge              = 0
         geometry            = filter_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 4
             height   = 0.3
             axis     = 0 0 1

--- a/HEN_HOUSE/doc/src/pirs898-egs++/egs_kerma.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/egs_kerma.doxy
@@ -446,7 +446,7 @@ for all materials in the scoring volume. Alternatively, one could compute mass-e
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, 0
         :stop shape:
 
@@ -595,7 +595,7 @@ for all materials in the scoring volume. Alternatively, one could compute mass-e
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, 0
         :stop shape:
 
@@ -818,7 +818,7 @@ for all materials in the scoring volume. Alternatively, one could compute mass-e
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, -100
         :stop shape:
 

--- a/HEN_HOUSE/egs++/Makefile
+++ b/HEN_HOUSE/egs++/Makefile
@@ -72,7 +72,8 @@ source_libs = egs_collimated_source egs_isotropic_source egs_parallel_beam \
 shape_libs = egs_circle egs_ellipse egs_extended_shape egs_gaussian_shape \
              egs_line_shape egs_polygon_shape egs_rectangle egs_shape_collection \
              egs_voxelized_shape egs_spherical_shell egs_conical_shell \
-             egs_circle_perpendicular egs_dynamic_shape
+             egs_circle_perpendicular egs_dynamic_shape egs_point_shape \
+             egs_box_shape egs_sphere_shape egs_cylinder_shape
 
 aobject_libs = egs_track_scoring egs_dose_scoring egs_radiative_splitting \
 	       egs_phsp_scoring egs_fluence_scoring

--- a/HEN_HOUSE/egs++/egs_geometry_tester.h
+++ b/HEN_HOUSE/egs++/egs_geometry_tester.h
@@ -100,7 +100,7 @@ public:
       \verbatim
       :start inside test:
           :start bounding shape:
-              type = box
+              library = egs_box_shape
               box size = 16
           :stop bounding shape:
           ntest = 10000

--- a/HEN_HOUSE/egs++/egs_shapes.cpp
+++ b/HEN_HOUSE/egs++/egs_shapes.cpp
@@ -83,6 +83,13 @@ void EGS_BaseShape::setTransformation(EGS_Input *input) {
 /**********************  Point  *******************************/
 
 EGS_Object *EGS_PointShape::createObject(EGS_Input *input) {
+    static bool warned = false;
+    if (!warned) {
+        egsWarning("EGS_PointShape::createShape: deprecated 'type = point' "
+                   "support is still available for backward compatibility; "
+                   "please migrate to 'library = egs_point_shape'\n");
+        warned = true;
+    }
     vector<EGS_Float> pos;
     int err = input->getInput("position",pos);
     if (err) {
@@ -102,6 +109,13 @@ EGS_Object *EGS_PointShape::createObject(EGS_Input *input) {
 /**********************  Box **********************************/
 
 EGS_Object *EGS_BoxShape::createObject(EGS_Input *input) {
+    static bool warned = false;
+    if (!warned) {
+        egsWarning("EGS_BoxShape::createShape: deprecated 'type = box' "
+                   "support is still available for backward compatibility; "
+                   "please migrate to 'library = egs_box_shape'\n");
+        warned = true;
+    }
     vector<EGS_Float> s;
     int err = input->getInput("box size",s);
     if (err) {
@@ -130,6 +144,13 @@ EGS_Object *EGS_BoxShape::createObject(EGS_Input *input) {
 /**********************  Sphere **********************************/
 
 EGS_Object *EGS_SphereShape::createObject(EGS_Input *input) {
+    static bool warned = false;
+    if (!warned) {
+        egsWarning("EGS_SphereShape::createShape: deprecated 'type = sphere' "
+                   "support is still available for backward compatibility; "
+                   "please migrate to 'library = egs_sphere_shape'\n");
+        warned = true;
+    }
     EGS_Float r;
     int err = input->getInput("radius",r);
     if (err) {
@@ -153,6 +174,13 @@ EGS_Object *EGS_SphereShape::createObject(EGS_Input *input) {
 /**********************  Cylinder **********************************/
 
 EGS_Object *EGS_CylinderShape::createObject(EGS_Input *input) {
+    static bool warned = false;
+    if (!warned) {
+        egsWarning("EGS_CylinderShape::getShape: deprecated 'type = cylinder' "
+                   "support is still available for backward compatibility; "
+                   "please migrate to 'library = egs_cylinder_shape'\n");
+        warned = true;
+    }
     EGS_Float r, H;
     int err = input->getInput("radius",r);
     if (err) {

--- a/HEN_HOUSE/egs++/egs_shapes.h
+++ b/HEN_HOUSE/egs++/egs_shapes.h
@@ -113,9 +113,9 @@ inline void setShapeInputs(shared_ptr<EGS_BlockInput> shapePtr) {
   Most shapes are implemented as small DSOs, which are loaded dynamically
   as needed. Such shapes require the \c library key to be
   present in their definition in the input file.
-  A few of the most frequently used shapes are compiled
-  into egspp and therefore require a \c type key instead of
-  a \c library key.
+  A few of the most frequently used shapes can still be selected with
+  a \c type key for backward compatibility. This usage is deprecated and
+  new inputs should use the \c library key instead.
 
 */
 
@@ -360,7 +360,7 @@ protected:
 A Point shape is specified in the input file via
 \verbatim
 :start shape:
-    type = point
+    library = egs_point_shape
     position = px, py, pz
 :stop shape:
 \endverbatim
@@ -401,7 +401,7 @@ protected:
  * on the box surface. Specified in the input file via
 \verbatim
 :start shape:
-    type = box
+    library = egs_box_shape
     box size = 1 or 3 inputs defining the box size
 :stop shape:
 \endverbatim
@@ -533,7 +533,7 @@ Samples random points within a sphere or on the spherical surfcace.
 Specified in the input file via
 \verbatim
 :start shape:
-    type = sphere
+    library = egs_sphere_shape
     midpoint = Ox, Oy, Oz
     radius = the sphere radius
 :stop shape:
@@ -635,7 +635,7 @@ Samples random points within a cylinder or on the cylinder surfcace.
 Specified in the input file via
 \verbatim
 :start shape:
-    type = cylinder
+    library = egs_cylinder_shape
     radius = the cylinder radius
     height = the cylinder height
     midpoint = Ox, Oy, Oz (optional)

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.h
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.h
@@ -235,7 +235,7 @@ There is an example geometry included in the examples/seeds_in_xyz_aenv.geom fil
             # bounding shape definition. Note only volumetric shapes make sense here!
             :start shape:
 
-                type = cylinder
+                library = egs_cylinder_shape
                 radius = 0.04
                 height = 0.45
 

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/volcor.h
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/volcor.h
@@ -225,7 +225,7 @@ EGS_Float getShapeVolume(EGS_Input *shape_inp) {
     density of random points (cm^-3) = 1E6 # Defaults to 1E8
 
     :start shape:
-        type = cylinder
+        library = egs_cylinder_shape
         radius = 0.04
         height = 0.45
         # volume = 123456 # use volume key for shapes other than cylinder, sphere, or box

--- a/HEN_HOUSE/egs++/shapes/egs_box_shape/Makefile
+++ b/HEN_HOUSE/egs++/shapes/egs_box_shape/Makefile
@@ -1,0 +1,36 @@
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build box shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_BOX_SHAPE_DLL
+
+library = egs_box_shape
+lib_files = egs_box_shape
+my_deps = $(common_shape_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/shapes/egs_box_shape/egs_box_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_box_shape/egs_box_shape.cpp
@@ -1,0 +1,63 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ box shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#include "egs_box_shape.h"
+#include "egs_input.h"
+
+extern "C" {
+
+    EGS_BOX_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        (void)f;
+        if (!input) {
+            egsWarning("createShape(box_shape): null input?\n");
+            return 0;
+        }
+        vector<EGS_Float> s;
+        int err = input->getInput("box size",s);
+        if (err) {
+            egsWarning("createShape(box_shape): no 'box size' input?\n");
+            return 0;
+        }
+        EGS_AffineTransform *t = EGS_AffineTransform::getTransformation(input);
+        EGS_BoxShape *shape = 0;
+        if (s.size() == 1) {
+            shape = new EGS_BoxShape(s[0],t);
+        }
+        else if (s.size() == 3) {
+            shape = new EGS_BoxShape(s[0],s[1],s[2],t);
+        }
+        else {
+            egsWarning("createShape(box_shape): invalid 'box size' input\n");
+        }
+        if (t) {
+            delete t;
+        }
+        if (!shape) {
+            return 0;
+        }
+        shape->setName(input);
+        return shape;
+    }
+}

--- a/HEN_HOUSE/egs++/shapes/egs_box_shape/egs_box_shape.h
+++ b/HEN_HOUSE/egs++/shapes/egs_box_shape/egs_box_shape.h
@@ -1,0 +1,47 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ box shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#ifndef EGS_BOX_SHAPE_
+#define EGS_BOX_SHAPE_
+
+#include "egs_shapes.h"
+
+#ifdef WIN32
+    #ifdef BUILD_BOX_SHAPE_DLL
+        #define EGS_BOX_SHAPE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_BOX_SHAPE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_BOX_SHAPE_LOCAL
+#else
+    #ifdef HAVE_VISIBILITY
+        #define EGS_BOX_SHAPE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_BOX_SHAPE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_BOX_SHAPE_EXPORT
+        #define EGS_BOX_SHAPE_LOCAL
+    #endif
+#endif
+
+#endif

--- a/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/Makefile
+++ b/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/Makefile
@@ -1,0 +1,36 @@
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build cylinder shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_CYLINDER_SHAPE_DLL
+
+library = egs_cylinder_shape
+lib_files = egs_cylinder_shape
+my_deps = $(common_shape_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/egs_cylinder_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/egs_cylinder_shape.cpp
@@ -1,0 +1,89 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ cylinder shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#include "egs_cylinder_shape.h"
+#include "egs_input.h"
+
+extern "C" {
+
+    EGS_CYLINDER_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        (void)f;
+        if (!input) {
+            egsWarning("createShape(cylinder_shape): null input?\n");
+            return 0;
+        }
+        EGS_Float r, H;
+        int err = input->getInput("radius",r);
+        if (err) {
+            egsWarning("createShape(cylinder_shape): wrong/missing 'radius' input\n");
+            return 0;
+        }
+        err = input->getInput("height",H);
+        if (err) {
+            egsWarning("createShape(cylinder_shape): wrong/missing 'height' input\n");
+            return 0;
+        }
+        vector<EGS_Float> phi_range;
+        bool set_phi = false;
+        if (!input->getInput("phi range",phi_range) && phi_range.size() == 2) {
+            set_phi = true;
+            phi_range[0] *= M_PI/180;
+            phi_range[1] *= M_PI/180;
+        }
+        EGS_AffineTransform *t = EGS_AffineTransform::getTransformation(input);
+        if (t) {
+            EGS_CylinderShape *shape = new EGS_CylinderShape(r,H,t);
+            shape->setName(input);
+            if (set_phi) {
+                shape->setPhiRange(phi_range[0],phi_range[1]);
+            }
+            delete t;
+            return shape;
+        }
+        vector<EGS_Float> Xo, A;
+        int err1 = input->getInput("midpoint",Xo);
+        int err2 = input->getInput("axis",A);
+        bool has_Xo = (err1 == 0 && Xo.size() == 3);
+        bool has_A = (err2 == 0 && A.size() == 3);
+        EGS_CylinderShape *shape;
+        if (has_Xo && has_A) {
+            shape = new EGS_CylinderShape(r,H,EGS_Vector(Xo[0],Xo[1],Xo[2]),EGS_Vector(A[0],A[1],A[2]));
+        }
+        else if (has_Xo) {
+            shape = new EGS_CylinderShape(r,H,EGS_Vector(Xo[0],Xo[1],Xo[2]));
+        }
+        else if (has_A) {
+            shape = new EGS_CylinderShape(r,H,EGS_Vector(0,0,0),EGS_Vector(A[0],A[1],A[2]));
+        }
+        else {
+            shape = new EGS_CylinderShape(r,H);
+        }
+        shape->setName(input);
+        if (set_phi) {
+            shape->setPhiRange(phi_range[0],phi_range[1]);
+        }
+        return shape;
+    }
+}

--- a/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/egs_cylinder_shape.h
+++ b/HEN_HOUSE/egs++/shapes/egs_cylinder_shape/egs_cylinder_shape.h
@@ -1,0 +1,47 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ cylinder shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#ifndef EGS_CYLINDER_SHAPE_
+#define EGS_CYLINDER_SHAPE_
+
+#include "egs_shapes.h"
+
+#ifdef WIN32
+    #ifdef BUILD_CYLINDER_SHAPE_DLL
+        #define EGS_CYLINDER_SHAPE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_CYLINDER_SHAPE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_CYLINDER_SHAPE_LOCAL
+#else
+    #ifdef HAVE_VISIBILITY
+        #define EGS_CYLINDER_SHAPE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_CYLINDER_SHAPE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_CYLINDER_SHAPE_EXPORT
+        #define EGS_CYLINDER_SHAPE_LOCAL
+    #endif
+#endif
+
+#endif

--- a/HEN_HOUSE/egs++/shapes/egs_point_shape/Makefile
+++ b/HEN_HOUSE/egs++/shapes/egs_point_shape/Makefile
@@ -1,0 +1,36 @@
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build point shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_POINT_SHAPE_DLL
+
+library = egs_point_shape
+lib_files = egs_point_shape
+my_deps = $(common_shape_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/shapes/egs_point_shape/egs_point_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_point_shape/egs_point_shape.cpp
@@ -1,0 +1,52 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ point shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#include "egs_point_shape.h"
+#include "egs_input.h"
+
+extern "C" {
+
+    EGS_POINT_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        (void)f;
+        if (!input) {
+            egsWarning("createShape(point_shape): null input?\n");
+            return 0;
+        }
+        vector<EGS_Float> pos;
+        int err = input->getInput("position",pos);
+        if (err) {
+            egsWarning("createShape(point_shape): no 'position' input\n");
+            return 0;
+        }
+        if (pos.size() != 3) {
+            egsWarning("createShape(point_shape): found %d inputs instead of 3\n",
+                       pos.size());
+            return 0;
+        }
+        EGS_PointShape *shape = new EGS_PointShape(EGS_Vector(pos[0],pos[1],pos[2]));
+        shape->setName(input);
+        return shape;
+    }
+}

--- a/HEN_HOUSE/egs++/shapes/egs_point_shape/egs_point_shape.h
+++ b/HEN_HOUSE/egs++/shapes/egs_point_shape/egs_point_shape.h
@@ -1,0 +1,47 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ point shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#ifndef EGS_POINT_SHAPE_
+#define EGS_POINT_SHAPE_
+
+#include "egs_shapes.h"
+
+#ifdef WIN32
+    #ifdef BUILD_POINT_SHAPE_DLL
+        #define EGS_POINT_SHAPE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_POINT_SHAPE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_POINT_SHAPE_LOCAL
+#else
+    #ifdef HAVE_VISIBILITY
+        #define EGS_POINT_SHAPE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_POINT_SHAPE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_POINT_SHAPE_EXPORT
+        #define EGS_POINT_SHAPE_LOCAL
+    #endif
+#endif
+
+#endif

--- a/HEN_HOUSE/egs++/shapes/egs_sphere_shape/Makefile
+++ b/HEN_HOUSE/egs++/shapes/egs_sphere_shape/Makefile
@@ -1,0 +1,36 @@
+###############################################################################
+#
+#  EGSnrc egs++ makefile to build sphere shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+include $(EGS_CONFIG)
+include $(SPEC_DIR)egspp.spec
+include $(SPEC_DIR)egspp_$(my_machine).conf
+
+DEFS = $(DEF1) -DBUILD_SPHERE_SHAPE_DLL
+
+library = egs_sphere_shape
+lib_files = egs_sphere_shape
+my_deps = $(common_shape_deps)
+extra_dep = $(addprefix $(DSOLIBS), $(my_deps))
+
+include $(SPEC_DIR)egspp_libs.spec
+
+$(make_depend)

--- a/HEN_HOUSE/egs++/shapes/egs_sphere_shape/egs_sphere_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_sphere_shape/egs_sphere_shape.cpp
@@ -1,0 +1,55 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ sphere shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#include "egs_sphere_shape.h"
+#include "egs_input.h"
+
+extern "C" {
+
+    EGS_SPHERE_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
+            EGS_ObjectFactory *f) {
+        (void)f;
+        if (!input) {
+            egsWarning("createShape(sphere_shape): null input?\n");
+            return 0;
+        }
+        EGS_Float r;
+        int err = input->getInput("radius",r);
+        if (err) {
+            egsWarning("createShape(sphere_shape): wrong/missing 'radius' input\n");
+            return 0;
+        }
+        vector<EGS_Float> xo;
+        EGS_SphereShape *shape = 0;
+        err = input->getInput("midpoint",xo);
+        if (!err && xo.size() == 3) {
+            shape = new EGS_SphereShape(r,EGS_Vector(xo[0],xo[1],xo[2]));
+        }
+        else {
+            shape = new EGS_SphereShape(r);
+        }
+        shape->setName(input);
+        return shape;
+    }
+}

--- a/HEN_HOUSE/egs++/shapes/egs_sphere_shape/egs_sphere_shape.h
+++ b/HEN_HOUSE/egs++/shapes/egs_sphere_shape/egs_sphere_shape.h
@@ -1,0 +1,47 @@
+/*
+###############################################################################
+#
+#  EGSnrc egs++ sphere shape
+#  Copyright (C) 2015 National Research Council Canada
+#
+#  This file is part of EGSnrc.
+#
+#  EGSnrc is free software: you can redistribute it and/or modify it under
+#  the terms of the GNU Affero General Public License as published by the
+#  Free Software Foundation, either version 3 of the License, or (at your
+#  option) any later version.
+#
+#  EGSnrc is distributed in the hope that it will be useful, but WITHOUT ANY
+#  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+#  FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for
+#  more details.
+#
+#  You should have received a copy of the GNU Affero General Public License
+#  along with EGSnrc. If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+*/
+
+#ifndef EGS_SPHERE_SHAPE_
+#define EGS_SPHERE_SHAPE_
+
+#include "egs_shapes.h"
+
+#ifdef WIN32
+    #ifdef BUILD_SPHERE_SHAPE_DLL
+        #define EGS_SPHERE_SHAPE_EXPORT __declspec(dllexport)
+    #else
+        #define EGS_SPHERE_SHAPE_EXPORT __declspec(dllimport)
+    #endif
+    #define EGS_SPHERE_SHAPE_LOCAL
+#else
+    #ifdef HAVE_VISIBILITY
+        #define EGS_SPHERE_SHAPE_EXPORT __attribute__ ((visibility ("default")))
+        #define EGS_SPHERE_SHAPE_LOCAL  __attribute__ ((visibility ("hidden")))
+    #else
+        #define EGS_SPHERE_SHAPE_EXPORT
+        #define EGS_SPHERE_SHAPE_LOCAL
+    #endif
+#endif
+
+#endif

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.h
@@ -136,7 +136,7 @@ A simple example:
         library = egs_collimated_source
         name = my_source
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 5
         :stop source shape:
         :start target shape:

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -224,7 +224,7 @@ the geometry and source blocks are provided:
         region selection    = IncludeSelected
         selected regions    = 1 2
         :start shape:
-            type     = box
+            library  = egs_box_shape
             box size    = 1 2 3
             :start media input:
                 media = H2O521ICRU

--- a/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.h
+++ b/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.h
@@ -102,7 +102,7 @@ A simple example:
         library = egs_parallel_beam
         name = my_source
         :start shape:
-            type = cylinder
+            library = egs_cylinder_shape
             radius   = 1
             height   = 2
             axis     = 0 0 1

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.h
@@ -956,7 +956,7 @@ results for non-disintegration emissions.
         region selection    = IncludeSelected
         selected regions    = 1 2
         :start shape:
-            type        = box
+            library     = egs_box_shape
             box size    = 1 2 3
         :stop shape:
         :start spectrum: # This will not actually be used, but is required

--- a/HEN_HOUSE/user_codes/egs_app/slab.egsinp
+++ b/HEN_HOUSE/user_codes/egs_app/slab.egsinp
@@ -81,7 +81,7 @@
             energy = 20                         # MeV
         :stop spectrum:
         :start shape:
-            type     = point
+            library  = egs_point_shape
             position = 0 0 -8                   # cm
         :stop shape:
     :stop source:

--- a/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
+++ b/HEN_HOUSE/user_codes/egs_cbct/example_w5br.egsinp
@@ -119,7 +119,7 @@
     name = the_zero_collimated_source
     distance = 80
     :start source shape:
-      type = point
+      library = egs_point_shape
       position = 0, 0, -100
     :stop source shape:
     :start target shape:

--- a/HEN_HOUSE/user_codes/egs_chamber/example1_co60_Pfactors.egsinp
+++ b/HEN_HOUSE/user_codes/egs_chamber/example1_co60_Pfactors.egsinp
@@ -431,7 +431,7 @@
         library = egs_collimated_source
         charge  = 0
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 -105.000
         :stop source shape:
         :start target shape:

--- a/HEN_HOUSE/user_codes/egs_chamber/example1_profile_pfactors.egsinp
+++ b/HEN_HOUSE/user_codes/egs_chamber/example1_profile_pfactors.egsinp
@@ -424,7 +424,7 @@
         library = egs_collimated_source
         charge  = 0
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 -100.000
         :stop source shape:
         :start target shape:

--- a/HEN_HOUSE/user_codes/egs_kerma/example_20MeV_e-_Pb-shield_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_20MeV_e-_Pb-shield_FD.egsinp
@@ -113,7 +113,7 @@
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, 0
         :stop shape:
 

--- a/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_40keV_SDD_1m_FD.egsinp
@@ -167,7 +167,7 @@
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, -100
         :stop shape:
 

--- a/HEN_HOUSE/user_codes/egs_kerma/example_5keV_H2O_FD.egsinp
+++ b/HEN_HOUSE/user_codes/egs_kerma/example_5keV_H2O_FD.egsinp
@@ -118,7 +118,7 @@
 
         ### source shape
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0, 0, 0
         :stop shape:
 

--- a/HEN_HOUSE/user_codes/egs_phd/ge-example.egsinp
+++ b/HEN_HOUSE/user_codes/egs_phd/ge-example.egsinp
@@ -230,7 +230,7 @@
         distance = 0.282094791774  ### 1/sqrt(4*pi), to normalized result per particle emitted in 4*pi
 
         :start source shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 40
        :stop source shape:
 

--- a/HEN_HOUSE/user_codes/egs_phd/icrm-hpge-example.egsinp
+++ b/HEN_HOUSE/user_codes/egs_phd/icrm-hpge-example.egsinp
@@ -399,7 +399,7 @@
         charge   = 0
         geometry = water_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 4.5
             height   = 4
             axis     = 0 0 1
@@ -422,7 +422,7 @@
         charge   = 0
         geometry = soil_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 3
             height   = 2
             axis     = 0 0 1
@@ -445,7 +445,7 @@
         charge   = 0
         geometry = filter_source_geom
         :start shape:
-            type     = cylinder
+            library  = egs_cylinder_shape
             radius   = 4
             height   = 0.3
             axis     = 0 0 1

--- a/HEN_HOUSE/user_codes/tutor2pp/test1.egsinp
+++ b/HEN_HOUSE/user_codes/tutor2pp/test1.egsinp
@@ -59,7 +59,7 @@
         library = egs_parallel_beam
         name = the_source
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 1e-7
         :stop shape:
         direction = 0 0 1

--- a/HEN_HOUSE/user_codes/tutor4pp/slab.egsinp
+++ b/HEN_HOUSE/user_codes/tutor4pp/slab.egsinp
@@ -107,7 +107,7 @@
             energy = 20                     # in MeV
         :stop spectrum:
         :start shape:
-            type     = point
+            library  = egs_point_shape
             position = 0 0 -10
         :stop shape:
     :stop source:

--- a/HEN_HOUSE/user_codes/tutor7pp/test1.egsinp
+++ b/HEN_HOUSE/user_codes/tutor7pp/test1.egsinp
@@ -56,7 +56,7 @@
         library = egs_parallel_beam
         name = the_source
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 1e-7
         :stop shape:
         direction = 0 0 1

--- a/HEN_HOUSE/user_codes/tutor7pp/tracks1.egsinp
+++ b/HEN_HOUSE/user_codes/tutor7pp/tracks1.egsinp
@@ -56,7 +56,7 @@
         library = egs_parallel_beam
         name = the_source
         :start shape:
-            type = point
+            library = egs_point_shape
             position = 0 0 -0.1
         :stop shape:
         direction = 0 0 1


### PR DESCRIPTION
## Summary
- Convert simple built-in shapes to shared-library shape modules by adding `egs_point_shape`, `egs_box_shape`, `egs_sphere_shape`, and `egs_cylinder_shape`.
- Keep backward compatibility for `type = point|box|sphere|cylinder` and emit one-time deprecation warnings that direct users to `library = egs_*_shape`.
- Update in-repo examples and docs to prefer `library = egs_*_shape`, including user-code inputs and `egs_autoenvelope` shape examples.

## Validation
- Build: `make shapes` in `HEN_HOUSE/egs++` succeeds with all four new DSOs.
- Style: `astyle` check using `HEN_HOUSE/scripts/egs_style_standard` on new shape files reports unchanged.
- Runtime matrix (`test_source`): all 8 paths pass (4 shapes x `type`/`library`), with deprecation warnings only on `type=`.
- Real app (`egs_app`): all 8 reduced-case runtime combinations pass (`exit 0`, simulation starts/finishes, no DSO load errors).
- Second app (`egs_kerma`): reduced-case example run passes (`exit 0`, finished simulation, no DSO load errors).

## Compatibility
- Preserved legacy input behavior:
  - `type = point` -> still works, warns to use `library = egs_point_shape`
  - `type = box` -> still works, warns to use `library = egs_box_shape`
  - `type = sphere` -> still works, warns to use `library = egs_sphere_shape`
  - `type = cylinder` -> still works, warns to use `library = egs_cylinder_shape`
- This PR is migration-friendly and non-breaking for existing `type=` inputs.
