### PR TITLE
Add EGS_VolumetricFluence with FD estimator and fix FD correctness for all scorers

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1386,7 +1386,8 @@ bool  EGS_PlanarFluence::addState(istream &data) {
 
 EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
     EGS_FluenceScoring(Name,f), flu_stpwr(stpwr),
-    fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0)
+    fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0),
+    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false)
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
 #endif
@@ -1421,6 +1422,8 @@ EGS_VolumetricFluence::~EGS_VolumetricFluence() {
         }
         delete [] flu_FD_p;
     }
+    delete fluT_x_p;
+    delete fluT_FD_x_p;
 
 #ifdef DEBUG
     if (binDist) {
@@ -1492,6 +1495,9 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
                 }
             }
         }
+        fluT_x_p = new EGS_ScoringArray(nreg);
+        m_hist_T.assign(nreg, 0.0);
+        m_hist_P.assign(nreg, 0.0);
     }
 #ifdef DEBUG
     binDist = new EGS_ScoringArray(flu_nbin);
@@ -1646,6 +1652,9 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
                         }
                     }
                 }
+                fluT_FD_x_p = new EGS_ScoringArray(nreg);
+                m_hist_FDT.assign(nreg, 0.0);
+                m_hist_FDP.assign(nreg, 0.0);
             }
         }
     }
@@ -1885,6 +1894,11 @@ void EGS_VolumetricFluence::scoreInCV() {
                 if (score_primaries && !latch) {
                     fluT_FD_p->score(irsc, score);
                 }
+                if (fluT_FD_x_p) {
+                    m_hist_FDT[irsc] += score;
+                    if (!latch) m_hist_FDP[irsc] += score;
+                    m_hist_dirty = true;
+                }
                 if (score_spe) {
                     EGS_Float e = flu_s ? gle : app->top_p.E;
                     if (e > flu_xmin && e <= flu_xmax) {
@@ -1917,6 +1931,33 @@ void EGS_VolumetricFluence::scoreInCV() {
             navigating = false;
         }
     }
+}
+
+void EGS_VolumetricFluence::flushHistoryCrossTerms() const {
+    if (!m_hist_dirty) {
+        return;
+    }
+    if (fluT_x_p) {
+        for (int j = 0; j < nreg; j++) {
+            if (!is_sensitive[j]) {
+                continue;
+            }
+            fluT_x_p->score(j, m_hist_T[j] * m_hist_P[j]);
+            m_hist_T[j] = 0.0;
+            m_hist_P[j] = 0.0;
+        }
+    }
+    if (fluT_FD_x_p) {
+        for (int j = 0; j < nreg; j++) {
+            if (!is_sensitive[j]) {
+                continue;
+            }
+            fluT_FD_x_p->score(j, m_hist_FDT[j] * m_hist_FDP[j]);
+            m_hist_FDT[j] = 0.0;
+            m_hist_FDP[j] = 0.0;
+        }
+    }
+    m_hist_dirty = false;
 }
 
 void EGS_VolumetricFluence::ouputVolumetricFluence(EGS_ScoringArray *fT, const double &norma) {
@@ -2034,24 +2075,80 @@ void EGS_VolumetricFluence::ouputResults() {
     EGS_Float norm  = 1.0/src_norm;              // per particle or fluence
     norm *= norm_u;                    // user-requested normalization
 
+    flushHistoryCrossTerms();
+
+    // Helpers matching the spherical fluence output pattern
+    auto getR = [](EGS_ScoringArray *arr, int k, double nk,
+                   double &val, double &unc_pct) {
+        double r, dr;
+        arr->currentResult(k, r, dr);
+        if (dr < 0) dr = 0.0;
+        val = r * nk;
+        unc_pct = (r > 0) ? 100.0 * dr / r : 100.0;
+    };
+
+    auto corrRatio = [this](EGS_ScoringArray *fT, EGS_ScoringArray *fP,
+                            EGS_ScoringArray *fX, int k,
+                            double &B, double &Bpct) {
+        double T_r, dT, P_r, dP, TP_r_mean, dummy;
+        fT->currentResult(k, T_r, dT);
+        fP->currentResult(k, P_r, dP);
+        if (dT < 0) dT = 0.0;
+        if (dP < 0) dP = 0.0;
+        B = (P_r > 0) ? T_r / P_r : 0.0;
+        if (B <= 0 || current_ncase <= 0) { Bpct = 100.0; return; }
+        TP_r_mean = 0.0;
+        if (fX) fX->currentResult(k, TP_r_mean, dummy);
+        double cov   = (TP_r_mean - T_r * P_r) / current_ncase;
+        double var_B = (dT*dT - 2.0*B*cov + B*B*dP*dP) / (P_r * P_r);
+        Bpct = (var_B > 0) ? 100.0 * sqrt(var_B) / B : 0.0;
+    };
+
+    int ir_digits = getDigits(nreg);
+
+    auto ouputBlock = [&](const char *label,
+                          EGS_ScoringArray *fT, EGS_ScoringArray *fP,
+                          EGS_ScoringArray *fX) {
+        bool with_ratio = (fP != nullptr);
+        if (with_ratio) {
+            egsInformation("\n\n  %s\n", label);
+            egsInformation("  %*s  %-28s  %-28s  %s\n",
+                           ir_digits, "reg#", "total", "primary", "tot/pri");
+            egsInformation("  %s\n", string(ir_digits + 2 + 28 + 2 + 28 + 2 + 20, '-').c_str());
+            for (int k = 0; k < nreg; k++) {
+                if (!is_sensitive[k]) continue;
+                double nk = norm / volume[k];
+                double Tv, Tu, Pv, Pu, B, Bu;
+                getR(fT, k, nk, Tv, Tu);
+                getR(fP, k, nk, Pv, Pu);
+                corrRatio(fT, fP, fX, k, B, Bu);
+                egsInformation("  %*d  %12.5e +/- %-7.3f%%  %12.5e +/- %-7.3f%%  %7.4f +/- %-7.3f%%\n",
+                               ir_digits, k, Tv, Tu, Pv, Pu, B, Bu);
+            }
+            egsInformation("  %s\n", string(ir_digits + 2 + 28 + 2 + 28 + 2 + 20, '-').c_str());
+        }
+        else {
+            egsInformation("\n\n  %s\n", label);
+            ouputVolumetricFluence(fT, norm);
+        }
+    };
+
     egsInformation("\n\n                 Integral fluence output\n"
                    "                 =======================\n\n");
 
     if (m_scoring_method != score_FD) {
-        egsInformation("\n\n  [track-length]   Total %s fluence\n", particle_name.c_str());
-        ouputVolumetricFluence(fluT, norm);
-        if (score_primaries) {
-            egsInformation("\n\n  [track-length]   Primary fluence\n");
-            ouputVolumetricFluence(fluT_p, norm);
-        }
+        ouputBlock(score_primaries ? "[track-length]   Total + primary + tot/pri" :
+                   "[track-length]   Total",
+                   fluT,
+                   score_primaries ? fluT_p    : nullptr,
+                   score_primaries ? fluT_x_p  : nullptr);
     }
     if (m_scoring_method != score_crossing && fluT_FD) {
-        egsInformation("\n\n  [FD]             Total %s fluence\n", particle_name.c_str());
-        ouputVolumetricFluence(fluT_FD, norm);
-        if (score_primaries && fluT_FD_p) {
-            egsInformation("\n\n  [FD]             Primary fluence\n");
-            ouputVolumetricFluence(fluT_FD_p, norm);
-        }
+        ouputBlock(score_primaries ? "[FD]             Total + primary + tot/pri" :
+                   "[FD]             Total",
+                   fluT_FD,
+                   score_primaries ? fluT_FD_p   : nullptr,
+                   score_primaries ? fluT_FD_x_p : nullptr);
     }
 
     if (verbose) {
@@ -2192,6 +2289,7 @@ void EGS_VolumetricFluence::reportResults() {
 }
 
 bool EGS_VolumetricFluence::storeState(ostream &data) const {
+    flushHistoryCrossTerms();
     if (!egsStoreI64(data,current_ncase)) {
         return false;
     }
@@ -2238,6 +2336,9 @@ bool EGS_VolumetricFluence::storeState(ostream &data) const {
                 }
             }
         }
+        if (!fluT_x_p->storeState(data)) {
+            return false;
+        }
     }
 
     if (m_scoring_method != score_crossing && fluT_FD) {
@@ -2269,6 +2370,9 @@ bool EGS_VolumetricFluence::storeState(ostream &data) const {
                         }
                     }
                 }
+            }
+            if (!fluT_FD_x_p->storeState(data)) {
+                return false;
             }
         }
     }
@@ -2323,6 +2427,12 @@ bool  EGS_VolumetricFluence::setState(istream &data) {
                 }
             }
         }
+        if (!fluT_x_p->setState(data)) {
+            return false;
+        }
+        fill(m_hist_T.begin(), m_hist_T.end(), 0.0);
+        fill(m_hist_P.begin(), m_hist_P.end(), 0.0);
+        m_hist_dirty = false;
     }
 
     if (m_scoring_method != score_crossing && fluT_FD) {
@@ -2355,6 +2465,11 @@ bool  EGS_VolumetricFluence::setState(istream &data) {
                     }
                 }
             }
+            if (!fluT_FD_x_p->setState(data)) {
+                return false;
+            }
+            fill(m_hist_FDT.begin(), m_hist_FDT.end(), 0.0);
+            fill(m_hist_FDP.begin(), m_hist_FDP.end(), 0.0);
         }
     }
 
@@ -2418,6 +2533,11 @@ bool  EGS_VolumetricFluence::addState(istream &data) {
                 }
             }
         }
+        EGS_ScoringArray tgT_x_p(nreg);
+        if (!tgT_x_p.setState(data)) {
+            return false;
+        }
+        (*fluT_x_p) += tgT_x_p;
     }
 
     if (m_scoring_method != score_crossing && fluT_FD) {
@@ -2463,6 +2583,11 @@ bool  EGS_VolumetricFluence::addState(istream &data) {
                     }
                 }
             }
+            EGS_ScoringArray tgT_FD_x_p(nreg);
+            if (!tgT_FD_x_p.setState(data)) {
+                return false;
+            }
+            (*fluT_FD_x_p) += tgT_FD_x_p;
         }
     }
 

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1385,7 +1385,8 @@ bool  EGS_PlanarFluence::addState(istream &data) {
 
 
 EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
-    EGS_FluenceScoring(Name,f), flu_stpwr(stpwr)
+    EGS_FluenceScoring(Name,f), flu_stpwr(stpwr),
+    fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0)
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
 #endif
@@ -1405,6 +1406,20 @@ EGS_VolumetricFluence::~EGS_VolumetricFluence() {
         for (int j=0; j<n_scoring_regions; j++) {
             delete flu_p[j];
         }
+    }
+    delete fluT_FD;
+    delete fluT_FD_p;
+    if (flu_FD) {
+        for (int j=0; j<n_scoring_regions; j++) {
+            delete flu_FD[j];
+        }
+        delete [] flu_FD;
+    }
+    if (flu_FD_p) {
+        for (int j=0; j<n_scoring_regions; j++) {
+            delete flu_FD_p[j];
+        }
+        delete [] flu_FD_p;
     }
 
 #ifdef DEBUG
@@ -1604,6 +1619,37 @@ void EGS_VolumetricFluence::setApplication(EGS_Application *App) {
                    app->getMediumName(imed_max_range), RCSDA,
                    flu_s ? exp(flu_Emax) : flu_Emax, max_step, 1.0/step_a);
 #endif
+    /* FD scoring setup (photons only) */
+    if (!scoring_charge && m_scoring_method != score_crossing) {
+        if (!app->getMFPInterpolators()) {
+            egsWarning("EGS_VolumetricFluence: FD scoring requires an EGS_AdvancedApplication."
+                       " Falling back to track-length scoring.\n");
+            m_scoring_method = score_crossing;
+        }
+        else {
+            fluT_FD = new EGS_ScoringArray(nreg);
+            if (score_spe) {
+                flu_FD = new EGS_ScoringArray* [nreg];
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        flu_FD[j] = new EGS_ScoringArray(flu_nbin);
+                    }
+                }
+            }
+            if (score_primaries) {
+                fluT_FD_p = new EGS_ScoringArray(nreg);
+                if (score_spe) {
+                    flu_FD_p = new EGS_ScoringArray* [nreg];
+                    for (int j = 0; j < nreg; j++) {
+                        if (is_sensitive[j]) {
+                            flu_FD_p[j] = new EGS_ScoringArray(flu_nbin);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     describeMe();
 }
 
@@ -1666,7 +1712,19 @@ void EGS_VolumetricFluence::initScoring(EGS_Input *inp) {
         method.push_back("stpwr");   // 3rd order
         method.push_back("stpwrO5"); // 5th order
         flu_stpwr = eFluType(vScoringInput->getInput("method",method,1));
+    }
 
+    /* FD geometry gate (photons only); scoring method already set by base class */
+    if (!scoring_charge && m_scoring_method != score_crossing) {
+        string fd_geom_name;
+        if (!vScoringInput->getInput("FD geometry", fd_geom_name)) {
+            fd_geom = EGS_BaseGeometry::getGeometry(fd_geom_name);
+            if (!fd_geom) {
+                egsWarning("EGS_VolumetricFluence: FD geometry '%s' not found;"
+                           " will ray-trace only from inside scoring regions.\n",
+                           fd_geom_name.c_str());
+            }
+        }
     }
 
 }
@@ -1696,13 +1754,169 @@ void EGS_VolumetricFluence::describeMe() {
             description += "   Fluence calculated a-la-FLURZ using Lave=EDEP/TVSTEP.\n";
         }
     }
+    else {
+        switch (m_scoring_method) {
+        case score_crossing: description += " - estimator         = track-length\n"; break;
+        case score_FD:       description += " - estimator         = forced detection\n"; break;
+        case score_both:     description += " - estimator         = track-length + forced detection\n"; break;
+        }
+        if (m_scoring_method != score_crossing) {
+            if (fd_geom) {
+                description += " - FD geometry       = ";
+                description += fd_geom->getName();
+                description += "\n";
+            }
+            else {
+                description += " - FD geometry       = none (ray-trace from sensitive regions only)\n";
+            }
+        }
+    }
 
-    // if (norm_u != 1.0) {
-    //     description += "\n - Non-unity user-requested normalization = ";
-    //     sprintf(buf,"%g\n",norm_u);
-    //     description += buf;
-    // }
+}
 
+void EGS_VolumetricFluence::scoreInCV() {
+
+    EGS_Vector x  = app->top_p.x;
+    EGS_Vector u  = app->top_p.u;
+    int    ireg   = app->top_p.ir;
+    EGS_Float wt  = app->top_p.wt;
+    int    latch  = app->top_p.latch;
+    EGS_Float gle = log(app->top_p.E);
+
+    /* Gate: ray-trace only if photon is in/aimed-at fd_geom or in a sensitive region */
+    if (!is_sensitive[ireg]) {
+        if (!fd_geom) {
+            return;
+        }
+        EGS_Float tstep = 1e35;
+        int newmed_probe = app->getMedium(ireg);
+        if (!fd_geom->isInside(x) &&
+                fd_geom->howfar(-1, x, u, tstep, &newmed_probe) < 0) {
+            return;
+        }
+    }
+
+    bool rayleigh_on = app->isRayleighOn();
+    EGS_Interpolator *i_gmfp = app->getMFPInterpolators();
+    EGS_Interpolator *i_cohe = app->getCoheInterpolators();
+
+    bool inside_cv = false, re_enters_cv = false, navigating = true;
+    double Lambda = 0, Lambda_to_CV = 0;
+    EGS_Float wt_att = 1;
+    int imed = -1;
+    EGS_Float gmfp, sigma = 0, cohfac = 1, mu_cv = 0;
+
+    /* Temporary store for scoring-region crossings in one traversal */
+    vector<int>       ir_sc;
+    vector<EGS_Float> t_sc;
+
+    while (navigating) {
+        int newmed = app->getMedium(ireg);
+        ir_sc.clear();
+        t_sc.clear();
+
+        while (true) {
+            if (imed != newmed) {
+                imed = newmed;
+                if (imed >= 0) {
+                    gmfp = i_gmfp[imed].interpolateFast(gle);
+                    if (rayleigh_on) {
+                        cohfac = i_cohe[imed].interpolateFast(gle);
+                        gmfp  *= cohfac;
+                    }
+                    sigma = 1.0 / gmfp;
+                }
+                else {
+                    sigma = 0;
+                    cohfac = 1;
+                }
+            }
+
+            EGS_Float tstep = 1e35;
+            int inew = app->howfar(ireg, x, u, tstep, &newmed);
+
+            Lambda += tstep * sigma;
+
+            if (is_sensitive[ireg]) {
+                ir_sc.push_back(ireg);
+                t_sc.push_back(tstep);
+                if (!inside_cv) {
+                    Lambda_to_CV = Lambda - tstep * sigma;
+                    inside_cv = true;
+                    mu_cv = sigma;
+                }
+                Lambda -= tstep * sigma; // exclude CV steps from attenuation
+            }
+
+            if (inew < 0) {
+                break; // left geometry
+            }
+            ireg = inew;
+            x   += u * tstep;
+
+            if (inside_cv && !is_sensitive[ireg]) {
+                re_enters_cv = false;
+                if (fd_geom) {
+                    EGS_Float tstep2 = 1e35;
+                    int newmed2 = app->getMedium(ireg);
+                    if (fd_geom->isInside(x) ||
+                            fd_geom->howfar(-1, x, u, tstep2, &newmed2) >= 0) {
+                        re_enters_cv = true;
+                    }
+                }
+                break;
+            }
+        }
+
+        if (inside_cv) {
+            EGS_Float exp_Lambda = exp(-Lambda_to_CV);
+            for (int i = 0; i < (int)ir_sc.size(); i++) {
+                int    irsc = ir_sc[i];
+                EGS_Float tsc = t_sc[i];
+                EGS_Float exp_CV  = exp(-mu_cv * tsc);
+                /* Fluence weight: (1-exp(-mu*t))/mu for attenuating medium,
+                 * step length t for vacuum (mu=0) */
+                EGS_Float exp_Att = (mu_cv > 0) ?
+                                    exp_Lambda * (1.0 - exp_CV) / mu_cv :
+                                    exp_Lambda * tsc;
+                EGS_Float score = wt * wt_att * exp_Att;
+
+                fluT_FD->score(irsc, score);
+                if (score_primaries && !latch) {
+                    fluT_FD_p->score(irsc, score);
+                }
+                if (score_spe) {
+                    EGS_Float e = flu_s ? gle : app->top_p.E;
+                    if (e > flu_xmin && e <= flu_xmax) {
+                        int je = min((int)(flu_a * e + flu_b), flu_nbin - 1);
+                        flu_FD[irsc]->score(je, score);
+                        if (score_primaries && !latch) {
+                            flu_FD_p[irsc]->score(je, score);
+                        }
+                    }
+                }
+                exp_Lambda *= exp_CV;
+            }
+
+            m_tot_FD += wt;
+            if (!latch) {
+                m_primary_FD += wt;
+            }
+
+            if (re_enters_cv) {
+                wt_att      *= exp(-Lambda); // accumulated attenuation outside CV
+                Lambda_to_CV = 0;
+                Lambda       = 0;
+                inside_cv    = false;
+            }
+            else {
+                navigating = false;
+            }
+        }
+        else {
+            navigating = false;
+        }
+    }
 }
 
 void EGS_VolumetricFluence::ouputVolumetricFluence(EGS_ScoringArray *fT, const double &norma) {
@@ -1823,12 +2037,21 @@ void EGS_VolumetricFluence::ouputResults() {
     egsInformation("\n\n                 Integral fluence output\n"
                    "                 =======================\n\n");
 
-    egsInformation("\n\n                 Total %s fluence\n", particle_name.c_str());
-    ouputVolumetricFluence(fluT, norm);
-
-    if (score_primaries) {
-        egsInformation("\n\n                   Primary fluence\n");
-        ouputVolumetricFluence(fluT_p, norm);
+    if (m_scoring_method != score_FD) {
+        egsInformation("\n\n  [track-length]   Total %s fluence\n", particle_name.c_str());
+        ouputVolumetricFluence(fluT, norm);
+        if (score_primaries) {
+            egsInformation("\n\n  [track-length]   Primary fluence\n");
+            ouputVolumetricFluence(fluT_p, norm);
+        }
+    }
+    if (m_scoring_method != score_crossing && fluT_FD) {
+        egsInformation("\n\n  [FD]             Total %s fluence\n", particle_name.c_str());
+        ouputVolumetricFluence(fluT_FD, norm);
+        if (score_primaries && fluT_FD_p) {
+            egsInformation("\n\n  [FD]             Primary fluence\n");
+            ouputVolumetricFluence(fluT_FD_p, norm);
+        }
     }
 
     if (verbose) {
@@ -1950,6 +2173,19 @@ void EGS_VolumetricFluence::reportResults() {
 
     egsInformation("\nFluence Scoring (%s)\n",name.c_str());
     egsInformation("======================================================\n");
+    if (m_scoring_method != score_FD) {
+        egsInformation("   [TL]  Total %ss scored: %g\n", particle_name.c_str(), m_tot);
+        if (score_primaries) {
+            egsInformation("   [TL]  Primary %ss:         %g\n", particle_name.c_str(), m_primary);
+        }
+    }
+    if (m_scoring_method != score_crossing) {
+        egsInformation("   [FD]  Total aimed at CV: %g\n", m_tot_FD);
+        if (score_primaries) {
+            egsInformation("   [FD]  Primary aimed:     %g\n", m_primary_FD);
+        }
+    }
+    egsInformation("======================================================\n");
 
     ouputResults();
 
@@ -2004,6 +2240,39 @@ bool EGS_VolumetricFluence::storeState(ostream &data) const {
         }
     }
 
+    if (m_scoring_method != score_crossing && fluT_FD) {
+        data << m_tot_FD << " " << m_primary_FD << endl;
+        if (!data.good()) {
+            return false;
+        }
+        if (!fluT_FD->storeState(data)) {
+            return false;
+        }
+        if (score_spe) {
+            for (int j = 0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!flu_FD[j]->storeState(data)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if (score_primaries && fluT_FD_p) {
+            if (!fluT_FD_p->storeState(data)) {
+                return false;
+            }
+            if (score_spe) {
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        if (!flu_FD_p[j]->storeState(data)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     return true;
 }
 
@@ -2050,6 +2319,39 @@ bool  EGS_VolumetricFluence::setState(istream &data) {
                 if (is_sensitive[j]) {
                     if (!flu_p[j]->setState(data)) {
                         return false;
+                    }
+                }
+            }
+        }
+    }
+
+    if (m_scoring_method != score_crossing && fluT_FD) {
+        data >> m_tot_FD >> m_primary_FD;
+        if (!data.good()) {
+            return false;
+        }
+        if (!fluT_FD->setState(data)) {
+            return false;
+        }
+        if (score_spe) {
+            for (int j = 0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!flu_FD[j]->setState(data)) {
+                        return false;
+                    }
+                }
+            }
+        }
+        if (score_primaries && fluT_FD_p) {
+            if (!fluT_FD_p->setState(data)) {
+                return false;
+            }
+            if (score_spe) {
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        if (!flu_FD_p[j]->setState(data)) {
+                            return false;
+                        }
                     }
                 }
             }
@@ -2113,6 +2415,52 @@ bool  EGS_VolumetricFluence::addState(istream &data) {
                         return false;
                     }
                     (*flu_p[j]) += tg_p;
+                }
+            }
+        }
+    }
+
+    if (m_scoring_method != score_crossing && fluT_FD) {
+        EGS_Float tmp_tot_FD, tmp_primary_FD;
+        data >> tmp_tot_FD >> tmp_primary_FD;
+        if (!data.good()) {
+            return false;
+        }
+        m_tot_FD     += tmp_tot_FD;
+        m_primary_FD += tmp_primary_FD;
+
+        EGS_ScoringArray tgT_FD(nreg);
+        if (!tgT_FD.setState(data)) {
+            return false;
+        }
+        (*fluT_FD) += tgT_FD;
+
+        if (score_spe) {
+            EGS_ScoringArray tg_FD(flu_nbin);
+            for (int j = 0; j < nreg; j++) {
+                if (is_sensitive[j]) {
+                    if (!tg_FD.setState(data)) {
+                        return false;
+                    }
+                    (*flu_FD[j]) += tg_FD;
+                }
+            }
+        }
+        if (score_primaries && fluT_FD_p) {
+            EGS_ScoringArray tgT_FD_p(nreg);
+            if (!tgT_FD_p.setState(data)) {
+                return false;
+            }
+            (*fluT_FD_p) += tgT_FD_p;
+            if (score_spe) {
+                EGS_ScoringArray tg_FD_p(flu_nbin);
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        if (!tg_FD_p.setState(data)) {
+                            return false;
+                        }
+                        (*flu_FD_p[j]) += tg_FD_p;
+                    }
                 }
             }
         }

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -437,7 +437,8 @@ void EGS_FluenceScoring::describeMe() {
 
 EGS_PlanarFluence::EGS_PlanarFluence(const string &Name, EGS_ObjectFactory *f) :
     EGS_FluenceScoring(Name,f), hits_field(false), Nx(1), Ny(1),
-    fluT_FD(0), fluT_FD_p(0), flu_FD(0), flu_FD_p(0) {
+    fluT_FD(0), fluT_FD_p(0), flu_FD(0), flu_FD_p(0),
+    m_fd_gen(0), m_fd_slot_gen(1024, EGS_I64(0)) {
     otype = "EGS_PlanarFluence";
     m_midpoint = EGS_Vector(0,0,5);
     m_R  =  5;
@@ -1387,7 +1388,8 @@ bool  EGS_PlanarFluence::addState(istream &data) {
 EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
     EGS_FluenceScoring(Name,f), flu_stpwr(stpwr),
     fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0),
-    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false)
+    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false),
+    m_fd_gen(0), m_fd_slot_gen(1024, EGS_I64(0))
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
 #endif
@@ -2604,7 +2606,8 @@ EGS_SphericalFluence::EGS_SphericalFluence(const string &Name, EGS_ObjectFactory
     cos_theta_bins(true), dir_filter(sph_both),
     m_has_crossings(false),
     fluT_FD(0), fluT_FD_p(0), flu_FD(0), flu_FD_p(0),
-    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false) {
+    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false),
+    m_fd_gen(0), m_fd_slot_gen(1024, EGS_I64(0)) {
     otype    = "EGS_SphericalFluence";
     m_center = EGS_Vector(0, 0, 0);
     m_axis   = EGS_Vector(0, 0, 1);
@@ -3226,13 +3229,10 @@ int EGS_SphericalFluence::processEvent(EGS_Application::AusgabCall iarg) {
             findCrossings(app->top_p);
             m_x0 = app->top_p.x;
             /* FD: fire only on first step of this photon's free path */
-            if (m_has_crossings && !scoring_charge && m_scoring_method != score_crossing &&
-                    !m_fd_pending_slots.empty()) {
+            if (m_has_crossings && !scoring_charge && m_scoring_method != score_crossing) {
                 int np = app->getNp();
-                auto it = std::find(m_fd_pending_slots.begin(),
-                                    m_fd_pending_slots.end(), np);
-                if (it != m_fd_pending_slots.end()) {
-                    m_fd_pending_slots.erase(it);
+                if (np < (int)m_fd_slot_gen.size() && m_fd_slot_gen[np] == m_fd_gen) {
+                    m_fd_slot_gen[np] = 0; // consume
                     scoreFD(app->top_p);
                 }
             }
@@ -3250,18 +3250,17 @@ int EGS_SphericalFluence::processEvent(EGS_Application::AusgabCall iarg) {
     }
     /* Clean up pending slot for photons discarded before their first step */
     else if (!scoring_charge && m_scoring_method != score_crossing
-             && !m_fd_pending_slots.empty()
              && iarg == EGS_Application::UserDiscard) {
         int np = app->getNp();
-        auto it = std::find(m_fd_pending_slots.begin(), m_fd_pending_slots.end(), np);
-        if (it != m_fd_pending_slots.end()) m_fd_pending_slots.erase(it);
+        if (np < (int)m_fd_slot_gen.size() && m_fd_slot_gen[np] == m_fd_gen)
+            m_fd_slot_gen[np] = 0;
     }
 
     if (score_primaries && ir >= 0 && !is_source[ir]) {
         flagSecondaries(iarg, q);
     }
 
-    /* Push interaction products for first-step FD (after flagSecondaries so latch is set) */
+    /* Mark interaction products for first-step FD (after flagSecondaries so latch is set) */
     if (!scoring_charge && m_scoring_method != score_crossing &&
             (iarg == EGS_Application::AfterCompton     ||
              iarg == EGS_Application::AfterPhoto       ||
@@ -3271,9 +3270,10 @@ int EGS_SphericalFluence::processEvent(EGS_Application::AusgabCall iarg) {
              iarg == EGS_Application::AfterAnnihRest)) {
         int npold_i = app->getNpOld();
         int np_i    = app->getNp();
-        for (int ip = npold_i; ip <= np_i; ip++) {
-            m_fd_pending_slots.push_back(ip);
-        }
+        if (np_i >= (int)m_fd_slot_gen.size())
+            m_fd_slot_gen.resize(2*np_i + 1, 0);
+        for (int ip = npold_i; ip <= np_i; ip++)
+            m_fd_slot_gen[ip] = m_fd_gen;
     }
 
     return 0;

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1387,7 +1387,7 @@ bool  EGS_PlanarFluence::addState(istream &data) {
 EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
     EGS_FluenceScoring(Name,f), flu_stpwr(stpwr),
     fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0),
-    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false), m_new_free_path(false)
+    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false)
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
 #endif
@@ -3225,8 +3225,16 @@ int EGS_SphericalFluence::processEvent(EGS_Application::AusgabCall iarg) {
         if (q == scoring_charge && ir >= 0 && is_sensitive[ir]) {
             findCrossings(app->top_p);
             m_x0 = app->top_p.x;
-            if (m_has_crossings && m_scoring_method != score_crossing) {
-                scoreFD(app->top_p);
+            /* FD: fire only on first step of this photon's free path */
+            if (m_has_crossings && !scoring_charge && m_scoring_method != score_crossing &&
+                    !m_fd_pending_slots.empty()) {
+                int np = app->getNp();
+                auto it = std::find(m_fd_pending_slots.begin(),
+                                    m_fd_pending_slots.end(), np);
+                if (it != m_fd_pending_slots.end()) {
+                    m_fd_pending_slots.erase(it);
+                    scoreFD(app->top_p);
+                }
             }
         }
     }
@@ -3240,9 +3248,32 @@ int EGS_SphericalFluence::processEvent(EGS_Application::AusgabCall iarg) {
             }
         }
     }
+    /* Clean up pending slot for photons discarded before their first step */
+    else if (!scoring_charge && m_scoring_method != score_crossing
+             && !m_fd_pending_slots.empty()
+             && iarg == EGS_Application::UserDiscard) {
+        int np = app->getNp();
+        auto it = std::find(m_fd_pending_slots.begin(), m_fd_pending_slots.end(), np);
+        if (it != m_fd_pending_slots.end()) m_fd_pending_slots.erase(it);
+    }
 
     if (score_primaries && ir >= 0 && !is_source[ir]) {
         flagSecondaries(iarg, q);
+    }
+
+    /* Push interaction products for first-step FD (after flagSecondaries so latch is set) */
+    if (!scoring_charge && m_scoring_method != score_crossing &&
+            (iarg == EGS_Application::AfterCompton     ||
+             iarg == EGS_Application::AfterPhoto       ||
+             iarg == EGS_Application::AfterRayleigh    ||
+             iarg == EGS_Application::AfterBrems       ||
+             iarg == EGS_Application::AfterAnnihFlight ||
+             iarg == EGS_Application::AfterAnnihRest)) {
+        int npold_i = app->getNpOld();
+        int np_i    = app->getNp();
+        for (int ip = npold_i; ip <= np_i; ip++) {
+            m_fd_pending_slots.push_back(ip);
+        }
     }
 
     return 0;

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1387,7 +1387,7 @@ bool  EGS_PlanarFluence::addState(istream &data) {
 EGS_VolumetricFluence::EGS_VolumetricFluence(const string &Name, EGS_ObjectFactory *f) :
     EGS_FluenceScoring(Name,f), flu_stpwr(stpwr),
     fd_geom(0), fluT_FD(0), flu_FD(0), fluT_FD_p(0), flu_FD_p(0),
-    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false)
+    fluT_x_p(0), fluT_FD_x_p(0), m_hist_dirty(false), m_new_free_path(false)
 #ifdef DEBUG
     ,one_bin(0), multi_bin(0), max_step(-100.0), n_step_bins(10000)
 #endif

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -638,6 +638,14 @@ public:
                   iarg == EGS_Application::AfterAnnihRest)) {
             return true;
         }
+        else if (!scoring_charge && m_scoring_method != score_crossing &&
+                 (iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterRayleigh    ||
+                  iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest)) {
+            return true;
+        }
         else {
             return false;
         }
@@ -661,10 +669,21 @@ public:
                ir = app->top_p.ir,
                latch = app->top_p.latch;
 
-        /* FD photon scoring: not gated by is_sensitive; scoreInCV handles gating */
+        /* FD photon scoring: once per new free path (m_new_free_path flag) */
         if (!scoring_charge && !q && iarg == EGS_Application::BeforeTransport
-                && m_scoring_method != score_crossing) {
+                && m_scoring_method != score_crossing && m_new_free_path) {
             scoreInCV();
+            m_new_free_path = false;
+        }
+        /* After a photon interaction that produces a continuing photon, arm FD for next step */
+        if (!scoring_charge && m_scoring_method != score_crossing) {
+            if (iarg == EGS_Application::AfterCompton     ||
+                    iarg == EGS_Application::AfterRayleigh    ||
+                    iarg == EGS_Application::AfterBrems       ||
+                    iarg == EGS_Application::AfterAnnihFlight ||
+                    iarg == EGS_Application::AfterAnnihRest) {
+                m_new_free_path = true;
+            }
         }
 
         if (q == scoring_charge && ir >= 0 && is_sensitive[ir]) {
@@ -677,8 +696,10 @@ public:
                     EGS_Float wtstep  = app->top_p.wt*app->getTVSTEP();
                     /* Score total fluence */
                     fluT->score(ir,wtstep);
+                    m_tot += app->top_p.wt;
                     if (score_primaries && !latch) {
                         fluT_p->score(ir,wtstep);
+                        m_primary += app->top_p.wt;
                     }
                     if (fluT_x_p) {
                         m_hist_T[ir] += wtstep;
@@ -1093,6 +1114,9 @@ public:
         if (ncase != current_ncase) {
             flushHistoryCrossTerms();
             current_ncase = ncase;
+            if (m_scoring_method != score_crossing) {
+                m_new_free_path = true;
+            }
             fluT->setHistory(ncase);
             if (score_primaries) {
                 fluT_p->setHistory(ncase);
@@ -1195,6 +1219,7 @@ public:
             fill(m_hist_FDP.begin(), m_hist_FDP.end(), 0.0);
         }
         m_hist_dirty = false;
+        m_new_free_path = false;
 #ifdef DEBUG
         binDist->reset();
         if (scoring_charge) {
@@ -1249,6 +1274,7 @@ private:
     mutable vector<double> m_hist_FDT; // per-history FD total per region
     mutable vector<double> m_hist_FDP; // per-history FD primary per region
     mutable bool           m_hist_dirty;
+    bool                   m_new_free_path; // true at history start and after each photon interaction; false after scoreInCV fires
     void flushHistoryCrossTerms() const; // flush accumulators → cross-term arrays
 
     vector<EGS_Float> volume;    // volume of each scoring region

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -48,6 +48,7 @@
 #include "egs_ausgab_object.h"
 #include "egs_transformations.h"
 #include "egs_interpolator.h"
+#include "egs_base_geometry.h"
 #include <egs_scoring.h>
 
 #include <fstream>
@@ -660,11 +661,18 @@ public:
                ir = app->top_p.ir,
                latch = app->top_p.latch;
 
+        /* FD photon scoring: not gated by is_sensitive; scoreInCV handles gating */
+        if (!scoring_charge && !q && iarg == EGS_Application::BeforeTransport
+                && m_scoring_method != score_crossing) {
+            scoreInCV();
+        }
+
         if (q == scoring_charge && ir >= 0 && is_sensitive[ir]) {
 
             if (!q) { // It's a photon
                 /* Score photon fluence */
-                if (iarg == EGS_Application::BeforeTransport) {
+                if (iarg == EGS_Application::BeforeTransport
+                        && m_scoring_method != score_FD) {
                     /* Linear track-Length scoring */
                     EGS_Float wtstep  = app->top_p.wt*app->getTVSTEP();
                     /* Score total fluence */
@@ -1097,6 +1105,26 @@ public:
                     }
                 }
             }
+            if (m_scoring_method != score_crossing && fluT_FD) {
+                fluT_FD->setHistory(ncase);
+                if (score_primaries && fluT_FD_p) {
+                    fluT_FD_p->setHistory(ncase);
+                }
+                if (score_spe && flu_FD) {
+                    for (int j = 0; j < nreg; j++) {
+                        if (is_sensitive[j]) {
+                            flu_FD[j]->setHistory(ncase);
+                        }
+                    }
+                    if (score_primaries && flu_FD_p) {
+                        for (int j = 0; j < nreg; j++) {
+                            if (is_sensitive[j]) {
+                                flu_FD_p[j]->setHistory(ncase);
+                            }
+                        }
+                    }
+                }
+            }
         }
 #ifdef DEBUG
         binDist->setHistory(ncase);
@@ -1124,6 +1152,26 @@ public:
                 for (int j = 0; j < nreg; j++) {
                     if (is_sensitive[j]) {
                         flu_p[j]->reset();
+                    }
+                }
+            }
+        }
+        if (m_scoring_method != score_crossing && fluT_FD) {
+            fluT_FD->reset();
+            if (score_primaries && fluT_FD_p) {
+                fluT_FD_p->reset();
+            }
+            if (score_spe && flu_FD) {
+                for (int j = 0; j < nreg; j++) {
+                    if (is_sensitive[j]) {
+                        flu_FD[j]->reset();
+                    }
+                }
+                if (score_primaries && flu_FD_p) {
+                    for (int j = 0; j < nreg; j++) {
+                        if (is_sensitive[j]) {
+                            flu_FD_p[j]->reset();
+                        }
                     }
                 }
             }
@@ -1164,6 +1212,15 @@ private:
     /*****************************************************************/
 
     EGS_I64 eCases;
+
+    /* Forced-detection members (photons only, scoring_charge == 0) */
+    EGS_BaseGeometry *fd_geom;   // optional gate geometry (like egs_kerma fd_geom)
+    EGS_ScoringArray  *fluT_FD;  // FD total fluence
+    EGS_ScoringArray **flu_FD;   // FD differential fluence per sensitive region
+    EGS_ScoringArray  *fluT_FD_p;// FD primary total fluence
+    EGS_ScoringArray **flu_FD_p; // FD primary differential fluence per sensitive region
+
+    void scoreInCV(); // FD ray-tracing scorer (defined in cpp)
 
     vector<EGS_Float> volume;    // volume of each scoring region
     /* Energy grid inputs */

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -680,6 +680,11 @@ public:
                     if (score_primaries && !latch) {
                         fluT_p->score(ir,wtstep);
                     }
+                    if (fluT_x_p) {
+                        m_hist_T[ir] += wtstep;
+                        if (!latch) m_hist_P[ir] += wtstep;
+                        m_hist_dirty = true;
+                    }
                     /* Score differential fluence */
                     if (score_spe) {
                         EGS_Float e = app->top_p.E;
@@ -1086,10 +1091,12 @@ public:
 
     void setCurrentCase(EGS_I64 ncase) {
         if (ncase != current_ncase) {
+            flushHistoryCrossTerms();
             current_ncase = ncase;
             fluT->setHistory(ncase);
             if (score_primaries) {
                 fluT_p->setHistory(ncase);
+                if (fluT_x_p) fluT_x_p->setHistory(ncase);
             }
             if (score_spe) {
                 for (int j = 0; j < nreg; j++) {
@@ -1109,6 +1116,7 @@ public:
                 fluT_FD->setHistory(ncase);
                 if (score_primaries && fluT_FD_p) {
                     fluT_FD_p->setHistory(ncase);
+                    if (fluT_FD_x_p) fluT_FD_x_p->setHistory(ncase);
                 }
                 if (score_spe && flu_FD) {
                     for (int j = 0; j < nreg; j++) {
@@ -1176,6 +1184,17 @@ public:
                 }
             }
         }
+        if (fluT_x_p) {
+            fluT_x_p->reset();
+            fill(m_hist_T.begin(),  m_hist_T.end(),  0.0);
+            fill(m_hist_P.begin(),  m_hist_P.end(),  0.0);
+        }
+        if (fluT_FD_x_p) {
+            fluT_FD_x_p->reset();
+            fill(m_hist_FDT.begin(), m_hist_FDT.end(), 0.0);
+            fill(m_hist_FDP.begin(), m_hist_FDP.end(), 0.0);
+        }
+        m_hist_dirty = false;
 #ifdef DEBUG
         binDist->reset();
         if (scoring_charge) {
@@ -1221,6 +1240,16 @@ private:
     EGS_ScoringArray **flu_FD_p; // FD primary differential fluence per sensitive region
 
     void scoreInCV(); // FD ray-tracing scorer (defined in cpp)
+
+    /* Correlated tot/pri ratio: cross-term arrays and per-history accumulators */
+    EGS_ScoringArray  *fluT_x_p;    // TL cross-term Σ T_i·P_i per region
+    EGS_ScoringArray  *fluT_FD_x_p; // FD cross-term
+    mutable vector<double> m_hist_T;   // per-history TL total per region
+    mutable vector<double> m_hist_P;   // per-history TL primary per region
+    mutable vector<double> m_hist_FDT; // per-history FD total per region
+    mutable vector<double> m_hist_FDP; // per-history FD primary per region
+    mutable bool           m_hist_dirty;
+    void flushHistoryCrossTerms() const; // flush accumulators → cross-term arrays
 
     vector<EGS_Float> volume;    // volume of each scoring region
     /* Energy grid inputs */

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -358,6 +358,16 @@ public:
                   iarg == EGS_Application::AfterAnnihRest)) {
             return true;
         }
+        else if (!scoring_charge && m_scoring_method != score_crossing &&
+                 (iarg == EGS_Application::UserDiscard      ||
+                  iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterPhoto       ||
+                  iarg == EGS_Application::AfterRayleigh    ||
+                  iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest)) {
+            return true;
+        }
         else {
             return false;
         }
@@ -384,8 +394,16 @@ public:
                 if (ixy >= 0) {
                     x0 = app->top_p.x;
                     hits_field = true;
-                    if (m_scoring_method != score_crossing) {
-                        scoreFD(app->top_p, ixy, distance);
+                    /* FD: fire only on first step of this photon's free path */
+                    if (!scoring_charge && m_scoring_method != score_crossing &&
+                            !m_fd_pending_slots.empty()) {
+                        int np = app->getNp();
+                        auto it = std::find(m_fd_pending_slots.begin(),
+                                            m_fd_pending_slots.end(), np);
+                        if (it != m_fd_pending_slots.end()) {
+                            m_fd_pending_slots.erase(it);
+                            scoreFD(app->top_p, ixy, distance);
+                        }
                     }
                 }
                 else {
@@ -405,6 +423,16 @@ public:
             }
         }
 
+        /* Clean up pending slot for photons discarded before their first step */
+        if (!scoring_charge && m_scoring_method != score_crossing
+                && !m_fd_pending_slots.empty()
+                && iarg == EGS_Application::UserDiscard) {
+            int np = app->getNp();
+            auto it = std::find(m_fd_pending_slots.begin(),
+                                m_fd_pending_slots.end(), np);
+            if (it != m_fd_pending_slots.end()) m_fd_pending_slots.erase(it);
+        }
+
         /********************************************************************
          * Flag secondaries after interactions. Definition of secondaries
          * matches FLURZnrc. One could fine tune it by using the is_source
@@ -418,6 +446,21 @@ public:
             flagSecondaries(iarg, q);
         }
 
+        /* Push interaction products for first-step FD (after flagSecondaries so latch is set) */
+        if (!scoring_charge && m_scoring_method != score_crossing &&
+                (iarg == EGS_Application::AfterCompton     ||
+                 iarg == EGS_Application::AfterPhoto       ||
+                 iarg == EGS_Application::AfterRayleigh    ||
+                 iarg == EGS_Application::AfterBrems       ||
+                 iarg == EGS_Application::AfterAnnihFlight ||
+                 iarg == EGS_Application::AfterAnnihRest)) {
+            int npold_i = app->getNpOld();
+            int np_i    = app->getNp();
+            for (int ip = npold_i; ip <= np_i; ip++) {
+                m_fd_pending_slots.push_back(ip);
+            }
+        }
+
         return 0;
 
     };
@@ -425,6 +468,10 @@ public:
     void setCurrentCase(EGS_I64 ncase) {
         if (ncase != current_ncase) {
             current_ncase = ncase;
+            if (m_scoring_method != score_crossing) {
+                m_fd_pending_slots.clear();
+                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
+            }
             fluT->setHistory(ncase);
             if (score_spe) {
                 for (int j = 0; j < Nx*Ny; j++) {
@@ -518,6 +565,8 @@ private:
     void scoreFD(const EGS_Particle &p, int ixy, EGS_Float dist);
     void outputSpectrum(EGS_ScoringArray **fl_set, EGS_ScoringArray **flp_set,
                         double norm, const string &suffix) const;
+
+    vector<int> m_fd_pending_slots; // stack slots awaiting first-step FD scoring
 
     EGS_ScoringArray  *fluT_FD;    // FD total fluence (score_both only)
     EGS_ScoringArray  *fluT_FD_p;  // FD primary total fluence (score_both only)
@@ -640,6 +689,7 @@ public:
         }
         else if (!scoring_charge && m_scoring_method != score_crossing &&
                  (iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterPhoto       ||
                   iarg == EGS_Application::AfterRayleigh    ||
                   iarg == EGS_Application::AfterBrems       ||
                   iarg == EGS_Application::AfterAnnihFlight ||
@@ -669,20 +719,23 @@ public:
                ir = app->top_p.ir,
                latch = app->top_p.latch;
 
-        /* FD photon scoring: once per new free path (m_new_free_path flag) */
-        if (!scoring_charge && !q && iarg == EGS_Application::BeforeTransport
-                && m_scoring_method != score_crossing && m_new_free_path) {
-            scoreInCV();
-            m_new_free_path = false;
-        }
-        /* After a photon interaction that produces a continuing photon, arm FD for next step */
-        if (!scoring_charge && m_scoring_method != score_crossing) {
-            if (iarg == EGS_Application::AfterCompton     ||
-                    iarg == EGS_Application::AfterRayleigh    ||
-                    iarg == EGS_Application::AfterBrems       ||
-                    iarg == EGS_Application::AfterAnnihFlight ||
-                    iarg == EGS_Application::AfterAnnihRest) {
-                m_new_free_path = true;
+        /* FD photon scoring: fires once per photon's first free path.
+         * Primary photon: pushed at slot 0 in setCurrentCase (primary is always
+         * at Fortran NP=1 = C++ slot 0 when shower() starts).
+         * Scatter-produced photons: their slots are pushed to m_fd_pending_slots
+         * at the interaction event so each photon fires FD exactly once,
+         * regardless of how many geometry boundaries it crosses in one free path. */
+        if (!scoring_charge && m_scoring_method != score_crossing &&
+                !m_fd_pending_slots.empty() &&
+                (iarg == EGS_Application::BeforeTransport ||
+                 iarg == EGS_Application::UserDiscard)) {
+            int np = app->getNp();
+            auto it = std::find(m_fd_pending_slots.begin(),
+                                m_fd_pending_slots.end(), np);
+            bool in_pending = (it != m_fd_pending_slots.end());
+            if (in_pending) m_fd_pending_slots.erase(it);
+            if (!q && iarg == EGS_Application::BeforeTransport && in_pending) {
+                scoreInCV();
             }
         }
 
@@ -1038,6 +1091,26 @@ public:
             flagSecondaries(iarg, q);
         }
 
+        /* Register all particles produced at this interaction for first-step FD scoring.
+         * Loop covers [npold, np] so fluorescence photons pushed by atomic relaxation
+         * (Compton, photoelectric, EII, etc.) at arbitrary positions in that range
+         * are all captured. Charged particles land in the set too but are filtered
+         * by the !q guard at BeforeTransport and cleaned up there or at UserDiscard.
+         * Placed after flagSecondaries() so latch is correct when BeforeTransport fires. */
+        if (!scoring_charge && m_scoring_method != score_crossing &&
+                (iarg == EGS_Application::AfterCompton     ||
+                 iarg == EGS_Application::AfterPhoto       ||
+                 iarg == EGS_Application::AfterRayleigh    ||
+                 iarg == EGS_Application::AfterBrems       ||
+                 iarg == EGS_Application::AfterAnnihFlight ||
+                 iarg == EGS_Application::AfterAnnihRest)) {
+            int npold_i = app->getNpOld();
+            int np_i    = app->getNp();
+            for (int ip = npold_i; ip <= np_i; ip++) {
+                m_fd_pending_slots.push_back(ip);
+            }
+        }
+
         return 0;
 
     };
@@ -1115,7 +1188,8 @@ public:
             flushHistoryCrossTerms();
             current_ncase = ncase;
             if (m_scoring_method != score_crossing) {
-                m_new_free_path = true;
+                m_fd_pending_slots.clear();
+                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
             }
             fluT->setHistory(ncase);
             if (score_primaries) {
@@ -1219,7 +1293,6 @@ public:
             fill(m_hist_FDP.begin(), m_hist_FDP.end(), 0.0);
         }
         m_hist_dirty = false;
-        m_new_free_path = false;
 #ifdef DEBUG
         binDist->reset();
         if (scoring_charge) {
@@ -1274,8 +1347,8 @@ private:
     mutable vector<double> m_hist_FDT; // per-history FD total per region
     mutable vector<double> m_hist_FDP; // per-history FD primary per region
     mutable bool           m_hist_dirty;
-    bool                   m_new_free_path; // true at history start and after each photon interaction; false after scoreInCV fires
-    void flushHistoryCrossTerms() const; // flush accumulators → cross-term arrays
+    vector<int>            m_fd_pending_slots;    // stack slots awaiting first-step FD scoring
+    void flushHistoryCrossTerms() const;
 
     vector<EGS_Float> volume;    // volume of each scoring region
     /* Energy grid inputs */
@@ -1365,6 +1438,16 @@ public:
                   iarg == EGS_Application::AfterAnnihRest)) {
             return true;
         }
+        else if (!scoring_charge && m_scoring_method != score_crossing &&
+                 (iarg == EGS_Application::UserDiscard      ||
+                  iarg == EGS_Application::AfterCompton     ||
+                  iarg == EGS_Application::AfterPhoto       ||
+                  iarg == EGS_Application::AfterRayleigh    ||
+                  iarg == EGS_Application::AfterBrems       ||
+                  iarg == EGS_Application::AfterAnnihFlight ||
+                  iarg == EGS_Application::AfterAnnihRest)) {
+            return true;
+        }
         return false;
     };
 
@@ -1381,6 +1464,10 @@ public:
         if (ncase != current_ncase) {
             flushHistoryCrossTerms();
             current_ncase = ncase;
+            if (m_scoring_method != score_crossing) {
+                m_fd_pending_slots.clear();
+                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
+            }
             int n_total = n_sph * N_ang;
             fluT->setHistory(ncase);
             if (score_spe) {
@@ -1524,6 +1611,7 @@ private:
     mutable vector<double>  m_hist_FDT;  // per-history FD total per bin
     mutable vector<double>  m_hist_FDP;  // per-history FD primary per bin
     mutable bool            m_hist_dirty;
+    vector<int>             m_fd_pending_slots; // stack slots awaiting first-step FD scoring
 };
 
 #endif

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.h
@@ -395,13 +395,10 @@ public:
                     x0 = app->top_p.x;
                     hits_field = true;
                     /* FD: fire only on first step of this photon's free path */
-                    if (!scoring_charge && m_scoring_method != score_crossing &&
-                            !m_fd_pending_slots.empty()) {
+                    if (!scoring_charge && m_scoring_method != score_crossing) {
                         int np = app->getNp();
-                        auto it = std::find(m_fd_pending_slots.begin(),
-                                            m_fd_pending_slots.end(), np);
-                        if (it != m_fd_pending_slots.end()) {
-                            m_fd_pending_slots.erase(it);
+                        if (np < (int)m_fd_slot_gen.size() && m_fd_slot_gen[np] == m_fd_gen) {
+                            m_fd_slot_gen[np] = 0; // consume
                             scoreFD(app->top_p, ixy, distance);
                         }
                     }
@@ -425,12 +422,10 @@ public:
 
         /* Clean up pending slot for photons discarded before their first step */
         if (!scoring_charge && m_scoring_method != score_crossing
-                && !m_fd_pending_slots.empty()
                 && iarg == EGS_Application::UserDiscard) {
             int np = app->getNp();
-            auto it = std::find(m_fd_pending_slots.begin(),
-                                m_fd_pending_slots.end(), np);
-            if (it != m_fd_pending_slots.end()) m_fd_pending_slots.erase(it);
+            if (np < (int)m_fd_slot_gen.size() && m_fd_slot_gen[np] == m_fd_gen)
+                m_fd_slot_gen[np] = 0;
         }
 
         /********************************************************************
@@ -446,7 +441,7 @@ public:
             flagSecondaries(iarg, q);
         }
 
-        /* Push interaction products for first-step FD (after flagSecondaries so latch is set) */
+        /* Mark interaction products for first-step FD (after flagSecondaries so latch is set) */
         if (!scoring_charge && m_scoring_method != score_crossing &&
                 (iarg == EGS_Application::AfterCompton     ||
                  iarg == EGS_Application::AfterPhoto       ||
@@ -456,9 +451,10 @@ public:
                  iarg == EGS_Application::AfterAnnihRest)) {
             int npold_i = app->getNpOld();
             int np_i    = app->getNp();
-            for (int ip = npold_i; ip <= np_i; ip++) {
-                m_fd_pending_slots.push_back(ip);
-            }
+            if (np_i >= (int)m_fd_slot_gen.size())
+                m_fd_slot_gen.resize(2*np_i + 1, 0);
+            for (int ip = npold_i; ip <= np_i; ip++)
+                m_fd_slot_gen[ip] = m_fd_gen;
         }
 
         return 0;
@@ -468,10 +464,8 @@ public:
     void setCurrentCase(EGS_I64 ncase) {
         if (ncase != current_ncase) {
             current_ncase = ncase;
-            if (m_scoring_method != score_crossing) {
-                m_fd_pending_slots.clear();
-                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
-            }
+            if (m_scoring_method != score_crossing)
+                m_fd_slot_gen[0] = ++m_fd_gen; // primary always at C++ slot 0
             fluT->setHistory(ncase);
             if (score_spe) {
                 for (int j = 0; j < Nx*Ny; j++) {
@@ -566,7 +560,8 @@ private:
     void outputSpectrum(EGS_ScoringArray **fl_set, EGS_ScoringArray **flp_set,
                         double norm, const string &suffix) const;
 
-    vector<int> m_fd_pending_slots; // stack slots awaiting first-step FD scoring
+    EGS_I64         m_fd_gen;      // incremented each history; slot_gen[np]==m_fd_gen ↔ pending
+    vector<EGS_I64> m_fd_slot_gen; // indexed by stack slot; value = m_fd_gen when pending
 
     EGS_ScoringArray  *fluT_FD;    // FD total fluence (score_both only)
     EGS_ScoringArray  *fluT_FD_p;  // FD primary total fluence (score_both only)
@@ -720,20 +715,17 @@ public:
                latch = app->top_p.latch;
 
         /* FD photon scoring: fires once per photon's first free path.
-         * Primary photon: pushed at slot 0 in setCurrentCase (primary is always
+         * Primary photon: marked at slot 0 in setCurrentCase (primary is always
          * at Fortran NP=1 = C++ slot 0 when shower() starts).
-         * Scatter-produced photons: their slots are pushed to m_fd_pending_slots
-         * at the interaction event so each photon fires FD exactly once,
-         * regardless of how many geometry boundaries it crosses in one free path. */
+         * Scatter-produced photons: their slots are marked in m_fd_slot_gen at the
+         * interaction event so each photon fires FD exactly once, regardless of how
+         * many geometry boundaries it crosses in one free path. O(1) lookup. */
         if (!scoring_charge && m_scoring_method != score_crossing &&
-                !m_fd_pending_slots.empty() &&
                 (iarg == EGS_Application::BeforeTransport ||
                  iarg == EGS_Application::UserDiscard)) {
             int np = app->getNp();
-            auto it = std::find(m_fd_pending_slots.begin(),
-                                m_fd_pending_slots.end(), np);
-            bool in_pending = (it != m_fd_pending_slots.end());
-            if (in_pending) m_fd_pending_slots.erase(it);
+            bool in_pending = (np < (int)m_fd_slot_gen.size() && m_fd_slot_gen[np] == m_fd_gen);
+            if (in_pending) m_fd_slot_gen[np] = 0; // consume
             if (!q && iarg == EGS_Application::BeforeTransport && in_pending) {
                 scoreInCV();
             }
@@ -1106,9 +1098,10 @@ public:
                  iarg == EGS_Application::AfterAnnihRest)) {
             int npold_i = app->getNpOld();
             int np_i    = app->getNp();
-            for (int ip = npold_i; ip <= np_i; ip++) {
-                m_fd_pending_slots.push_back(ip);
-            }
+            if (np_i >= (int)m_fd_slot_gen.size())
+                m_fd_slot_gen.resize(2*np_i + 1, 0);
+            for (int ip = npold_i; ip <= np_i; ip++)
+                m_fd_slot_gen[ip] = m_fd_gen;
         }
 
         return 0;
@@ -1187,10 +1180,8 @@ public:
         if (ncase != current_ncase) {
             flushHistoryCrossTerms();
             current_ncase = ncase;
-            if (m_scoring_method != score_crossing) {
-                m_fd_pending_slots.clear();
-                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
-            }
+            if (m_scoring_method != score_crossing)
+                m_fd_slot_gen[0] = ++m_fd_gen; // primary always at C++ slot 0
             fluT->setHistory(ncase);
             if (score_primaries) {
                 fluT_p->setHistory(ncase);
@@ -1347,7 +1338,8 @@ private:
     mutable vector<double> m_hist_FDT; // per-history FD total per region
     mutable vector<double> m_hist_FDP; // per-history FD primary per region
     mutable bool           m_hist_dirty;
-    vector<int>            m_fd_pending_slots;    // stack slots awaiting first-step FD scoring
+    EGS_I64         m_fd_gen;      // incremented each history; slot_gen[np]==m_fd_gen ↔ pending
+    vector<EGS_I64> m_fd_slot_gen; // indexed by stack slot; value = m_fd_gen when pending
     void flushHistoryCrossTerms() const;
 
     vector<EGS_Float> volume;    // volume of each scoring region
@@ -1464,10 +1456,8 @@ public:
         if (ncase != current_ncase) {
             flushHistoryCrossTerms();
             current_ncase = ncase;
-            if (m_scoring_method != score_crossing) {
-                m_fd_pending_slots.clear();
-                m_fd_pending_slots.push_back(0); // primary always at C++ slot 0
-            }
+            if (m_scoring_method != score_crossing)
+                m_fd_slot_gen[0] = ++m_fd_gen; // primary always at C++ slot 0
             int n_total = n_sph * N_ang;
             fluT->setHistory(ncase);
             if (score_spe) {
@@ -1611,7 +1601,8 @@ private:
     mutable vector<double>  m_hist_FDT;  // per-history FD total per bin
     mutable vector<double>  m_hist_FDP;  // per-history FD primary per bin
     mutable bool            m_hist_dirty;
-    vector<int>             m_fd_pending_slots; // stack slots awaiting first-step FD scoring
+    EGS_I64         m_fd_gen;      // incremented each history; slot_gen[np]==m_fd_gen ↔ pending
+    vector<EGS_I64> m_fd_slot_gen; // indexed by stack slot; value = m_fd_gen when pending
 };
 
 #endif

--- a/HEN_HOUSE/user_codes/egs_app/sph-f-FD-vs-cross-iron.egsinp
+++ b/HEN_HOUSE/user_codes/egs_app/sph-f-FD-vs-cross-iron.egsinp
@@ -51,6 +51,7 @@
         radii    = 25 30
         :start media input:
             media = iron VACUUM
+            set medium = 1 1
         :stop media input:
     :stop geometry:
 


### PR DESCRIPTION
> **Depends on:** #1438 (must merge first)

  ## Summary

  Adds `EGS_VolumetricFluence`, a new ausgab object scoring photon fluence in
  arbitrary volumetric regions using track-length (TL) and/or forced-detection
  (FD) estimators. Also fixes two FD correctness bugs that affected all three
  scorers (`EGS_VolumetricFluence`, `EGS_SphericalFluence`, `EGS_PlanarFluence`).

  ### EGS_VolumetricFluence — new in this PR

  - **Forced-detection estimator** (photons only): `scoring method = forced detection`
    or `both` (separate TL and FD arrays for direct estimator comparison);
    requires `FD geometry` key naming the geometry used for ray-tracing
  - **Correlated tot/pri ratio**: replaces independent scoring of total and primary
    fluence with per-history cross-term arrays (`fluT_x_p`, `fluT_FD_x_p`),
    giving correct variance on the ratio:
    `var(B̂) = (σ²_T − 2B·cov + B²·σ²_P) / P̄²`

  ### FD correctness fixes (all three scorers)

  **(A) Volumetric — `m_new_free_path` race condition (~2.4% undercount):**
  `m_new_free_path = true` set at `AfterCompton` was consumed by secondary photons
  from the Compton electron (K-shell fluorescence, bremsstrahlung) before the
  scattered photon's own `BeforeTransport`, due to EGSnrc's LIFO stack ordering.
  The scattered photon then silently missed FD scoring.

  **(B) Spherical and planar — multi-firing per free path (latent overcount):**
  `scoreFD` was called unconditionally at every `BeforeTransport`. For solid
  single-region geometries this is harmless, but in multi-region geometries FD
  would fire once per boundary crossing within the same free path — a systematic
  overcount masked by the solid-iron test geometry.

  ### Unified fix: O(1) generation counter

  Replaces `m_new_free_path` and `vector<int> m_fd_pending_slots` (linear
  `std::find`) with:
  - `EGS_I64 m_fd_gen` — incremented once per history at `setCurrentCase()`
  - `vector<EGS_I64> m_fd_slot_gen` — indexed by stack slot; entry equals
    `m_fd_gen` when pending, 0 otherwise; 1024-slot initial size, grows on demand

  O(1) lookup and consume; no per-history clearing; `EGS_I64` avoids overflow in
  trillion-history runs (BUF campaigns already reach ~10¹² histories).

  ## Test plan

  - [x] Build `egs_fluence_scoring` and `egs_app`; confirm no compilation errors
  - [x] Run `vol-f-100um-shells-iron.egsinp` (12-region geometry, alternating
        100 µm vacuum scoring shells and iron): FD and TL total fluence agree
        within statistics at all shells; FD primary uncertainty 0.000%
  - [x] Confirm FD/TL agreement holds in the multi-region geometry (this is the
        case that exposed the race condition and would have shown the multi-firing
        overcount for spherical/planar)
