### PR TITLE
Fix #934: expand environment variables in include file paths

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -59,12 +59,14 @@ and variance reduction techniques vary between applications.
 
 <em>Tip 2: All distances are in units of cm, and energies in MeV.</em>
 
-\subsection common_includefile Include files
+\subsection common_includefile Include files and file paths
 Input blocks can pull in external files using the \c include file key. The path may be absolute, relative to the current working directory, or may begin with an environment variable using \c \$VAR or \c \%VAR\% syntax (only the first environment variable is expanded, and it must be followed by \c / or \c \\), consistent with other file paths in egs++ (e.g. spectrum files). For portable inputs, \c \$EGS_HOME/... or \c \$HEN_HOUSE/... is recommended.
 
 \verbatim
 include file = $EGS_HOME/egs_brachy/lib/geometry/my_geom.geom
 \endverbatim
+
+In pegsless mode, the \c material data file input in the \c media definition block also accepts a leading \c \$VAR/ path (Fortran \c replace_env), consistent with other Fortran user codes.
 
 \section common_geom Geometry
 For full description of the geometry input, see the \link Geometry geometry module \endlink.

--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -59,6 +59,13 @@ and variance reduction techniques vary between applications.
 
 <em>Tip 2: All distances are in units of cm, and energies in MeV.</em>
 
+\subsection common_includefile Include files
+Input blocks can pull in external files using the \c include file key. The path may be absolute, relative to the current working directory, or may begin with an environment variable using \c \$VAR or \c \%VAR\% syntax (only the first environment variable is expanded, and it must be followed by \c / or \c \\), consistent with other file paths in egs++ (e.g. spectrum files). For portable inputs, \c \$EGS_HOME/... or \c \$HEN_HOUSE/... is recommended.
+
+\verbatim
+include file = $EGS_HOME/egs_brachy/lib/geometry/my_geom.geom
+\endverbatim
+
 \section common_geom Geometry
 For full description of the geometry input, see the \link Geometry geometry module \endlink.
 

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -502,7 +502,8 @@ int EGS_InputPrivate::addContentFromFile(const char *fname) {
     while (isspace(*s) && (*s)) {
         ++s;
     }
-    ifstream in(s);
+    string path = egsExpandPath(string(s));
+    ifstream in(path.c_str());
     if (!in) {
         return -1;
     }
@@ -898,10 +899,11 @@ int EGS_InputPrivate::addContent(istream &in) {
                 while (isspace(*s) && (*s)) {
                     ++s;
                 }
-                ifstream in2(s);
+                string path = egsExpandPath(string(s));
+                ifstream in2(path.c_str());
                 if (!in2) {
                     egsFatal("EGS_Input: failed to add content from "
-                             "include file %s\n",value.c_str());
+                             "include file %s\n",path.c_str());
                 }
 
                 string input2 = getCleanInputString(in2);

--- a/HEN_HOUSE/src/get_media_inputs.mortran
+++ b/HEN_HOUSE/src/get_media_inputs.mortran
@@ -779,6 +779,7 @@ Nmin = ival_medfile; Nmax = ival_medfile;
 CALL GET_INPUT;
 IF(error_flags(ival_medfile)=0)[
    material_file=char_value(ival_medfile,1);
+   call replace_env(material_file);
    medfile_specified=.true.;
    "try opening it"
    i_medfile=17;
@@ -1466,6 +1467,7 @@ DO i=1,NMED[
 
    "now, try to open the density correction file, if specified"
    IF(densityfile_specified)[
+     call replace_env(density_file);
      "if a file separator is specified in the name, assume the full path + name"
      "of the file is specified"
       write(*,*)' density_file ',density_file;


### PR DESCRIPTION
Fixes #934.

Applies `egsExpandPath()` when opening `include file` paths in `addContentFromFile()` and inline include-file handling, matching behaviour of other egs++ file-path inputs (e.g. spectrum files, beam sources).

After this change, paths such as `$EGS_HOME/egs_brachy/lib/geometry/my.geom` or `%HEN_HOUSE%/pegs4/data/521icru.pegs4dat` work in `include file` statements. Only the first environment variable is expanded; it must be followed by `/` or `\`.

Documentation added to PIRS-898 common input syntax (`common.doxy`).


Made with [Cursor](https://cursor.com)