### PR TITLE
Fix #1422: Electric field work not applied to energy of charged particles

### DIFF
--- a/HEN_HOUSE/src/EEMF_macros.mortran
+++ b/HEN_HOUSE/src/EEMF_macros.mortran
@@ -287,7 +287,6 @@ REPLACE{$EMFIELD_INITIATE_SET_TUSTEP;}WITH{;
   E_amp = r0_em;
 
   "Adjust the electric field to be in V/m instead of the V/cm"
-  Ex = Ex*100.;Ey = Ey*100.;Ez = Ez*100.;
   E_amp = E_amp*100.;
 
   "activate the transport for the rest of the calculation"

--- a/HEN_HOUSE/src/egsnrc.mortran
+++ b/HEN_HOUSE/src/egsnrc.mortran
@@ -1588,9 +1588,9 @@ $start_new_particle;
             "Now done with multiple scattering,
             "update energy and see if below cut
             "below subtracts only energy deposited"
-            peie  = peie - edep;
+            "peie  = peie - edep;"
             "below subtracts energy deposited + work due to E field"
-            "peie = peie - de;"
+            peie = peie - de;
             eie   = peie;
             e(np) = peie;
 


### PR DESCRIPTION
Fix a bug where the electric field did not subtract energy from charged particles when work was done. 

Also, fix a mistake in the magnitude of the electric field that was noticeable now that the work was applied.

Thanks to @LouisLechNissen for finding this issue and the solution.