### PR TITLE
Fix tutor2pp segfault from double-free in createObjects

### DIFF
--- a/HEN_HOUSE/egs++/egs_object_factory.cpp
+++ b/HEN_HOUSE/egs++/egs_object_factory.cpp
@@ -161,6 +161,7 @@ EGS_Object *EGS_ObjectFactory::createObjects(EGS_Input *i,
         return 0;
     }
     EGS_Input *input = i;
+    bool delete_it = false;
     if (!i->isA(section_delimeter)) {
         input = i->takeInputItem(section_delimeter);
         if (!input) {
@@ -169,6 +170,7 @@ EGS_Object *EGS_ObjectFactory::createObjects(EGS_Input *i,
                        section_delimeter.c_str());
             return 0;
         }
+        delete_it = true;
     }
     EGS_Input *ij;
     int errors = 0;
@@ -192,7 +194,9 @@ EGS_Object *EGS_ObjectFactory::createObjects(EGS_Input *i,
         if (!o) egsWarning("EGS_ObjectFactory::createObjects(): an object "
                                "with the name %s does not exist\n",sought_object.c_str());
     }
-    delete input;
+    if (delete_it) {
+        delete input;
+    }
     return o;
 }
 


### PR DESCRIPTION
## Summary

- Fix a segmentation fault in `tutor2pp` (and any user code derived from `EGS_SimpleApplication`) caused by a double-free in `EGS_ObjectFactory::createObjects()`.
- `createObjects()` now deletes its working `EGS_Input` pointer only when it extracted the section itself via `takeInputItem()`, matching the ownership pattern already used in `EGS_BaseGeometry::createGeometry()`.

Fixes nrc-cnrc/EGSnrc#1140

## Root cause

`EGS_SimpleApplication` takes the `source definition` block from the input file, passes that pointer to `EGS_BaseSource::createSource()`, and then deletes it. Inside `createSource()` → `createObjects()`, when the argument is already a `source definition` section, the local `input` pointer aliases the caller's pointer. An unconditional `delete input` at the end of `createObjects()` (added in def34e2d to fix a sanitizer-reported leak) freed memory that `EGS_SimpleApplication` then deleted again.

Advanced applications (`EGS_AdvancedApplication`, egs_brachy, tutor7pp, etc.) were unaffected because they pass the full input file; `createObjects()` takes the section internally and owns that extracted pointer.

## Reasoning / alignment with #1140

Ernesto Mainegra identified the same cause on [#1140](https://github.com/nrc-cnrc/EGSnrc/issues/1140#issuecomment-2922359450) and suggested two approaches:

1. **Pass a copy** into `createObjects` so the factory frees its copy while the caller keeps the original.
2. **Adjust deletion in `egs_simple_application.cpp`** (Matt Inglis Whalen's workaround was to remove `delete source_input` entirely).

This PR follows **option 1 in intent**—make ownership explicit at the factory—without copying `EGS_Input`. When the caller passes an already-extracted section, `createObjects()` leaves it for the caller to delete; when it extracts the section from a larger input (the advanced-application path), it deletes what it took. That preserves the 2021 leak fix for the advanced path while fixing the SimpleApplication double-free, and avoids the leak that would result from simply removing `delete source_input` in `egs_simple_application.cpp`.

## Test plan

- [x] Rebuild `libegspp` and run `tutor2pp -i test1.egsinp -p tutor_data` on macOS (eb-dev config): completes with deposited/transmitted energy fractions.
- [ ] CI / upstream reviewer: confirm `tutor2pp` and an `EGS_AdvancedApplication` example still run on Linux.


Made with [Cursor](https://cursor.com)