### PR TITLE
Fix #1275 accessing egs_glib geometries by ausgab objects

### DIFF
--- a/HEN_HOUSE/egs++/egs_base_geometry.cpp
+++ b/HEN_HOUSE/egs++/egs_base_geometry.cpp
@@ -49,6 +49,7 @@
 
 #include <algorithm>
 #include <vector>
+#include <map>
 #include <cstdio>
 #include <cstdarg>
 #include <cstdlib>
@@ -68,6 +69,7 @@ public:
 
     int nnow, ntot;
     EGS_BaseGeometry **geoms;
+    map<string, EGS_BaseGeometry *> aliases;
     vector<string> media;
     vector<EGS_Library *> glibs;
     static string geom_delimeter;
@@ -127,6 +129,7 @@ public:
 
     void clearGeometries() {
         media.clear();
+        aliases.clear();
         if (!ntot) {
             return;
         }
@@ -188,6 +191,14 @@ public:
     };
 
     void removeGeometry(EGS_BaseGeometry *g) {
+        for (map<string, EGS_BaseGeometry *>::iterator it = aliases.begin(); it != aliases.end(); ) {
+            if (it->second == g) {
+                aliases.erase(it++);
+            }
+            else {
+                ++it;
+            }
+        }
         ntot--;
         EGS_BaseGeometry **tmp = new EGS_BaseGeometry* [ntot];
         int i=0;
@@ -208,7 +219,35 @@ public:
             if (geoms[j]->getName() == name) {
                 return geoms[j];
             }
+        map<string, EGS_BaseGeometry *>::const_iterator alias = aliases.find(name);
+        if (alias != aliases.end()) {
+            return alias->second;
+        }
         return 0;
+    };
+
+    bool addGeometryAlias(const string &alias, EGS_BaseGeometry *geom) {
+        if (!geom || alias.empty()) {
+            return false;
+        }
+        for (int j=0; j<nnow; ++j) {
+            if (geoms[j]->getName() == alias && geoms[j] != geom) {
+                egsWarning("EGS_GeometryPrivate::addGeometryAlias: alias '%s' conflicts with geometry name '%s'\n",
+                           alias.c_str(), geoms[j]->getName().c_str());
+                return false;
+            }
+        }
+        map<string, EGS_BaseGeometry *>::iterator it = aliases.find(alias);
+        if (it != aliases.end()) {
+            if (it->second == geom) {
+                return true;
+            }
+            egsWarning("EGS_GeometryPrivate::addGeometryAlias: alias '%s' already refers to geometry '%s'\n",
+                       alias.c_str(), it->second->getName().c_str());
+            return false;
+        }
+        aliases[alias] = geom;
+        return true;
     };
 
     int addMedium(const string &Name) {
@@ -471,6 +510,10 @@ void EGS_BaseGeometry::clearGeometries() {
 
 EGS_BaseGeometry *EGS_BaseGeometry::getGeometry(const string &Name) {
     return egs_geometries[active_glist].getGeometry(Name);
+}
+
+bool EGS_BaseGeometry::addGeometryAlias(const string &alias, EGS_BaseGeometry *geom) {
+    return egs_geometries[active_glist].addGeometryAlias(alias,geom);
 }
 
 EGS_BaseGeometry **EGS_BaseGeometry::getGeometries() {

--- a/HEN_HOUSE/egs++/egs_base_geometry.h
+++ b/HEN_HOUSE/egs++/egs_base_geometry.h
@@ -607,6 +607,7 @@ public:
      geometries, or \c null if no such geometry exists.
      */
     static EGS_BaseGeometry *getGeometry(const string &Name);
+    static bool addGeometryAlias(const string &alias, EGS_BaseGeometry *geom);
 
     static EGS_BaseGeometry **getGeometries();
 

--- a/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
@@ -111,7 +111,15 @@ extern "C" {
             return 0;
         }
 
+        string included_name = final->getName();
         final->setName(input);
+        string wrapper_name = final->getName();
+        if (included_name != wrapper_name) {
+            if (!EGS_BaseGeometry::addGeometryAlias(included_name, final)) {
+                egsWarning("createGeometry(egs_glib): failed to register alias '%s' for geometry '%s'\n",
+                           included_name.c_str(), wrapper_name.c_str());
+            }
+        }
 
         return final;
 

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_include.geom
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_include.geom
@@ -1,0 +1,17 @@
+:start geometry definition:
+
+    :start geometry:
+        name = myxyz_tiny2
+        library = egs_ndgeometry
+        type = EGS_XYZGeometry
+        x-planes = -7, -6
+        y-planes = -7, -6
+        z-planes = -1, 1
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+
+    simulation geometry = myxyz_tiny2
+
+:stop geometry definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_include_box.geom
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_include_box.geom
@@ -1,0 +1,14 @@
+:start geometry definition:
+
+    :start geometry:
+        library = egs_box
+        name = myxyz_tiny2
+        box size = 2
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+
+    simulation geometry = myxyz_tiny2
+
+:stop geometry definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_include.geom
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_include.geom
@@ -1,0 +1,19 @@
+:start geometry definition:
+
+    :start geometry:
+        name = myxyz_labeled
+        library = egs_ndgeometry
+        type = EGS_XYZGeometry
+        x-planes = -7, -6, -5
+        y-planes = -7, -6
+        z-planes = -1, 1
+        set label = left_voxel 0
+        set label = right_voxel 1
+        :start media input:
+            media = water
+        :stop media input:
+    :stop geometry:
+
+    simulation geometry = myxyz_labeled
+
+:stop geometry definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_neg_unknown_label.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_neg_unknown_label.egsinp
@@ -1,0 +1,58 @@
+##############################################################################
+# Negative probe: unknown dose region label with egs_glib + alias lookup
+##############################################################################
+
+:start run control:
+    ncase = 1e3
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib-label
+        include file = glib_alias_labels_include.geom
+    :stop geometry:
+    simulation geometry = my-glib-label
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = -6.75 -6.5 0
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_label_unknown
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = yes
+        dose regions = does_not_exist
+        :start output dose file:
+            geometry name = myxyz_labeled
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_pos.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_labels_pos.egsinp
@@ -1,0 +1,58 @@
+##############################################################################
+# Positive test: region labels with egs_glib + alias lookup
+##############################################################################
+
+:start run control:
+    ncase = 1e4
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib-label
+        include file = glib_alias_labels_include.geom
+    :stop geometry:
+    simulation geometry = my-glib-label
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = -6.75 -6.5 0
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_label_left
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = yes
+        dose regions = left_voxel
+        :start output dose file:
+            geometry name = myxyz_labeled
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_lookup.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_lookup.egsinp
@@ -1,0 +1,35 @@
+# Regression input for egs_glib name aliasing.
+# This demonstrates that both the internal included simulation geometry name
+# and the wrapper egs_glib geometry name can be resolved by geometry lookups.
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib
+        include file = glib_alias_include.geom
+    :stop geometry:
+
+    simulation geometry = my-glib
+:stop geometry definition:
+
+:start ausgab object:
+    name = dose_internal_name
+    library = egs_dose_scoring
+    medium dose = no
+    region dose = no
+    :start output dose file:
+        geometry name = myxyz_tiny2
+        file type = 3ddose
+    :stop output dose file:
+:stop ausgab object:
+
+:start ausgab object:
+    name = dose_wrapper_name
+    library = egs_dose_scoring
+    medium dose = no
+    region dose = no
+    :start output dose file:
+        geometry name = my-glib
+        file type = 3ddose
+    :stop output dose file:
+:stop ausgab object:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_neg_collision_internal.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_neg_collision_internal.egsinp
@@ -1,0 +1,64 @@
+##############################################################################
+# Negative test: alias collision between two glib wrappers
+##############################################################################
+
+:start run control:
+    ncase = 0
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib-box
+        include file = glib_alias_include_box.geom
+    :stop geometry:
+
+    :start geometry:
+        library = egs_glib
+        name = my-glib-xyz
+        include file = glib_alias_include.geom
+    :stop geometry:
+
+    simulation geometry = my-glib-xyz
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = 0 0 -0.5
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_internal_name_collision
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = myxyz_tiny2
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_neg_missing_geom.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_neg_missing_geom.egsinp
@@ -1,0 +1,57 @@
+##############################################################################
+# Negative test: missing geometry name in dose scoring
+##############################################################################
+
+:start run control:
+    ncase = 0
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib
+        include file = glib_alias_include.geom
+    :stop geometry:
+    simulation geometry = my-glib
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = 0 0 -0.5
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_missing_geom
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = no_such_geometry
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_both.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_both.egsinp
@@ -1,0 +1,68 @@
+##############################################################################
+# Positive test: both internal and wrapper geometry names resolve
+##############################################################################
+
+:start run control:
+    ncase = 1e4
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib
+        include file = glib_alias_include.geom
+    :stop geometry:
+    simulation geometry = my-glib
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = -6.5 -6.5 0
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_internal_name
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = myxyz_tiny2
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+
+    :start ausgab object:
+        name = dose_wrapper_name
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = my-glib
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_internal.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_internal.egsinp
@@ -1,0 +1,57 @@
+##############################################################################
+# Positive test: dose scoring by internal included geometry name
+##############################################################################
+
+:start run control:
+    ncase = 1e4
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib
+        include file = glib_alias_include.geom
+    :stop geometry:
+    simulation geometry = my-glib
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = -6.5 -6.5 0
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_internal_name
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = myxyz_tiny2
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_wrapper.egsinp
+++ b/HEN_HOUSE/egs++/geometry/examples/glib_alias_pos_wrapper.egsinp
@@ -1,0 +1,57 @@
+##############################################################################
+# Positive test: dose scoring by wrapper glib geometry name
+##############################################################################
+
+:start run control:
+    ncase = 1e4
+:stop run control:
+
+:start geometry definition:
+    :start geometry:
+        library = egs_glib
+        name = my-glib
+        include file = glib_alias_include.geom
+    :stop geometry:
+    simulation geometry = my-glib
+:stop geometry definition:
+
+:start media definition:
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+:stop media definition:
+
+:start source definition:
+    :start source:
+        name = pencil_beam
+        library = egs_parallel_beam
+        charge = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 1
+        :stop spectrum:
+        :start shape:
+            type = point
+            position = -6.5 -6.5 0
+        :stop shape:
+    :stop source:
+    simulation source = pencil_beam
+:stop source definition:
+
+:start ausgab object definition:
+    :start ausgab object:
+        name = dose_wrapper_name
+        library = egs_dose_scoring
+        medium dose = no
+        region dose = no
+        :start output dose file:
+            geometry name = my-glib
+            file type = 3ddose
+        :stop output dose file:
+    :stop ausgab object:
+:stop ausgab object definition:

--- a/HEN_HOUSE/egs++/geometry/examples/run_glib_alias_tests.sh
+++ b/HEN_HOUSE/egs++/geometry/examples/run_glib_alias_tests.sh
@@ -1,9 +1,76 @@
 #!/usr/bin/env bash
+# Run glib geometry-alias regression tests via egs_app.
+#
+# Environment (optional unless noted):
+#   HEN_HOUSE    — path to HEN_HOUSE (default: inferred from this script’s location)
+#   EGS_HOME     — user application tree (default: dirname(HEN_HOUSE)/egs_home if present)
+#   EGS_CONFIG   — e.g. $HEN_HOUSE/specs/<machine>.conf; used to read my_machine if set
+#   EGS_MACHINE  — config/machine name (default: from EGS_CONFIG, else glib-ausgab)
+#   APP_BIN      — override path to egs_app (default: $EGS_HOME/bin/$EGS_MACHINE/egs_app)
+#   LIB_DIR      — DSO directory for DYLD_LIBRARY_PATH (default:
+#                  $HEN_HOUSE/egs++/dso/$EGS_MACHINE)
+#
+# egs_app always opens inputs from $EGS_HOME/egs_app/<name>.egsinp. This script
+# symlinks the glib_alias example .egsinp and .geom files from this directory
+# into that folder so the tests do not need manual copies.
+
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
-APP_BIN="${APP_BIN:-/Users/marc/Developer/EGSnrc/egs_home/bin/glib-ausgab/egs_app}"
-LIB_DIR="${LIB_DIR:-/Users/marc/Developer/EGSnrc/HEN_HOUSE/egs++/dso/glib-ausgab}"
+
+# Infer HEN_HOUSE when unset: this file lives under .../HEN_HOUSE/egs++/geometry/examples
+if [[ -z "${HEN_HOUSE:-}" ]]; then
+  _hh="$(cd "${ROOT_DIR}/../../.." && pwd)"
+  if [[ "$(basename "${_hh}")" == "HEN_HOUSE" ]] || [[ -d "${_hh}/egs++/dso" ]]; then
+    HEN_HOUSE="${_hh}"
+  fi
+fi
+if [[ -z "${HEN_HOUSE:-}" ]]; then
+  echo "error: set HEN_HOUSE or install this script under HEN_HOUSE/egs++/geometry/examples" >&2
+  exit 1
+fi
+HEN_HOUSE="${HEN_HOUSE%/}"
+
+# Machine name: explicit env, or parse from EGS_CONFIG (my_machine = ...), or default
+EGS_MACHINE="${EGS_MACHINE:-}"
+if [[ -z "${EGS_MACHINE}" && -n "${EGS_CONFIG:-}" && -f "${EGS_CONFIG}" ]]; then
+  EGS_MACHINE="$(grep -m1 '^[[:space:]]*my_machine[[:space:]]*=' "${EGS_CONFIG}" | sed -e 's/^[^=]*=[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//")"
+fi
+EGS_MACHINE="${EGS_MACHINE:-glib-ausgab}"
+
+# EGS_HOME: sibling of HEN_HOUSE by convention
+if [[ -z "${EGS_HOME:-}" ]]; then
+  _parent="$(dirname "${HEN_HOUSE}")"
+  if [[ -d "${_parent}/egs_home" ]]; then
+    EGS_HOME="${_parent}/egs_home"
+  fi
+fi
+
+LIB_DIR="${LIB_DIR:-${HEN_HOUSE}/egs++/dso/${EGS_MACHINE}}"
+APP_BIN="${APP_BIN:-${EGS_HOME:-}/bin/${EGS_MACHINE}/egs_app}"
+
+if [[ ! -x "${APP_BIN}" ]]; then
+  echo "error: egs_app not found or not executable: ${APP_BIN}" >&2
+  echo "Set APP_BIN, EGS_HOME, and/or EGS_MACHINE (or EGS_CONFIG so my_machine can be read)." >&2
+  exit 1
+fi
+
+if [[ -z "${EGS_HOME:-}" || ! -d "${EGS_HOME}/egs_app" ]]; then
+  echo "error: EGS_HOME must be set and contain egs_app/ (egs_app loads -i from there only)." >&2
+  exit 1
+fi
+
+# egs_app resolves -i as $EGS_HOME/egs_app/<input>.egsinp (not cwd)
+link_glib_alias_inputs() {
+  local f base
+  shopt -s nullglob
+  for f in "${ROOT_DIR}"/glib_alias_*.egsinp "${ROOT_DIR}"/glib_alias_*.geom; do
+    base="$(basename "${f}")"
+    ln -sf "${f}" "${EGS_HOME}/egs_app/${base}"
+  done
+  shopt -u nullglob
+}
+link_glib_alias_inputs
 
 run_expect_success() {
   local input_name="$1"
@@ -34,7 +101,7 @@ cd "${ROOT_DIR}"
 
 run_expect_success "glib_alias_pos_internal"
 run_expect_success "glib_alias_pos_wrapper"
-run_expect_success "glib_alias_validation"
+run_expect_success "glib_alias_pos_both"
 run_expect_success "glib_alias_labels_pos"
 # Unknown label currently falls back to all regions; keep as a passing regression probe.
 run_expect_success "glib_alias_labels_neg_unknown_label"

--- a/HEN_HOUSE/egs++/geometry/examples/run_glib_alias_tests.sh
+++ b/HEN_HOUSE/egs++/geometry/examples/run_glib_alias_tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_BIN="${APP_BIN:-/Users/marc/Developer/EGSnrc/egs_home/bin/glib-ausgab/egs_app}"
+LIB_DIR="${LIB_DIR:-/Users/marc/Developer/EGSnrc/HEN_HOUSE/egs++/dso/glib-ausgab}"
+
+run_expect_success() {
+  local input_name="$1"
+  local log_file="${ROOT_DIR}/${input_name}.log"
+  echo "==> PASS expected: ${input_name}"
+  DYLD_LIBRARY_PATH="${LIB_DIR}" "${APP_BIN}" -i "${input_name}" > "${log_file}" 2>&1
+  awk '/Dose Scoring Object\(/ {found=1} END {exit(found?0:1)}' "${log_file}"
+  awk '/fluence = [1-9]/ {found=1} END {exit(found?0:1)}' "${log_file}"
+}
+
+run_expect_fail() {
+  local input_name="$1"
+  local expected_pattern="$2"
+  local log_file="${ROOT_DIR}/${input_name}.log"
+  echo "==> FAIL expected: ${input_name}"
+  set +e
+  DYLD_LIBRARY_PATH="${LIB_DIR}" "${APP_BIN}" -i "${input_name}" > "${log_file}" 2>&1
+  local ec=$?
+  set -e
+  if [[ ${ec} -eq 0 ]]; then
+    echo "Expected failure but command succeeded: ${input_name}" >&2
+    exit 1
+  fi
+  awk -v pat="${expected_pattern}" 'index($0, pat) {found=1} END {exit(found?0:1)}' "${log_file}"
+}
+
+cd "${ROOT_DIR}"
+
+run_expect_success "glib_alias_pos_internal"
+run_expect_success "glib_alias_pos_wrapper"
+run_expect_success "glib_alias_validation"
+run_expect_success "glib_alias_labels_pos"
+# Unknown label currently falls back to all regions; keep as a passing regression probe.
+run_expect_success "glib_alias_labels_neg_unknown_label"
+run_expect_fail "glib_alias_neg_missing_geom" "does not name an existing geometry"
+run_expect_fail "glib_alias_neg_collision_internal" "failed to register alias"
+
+echo "All glib alias tests completed successfully."


### PR DESCRIPTION
## Summary

- Fixes [#1275](https://github.com/nrc-cnrc/EGSnrc/issues/1275) by making `egs_glib` geometries discoverable by both names:
  - the outer wrapper name (existing behavior)
  - the internal included simulation geometry name (new alias behavior)
- Keeps lookup deterministic and backward compatible by preserving primary-name precedence and adding alias collision warnings.
- Adds a focused regression suite (positive + negative + label-based cases) under `HEN_HOUSE/egs++/geometry/examples`, plus a helper script:
  - `run_glib_alias_tests.sh`

## What changed

- **Geometry registry**
  - Added alias storage and lookup support in `EGS_BaseGeometry` internals.
  - Added `EGS_BaseGeometry::addGeometryAlias(...)`.
  - Clears/removes aliases with the geometry lifecycle.
- **`egs_glib`**
  - Captures the included geometry name before the wrapper rename.
  - Registers the original name as an alias after the rename.
  - Warns if alias registration fails (e.g. collision).
- **Tests**
  - Added `egs_glib` include examples and `egs_app` inputs for:
    - internal-name success
    - wrapper-name success
    - both names in one input (`glib_alias_pos_both`)
    - missing geometry (expected failure)
    - alias collision (expected failure)
    - region-label usage (`glib_alias_labels_pos`)
    - unknown dose-region label with glib + alias lookup (`glib_alias_labels_neg_unknown_label`; still completes successfully given current fallback behavior)

## Validation

- Ran the full matrix via `HEN_HOUSE/egs++/geometry/examples/run_glib_alias_tests.sh`:
  - **PASS expected:** internal / wrapper / both / label tests / unknown-label probe
  - **FAIL expected:** missing geometry and alias collision tests
- Confirmed non-zero scoring in generated `3ddose` outputs for the positive cases checked.
- Performance sanity check: no measurable runtime difference between wrapper-name and alias-name lookup paths in repeated `egs_app` runs.
