### PR TITLE
Fix infinite loop in egs_isotropic_source.h

### DIFF
--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.h
@@ -295,6 +295,7 @@ public:
                               EGS_Vector &x, EGS_Vector &u, EGS_Float &wt) {
         bool ok = true;
         bool ok2 = true;
+        int ntry = 0;
         do {
             x = shape->getRandomPoint(rndm);
             if (geom) {
@@ -355,6 +356,16 @@ public:
                 if (ok2 == false) {
                     ok = false;
                 }
+            }
+            ntry++;
+            if (ntry > 100000) {
+                egsFatal("\nEGS_IsotropicSource::getPositionDirection:\n"
+                         " For target shape %s, which is of type %s:\n"
+                         " Failed to create a particle from the source after 100 000 attempts\n"
+                         " Please ensure your .egsinp source definition -> source"
+                         " -> shape encompasses the source region.\n",
+                         shape->getObjectName().c_str(),
+                         shape->getObjectType().c_str());
             }
         }
         while (!ok);


### PR DESCRIPTION
Infinite loops can occur from seemingly well-formed .egsinp files when the 

<pre>
:start source definition:
    :source:
        :shape:
</pre>

block does not encompass any source regions. This is already guarded in e.g. egs_collimated_source.h but not in egs_isotropic_source.h. 

This PR aims to catch these geometry mistakes early, with a helpful message to pinpoint what went wrong. The style is copied from the style already used in egs_collimated_source.h. The 100k threshold is more tolerant than the previous 10k threshold in order to capture microscopic source regions.