### PR TITLE
Fix #1351: expand include file paths in input loops

### DIFF
--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -59,6 +59,13 @@ and variance reduction techniques vary between applications.
 
 <em>Tip 2: All distances are in units of cm, and energies in MeV.</em>
 
+\subsection common_includefile Include files
+Input blocks can pull in external files using the \c include file key. The path may be absolute, relative to the current working directory, or may begin with an environment variable using \c \$VAR or \c \%VAR\% syntax (only the first environment variable is expanded, and it must be followed by \c / or \c \\), consistent with other file paths in egs++ (e.g. spectrum files). For portable inputs, \c \$EGS_HOME/... or \c \$HEN_HOUSE/... is recommended.
+
+\verbatim
+include file = $EGS_HOME/egs_brachy/lib/geometry/my_geom.geom
+\endverbatim
+
 \section common_geom Geometry
 For full description of the geometry input, see the \link Geometry geometry module \endlink.
 

--- a/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
+++ b/HEN_HOUSE/doc/src/pirs898-egs++/common.doxy
@@ -60,7 +60,7 @@ and variance reduction techniques vary between applications.
 <em>Tip 2: All distances are in units of cm, and energies in MeV.</em>
 
 \subsection common_includefile Include files
-Input blocks can pull in external files using the \c include file key. The path may be absolute, relative to the current working directory, or may begin with an environment variable using \c \$VAR or \c \%VAR\% syntax (only the first environment variable is expanded, and it must be followed by \c / or \c \\), consistent with other file paths in egs++ (e.g. spectrum files). For portable inputs, \c \$EGS_HOME/... or \c \$HEN_HOUSE/... is recommended.
+Input blocks can pull in external files using the \c include file key. The path may be absolute, relative to the current working directory, or may begin with an environment variable using \c \$VAR or \c \%VAR\% syntax (only the first environment variable is expanded, and it must be followed by \c / or \c \\), consistent with other file paths in egs++ (e.g. spectrum files). For portable inputs, \c \$EGS_HOME/... or \c \$HEN_HOUSE/... is recommended. Inside an \c input loop, the path may also use loop variables such as \c \$(name); the file is included after the loop variable is expanded for each iteration.
 
 \verbatim
 include file = $EGS_HOME/egs_brachy/lib/geometry/my_geom.geom

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -109,6 +109,7 @@ public:
     string getCleanInputString(istream &input);
 
     void processInputLoop(EGS_InputPrivate *p);
+    void expandIncludeFiles();
 
     void addItem(EGS_InputPrivate *p) {
         p->nref++;
@@ -564,6 +565,18 @@ bool EGS_InputPrivate::compareKeys(const string &s1, const string &s2) {
 
 }
 
+static bool hasLoopVariable(const string &s) {
+    return s.find("$(") != string::npos;
+}
+
+static string trimInputValue(const string &value) {
+    const char *s = value.c_str();
+    while (isspace(*s) && (*s)) {
+        ++s;
+    }
+    return string(s);
+}
+
 #ifdef INPUT_DEBUG
     #include <iostream>
 #endif
@@ -868,12 +881,81 @@ void EGS_InputPrivate::processInputLoop(EGS_InputPrivate *p) {
                 pnew->replace(ivars[ivar]->getVarNameReplacement(),
                               ivars[ivar]->getVarReplacement());
             }
-            children.push_back(pnew);
+            pnew->expandIncludeFiles();
+            if (pnew->key.empty() && !pnew->children.empty()) {
+                for (unsigned int k = 0; k < pnew->children.size(); k++) {
+                    children.push_back(pnew->children[k]);
+                }
+                pnew->children.clear();
+                delete pnew;
+            }
+            else {
+                children.push_back(pnew);
+            }
         }
     }
 
     for (j=0; j<ivars.size(); j++) {
         delete ivars[j];
+    }
+}
+
+static void inlineIncludeFileNode(EGS_InputPrivate *node) {
+    string path = egsExpandPath(trimInputValue(node->value));
+    ifstream in(path.c_str());
+    if (!in) {
+        egsFatal("EGS_Input: failed to add content from "
+                 "include file %s\n", path.c_str());
+    }
+    EGS_InputPrivate holder;
+    holder.addContent(in);
+    if (holder.children.size() == 1 && !holder.children[0]->key.empty()) {
+        EGS_InputPrivate *block = holder.children[0];
+        node->key = block->key;
+        node->value = block->value;
+        for (unsigned int k = 0; k < block->children.size(); k++) {
+            node->children.push_back(block->children[k]);
+        }
+        block->children.clear();
+        delete block;
+        holder.children.clear();
+        return;
+    }
+    node->key.clear();
+    node->value.clear();
+    for (unsigned int k = 0; k < holder.children.size(); k++) {
+        node->children.push_back(holder.children[k]);
+    }
+    holder.children.clear();
+}
+
+void EGS_InputPrivate::expandIncludeFiles() {
+    if (compareKeys(key, "include file")) {
+        if (!hasLoopVariable(value)) {
+            inlineIncludeFileNode(this);
+        }
+        return;
+    }
+    for (int j = children.size() - 1; j >= 0; j--) {
+        if (!compareKeys(children[j]->key, "include file")) {
+            children[j]->expandIncludeFiles();
+            continue;
+        }
+        if (hasLoopVariable(children[j]->value)) {
+            continue;
+        }
+        inlineIncludeFileNode(children[j]);
+        if (children[j]->children.size()) {
+            EGS_InputPrivate *old = children[j];
+            children.erase(children.begin() + j);
+            for (unsigned int k = 0; k < old->children.size(); k++) {
+                children.insert(children.begin() + j + k, old->children[k]);
+            }
+            old->children.clear();
+            delete old;
+        }
+        expandIncludeFiles();
+        return;
     }
 }
 
@@ -894,12 +976,12 @@ int EGS_InputPrivate::addContent(istream &in) {
                 string value;
                 value.assign(input,p2+1,p1-p2-1);
 
-
-                const char *s = value.c_str();
-                while (isspace(*s) && (*s)) {
-                    ++s;
+                if (hasLoopVariable(value)) {
+                    p = p1+1;
+                    continue;
                 }
-                string path = egsExpandPath(string(s));
+
+                string path = egsExpandPath(trimInputValue(value));
                 ifstream in2(path.c_str());
                 if (!in2) {
                     egsFatal("EGS_Input: failed to add content from "

--- a/HEN_HOUSE/egs++/egs_input.cpp
+++ b/HEN_HOUSE/egs++/egs_input.cpp
@@ -502,7 +502,8 @@ int EGS_InputPrivate::addContentFromFile(const char *fname) {
     while (isspace(*s) && (*s)) {
         ++s;
     }
-    ifstream in(s);
+    string path = egsExpandPath(string(s));
+    ifstream in(path.c_str());
     if (!in) {
         return -1;
     }
@@ -898,10 +899,11 @@ int EGS_InputPrivate::addContent(istream &in) {
                 while (isspace(*s) && (*s)) {
                     ++s;
                 }
-                ifstream in2(s);
+                string path = egsExpandPath(string(s));
+                ifstream in2(path.c_str());
                 if (!in2) {
                     egsFatal("EGS_Input: failed to add content from "
-                             "include file %s\n",value.c_str());
+                             "include file %s\n",path.c_str());
                 }
 
                 string input2 = getCleanInputString(in2);

--- a/HEN_HOUSE/user_codes/egs_app/include_loop_test/dose_ausgab.inc
+++ b/HEN_HOUSE/user_codes/egs_app/include_loop_test/dose_ausgab.inc
@@ -1,0 +1,6 @@
+### Included by slab_include_loop.egsinp (loop iteration: dose)
+:start ausgab object:
+    name    = dose
+    library = egs_dose_scoring
+    volume  = 1000, 100, 900
+:stop ausgab object:

--- a/HEN_HOUSE/user_codes/egs_app/include_loop_test/tracks_ausgab.inc
+++ b/HEN_HOUSE/user_codes/egs_app/include_loop_test/tracks_ausgab.inc
@@ -1,0 +1,5 @@
+### Included by slab_include_loop.egsinp (loop iteration: tracks)
+:start ausgab object:
+    name    = tracks
+    library = egs_track_scoring
+:stop ausgab object:

--- a/HEN_HOUSE/user_codes/egs_app/slab_include_loop.egsinp
+++ b/HEN_HOUSE/user_codes/egs_app/slab_include_loop.egsinp
@@ -1,0 +1,108 @@
+##############################################################################
+#
+# egs_app test for include file paths with input-loop variables (issue #1351)
+#
+# Pegsless run (no -p). Media are inline because Fortran HATCH reads the raw
+# .egsinp on unit 5 and does not expand C++ include loops. The include loop
+# below is in ausgab object definition, which is parsed by egs++ only.
+#
+# Before the fix, parsing fails with:
+#   EGS_Input: failed to add content from include file .../$(obj).inc
+#
+#   cd $EGS_HOME/egs_app
+#   ./egs_app -i slab_include_loop
+#
+# Include fragments live in include_loop_test/
+#
+##############################################################################
+
+
+##############################################################################
+### Run control
+##############################################################################
+:start run control:
+    ncase = 1000
+:stop run control:
+
+
+##############################################################################
+### Geometry (same slab as slab.egsinp)
+##############################################################################
+:start geometry definition:
+
+    :start geometry:
+        name     = plate
+        library  = egs_ndgeometry
+        type     = EGS_XYZGeometry
+        x-planes = -5, 5
+        y-planes = -5, 5
+        z-planes = -10, 0, 1, 10
+        :start media input:
+            media = air water
+            set medium = 1 1
+        :stop media input:
+    :stop geometry:
+
+    simulation geometry = plate
+
+:stop geometry definition:
+
+
+##############################################################################
+### Media (inline — required for pegsless; see header comment)
+##############################################################################
+:start media definition:
+
+    ae = 0.521
+    ap = 0.010
+    ue = 50.511
+    up = 50
+
+    :start air:
+        density correction file = air_dry_nearsealevel
+    :stop air:
+
+    :start water:
+        density correction file = water_liquid
+    :stop water:
+
+:stop media definition:
+
+
+##############################################################################
+### Source (same as slab.egsinp)
+##############################################################################
+:start source definition:
+
+    :start source:
+        name      = pencil_beam
+        library   = egs_parallel_beam
+        charge    = -1
+        direction = 0 0 1
+        :start spectrum:
+            type = monoenergetic
+            energy = 20
+        :stop spectrum:
+        :start shape:
+            type     = point
+            position = 0 0 -8
+        :stop shape:
+    :stop source:
+
+    simulation source = pencil_beam
+
+:stop source definition:
+
+
+##############################################################################
+### Ausgab — input loop + include files (tests #1351)
+##############################################################################
+:start ausgab object definition:
+
+    :start input loop:
+        loop count = 2
+        loop variable = 2 obj dose tracks
+        include file = include_loop_test/$(obj)_ausgab.inc
+    :stop input loop:
+
+:stop ausgab object definition:


### PR DESCRIPTION
## Summary

- Defer `include file` inlining when the path contains input-loop variables (`$(name)`), then open each file after loop substitution via `egsExpandPath()` (builds on #934 / PR #1425).
- Add `egs_app` pegsless example input `slab_include_loop.egsinp` with ausgab include fragments under `include_loop_test/` for manual testing.

Fixes [nrc-cnrc/EGSnrc#1351](https://github.com/nrc-cnrc/EGSnrc/issues/1351).

## Test plan

- [x] Rebuild `libegspp` and `egs_app` from `$EGS_HOME`
- [x] Run pegsless (no `-p`): `cd $EGS_HOME/egs_app && ./egs_app -i slab_include_loop`
- [x] Confirm log shows `Processing input loop`, pegsless cross sections, and both `dose` and `tracks` ausgab objects
- [x] Confirm simulation completes without `failed to add content from include file .../$(obj).inc`


Made with [Cursor](https://cursor.com)