### PR TITLE
Add geometry importance sampling and Russian roulette to egs_kerma

### DIFF
--- a/HEN_HOUSE/egs++/egs_ausgab_object.cpp
+++ b/HEN_HOUSE/egs++/egs_ausgab_object.cpp
@@ -44,6 +44,11 @@ static EGS_LOCAL EGS_TypedObjectFactory<EGS_AusgabObject>
 ausgab_object_creator(string("egs++/dso/")+CONFIG_NAME,"EGS_AusgabObject");
 
 void EGS_AusgabObject::createAusgabObjects(EGS_Input *i) {
+    if (!i) return;
+    if (!i->isA("ausgab object definition") &&
+        !i->getInputItem("ausgab object definition")) {
+        return;
+    }
     ausgab_object_creator.createObjects(i,"ausgab object definition",
                                         "ausgab object","__no__key__","createAusgabObject",true);
 }

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -377,6 +377,14 @@ public:
                             the_stack->latch[nn]=latch|IS_COPY_FLAG; the_stack->dnear[nn]=dn;
                             the_stack->np++;
                         }
+                        /* BUG FIX (2026-08-11): the LAST copy pushed is now the
+                         * top of stack, i.e. Fortran's np, and PHOTON continues
+                         * transport with it WITHOUT re-entering :PNEWENERGY:.
+                         * It therefore never calls selectPhotonMFP() here and
+                         * never consumes its flag, which would later suppress a
+                         * legitimate scoreInCV().  The original at np keeps its
+                         * flag -- it is popped fresh at :PNEWENERGY:. */
+                        the_stack->latch[the_stack->np - 1] &= ~IS_COPY_FLAG;
                     }
                 }
                 else if (ratio < 1.0 - 1e-10) {

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -335,6 +335,12 @@ public:
                     if (nsplit > 1) {
                         EGS_Float new_wt = the_stack->wt[np] / nsplit;
                         the_stack->wt[np] = new_wt;
+                        /* Mark the original particle too: EGSnrc's LIFO stack
+                         * will re-enter :PNEWENERGY: for this particle after all
+                         * copies are processed, which would call scoreInCV() again
+                         * from the split boundary — double-counting the FD
+                         * contribution already scored from the MFP start. */
+                        the_stack->latch[np] |= IS_COPY_FLAG;
                         EGS_Float x_=the_stack->x[np], y_=the_stack->y[np],
                                   z_=the_stack->z[np], u_=the_stack->u[np],
                                   v_=the_stack->v[np], w_=the_stack->w[np],
@@ -1218,12 +1224,12 @@ public:
         int ireg   = the_stack->ir[np]-2, newmed = geometry->medium(ireg);
         prev_ir_imp = ireg;  // snapshot for crossing detection in AfterTransport
 
-        /* IS split copies carry IS_COPY_FLAG in latch to suppress the FD score
-         * on their first MFP restart.  The original photon already scored from
-         * its MFP start; letting the copy score again from the split point
-         * would double-count the FD contribution from there onward.  Clear the
-         * flag here so all subsequent MFPs (after physical interactions) score
-         * normally. */
+        /* IS_COPY_FLAG is set on both IS copies and the original particle when a
+         * split fires.  EGSnrc's LIFO stack re-enters :PNEWENERGY: for the
+         * original after processing the copies; the original already had
+         * scoreInCV() called from its MFP start, so this re-entry must be
+         * suppressed.  Copies likewise must not re-score from the split point.
+         * The flag is cleared here so post-interaction MFPs score normally. */
         bool is_copy = the_stack->latch[np] & IS_COPY_FLAG;
         if (is_copy) the_stack->latch[np] &= ~IS_COPY_FLAG;
 
@@ -1378,12 +1384,14 @@ private:
     vector<vector<EGS_Float>> region_importance; // [ig][ir], default 1.0
     int                       prev_ir_imp;        // region at start of current step
 
-    /* Bit flag set on IS split copies to suppress scoreInCV() on their first
-     * MFP restart.  The original photon already scored scoreInCV() from its
-     * MFP start; the copy's restart call would double-count the FD contribution
-     * from the split point onward.  The flag is cleared immediately in
-     * selectPhotonMFP() so all subsequent MFPs (after physical interactions)
-     * score normally.  Bit 30 is used to stay clear of physics latch bits. */
+    /* Flag set on both the original and all IS copies when a split occurs.
+     * EGSnrc's LIFO stack re-enters :PNEWENERGY: for the original particle
+     * after processing its copies, which would call scoreInCV() again from
+     * the split boundary — double-counting the FD contribution already scored
+     * from the MFP start.  Setting the flag on the original as well suppresses
+     * that re-entry call.  selectPhotonMFP() clears the flag so that
+     * post-interaction MFPs (genuinely new physics) score normally.
+     * Bit 30 is used to stay clear of physics latch bits. */
     static const int IS_COPY_FLAG = 1 << 30;
 
     static string revision;

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -880,10 +880,22 @@ public:
                        " Simulation statistics\n"
                        "===========================================================\n\n");
 
+        EGS_Float flu = source->getFluence();
+        /* Sources that return only a particle count (isotropic, beam, point,
+         * phase-space, ...) have getFluence() == current_case.  Only parallel
+         * and collimated sources divide by area or distance² and return a
+         * true fluence per cm².  Distinguish by exact equality with the case
+         * counter (both are doubles for count-mode sources). */
+        bool is_fluence = (flu != (EGS_Float)current_case);
+
         egsInformation(" %-24s %lld\n",
                        "Histories simulated :", current_case);
-        egsInformation(" %-24s %.6g cm^-2\n\n",
-                       "Source fluence :", source->getFluence());
+        if (is_fluence)
+            egsInformation(" %-24s %.6g cm^-2\n\n",
+                           "Source fluence :", flu);
+        else
+            egsInformation(" %-24s %.6g\n\n",
+                           "Source particles :", flu);
 
         if (has_src_ph || has_src_el) {
             egsInformation(" Source particles\n");

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -343,14 +343,24 @@ public:
                         int needed = the_stack->np + nsplit;
                         if (needed > max_stack_needed) max_stack_needed = needed;
                     }
-                    /* Weight is always divided by nsplit — unconditionally.
-                     * Every surviving particle, including the original when
-                     * the stack is too full for any copies, must carry the
-                     * correct IS-assigned weight w/nsplit.  Copies that do
-                     * not fit are simply dropped (downward bias only when
-                     * the stack is genuinely saturated). */
                     EGS_Float new_wt = the_stack->wt[np] / nsplit;
-                    the_stack->wt[np] = new_wt;
+                    if (n_actual == 0) {
+                        /* Stack completely full — no copies can be created.
+                         * Dividing the weight by nsplit without copies leaves
+                         * near-zero-weight particles clogging the stack.
+                         * Instead: Russian roulette with survival prob 1/nsplit.
+                         * Survivors keep their weight intact and will be split
+                         * properly once the stack has room.  Expected weight is
+                         * (1/nsplit) × w = new_wt, so the estimator is unbiased. */
+                        if (rndm->getUniform() > 1.0 / nsplit)
+                            the_epcont->idisc = 1;  // kill — clears stack pressure
+                        // survivor: wt[np] unchanged, will split at next opportunity
+                    } else {
+                        /* Partial or full split: all surviving particles carry
+                         * w/nsplit.  Copies that don't fit are dropped
+                         * (small downward bias only when heavily capped). */
+                        the_stack->wt[np] = new_wt;
+                    }
                     if (n_actual > 1) {
                         /* IS_COPY_FLAG is only needed when copies exist:
                          * it prevents the original from calling scoreInCV()

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -304,55 +304,65 @@ public:
         // }
         }
 
-        /* Geometry importance: splitting and Russian roulette at region crossings */
-        if (iarg == AfterTransport && !iq && ir >= 0
-                && prev_ir_imp >= 0 && ir != prev_ir_imp
-                && ig < (int)region_importance.size()
-                && prev_ir_imp < (int)region_importance[ig].size()
-                && ir          < (int)region_importance[ig].size()) {
+        /* Geometry importance: splitting and Russian roulette at region crossings.
+         * prev_ir_imp is updated at every AfterTransport so that successive
+         * boundary crossings within a single photon MFP use the immediately
+         * preceding region, not the region from selectPhotonMFP().  Without
+         * this update, $SELECT-PHOTON-MFP is called only once per MFP (at
+         * :PNEWENERGY:), leaving prev_ir_imp stale for crossings 2, 3, ... */
+        if (iarg == AfterTransport && !iq && ir >= 0) {
+            if (prev_ir_imp >= 0 && ir != prev_ir_imp
+                    && ig < (int)region_importance.size()
+                    && prev_ir_imp < (int)region_importance[ig].size()
+                    && ir          < (int)region_importance[ig].size()) {
 
-            EGS_Float I_old = region_importance[ig][prev_ir_imp];
-            EGS_Float I_new = region_importance[ig][ir];
-            EGS_Float ratio = I_new / I_old;
+                EGS_Float I_old = region_importance[ig][prev_ir_imp];
+                EGS_Float I_new = region_importance[ig][ir];
+                EGS_Float ratio = I_new / I_old;
 
-            if (ratio > 1.0 + 1e-10) {
-                /* Forward crossing (deeper): split.
-                 * Cap nsplit to available stack slots so an aggressive
-                 * importance table (e.g. exp(eta)) degrades gracefully
-                 * instead of aborting.  The result remains unbiased:
-                 * weight is divided by the actual nsplit used.
-                 */
-                int nsplit = (int)ratio;
-                if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
-                int avail = MXSTACK - the_stack->np;
-                if (nsplit > avail) nsplit = avail;
-                if (nsplit > 1) {
-                    EGS_Float new_wt = the_stack->wt[np] / nsplit;
-                    the_stack->wt[np] = new_wt;
-                    EGS_Float x_=the_stack->x[np], y_=the_stack->y[np],
-                              z_=the_stack->z[np], u_=the_stack->u[np],
-                              v_=the_stack->v[np], w_=the_stack->w[np],
-                              E_=the_stack->E[np], dn=the_stack->dnear[np];
-                    int ir_=the_stack->ir[np], latch_=the_stack->latch[np];
-                    for (int k = 1; k < nsplit; ++k) {
-                        int nn = the_stack->np;
-                        the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
-                        the_stack->z[nn]=z_;  the_stack->u[nn]=u_;
-                        the_stack->v[nn]=v_;  the_stack->w[nn]=w_;
-                        the_stack->E[nn]=E_;  the_stack->wt[nn]=new_wt;
-                        the_stack->iq[nn]=0;  the_stack->ir[nn]=ir_;
-                        the_stack->latch[nn]=latch_; the_stack->dnear[nn]=dn;
-                        the_stack->np++;
+                if (ratio > 1.0 + 1e-10) {
+                    /* Forward crossing (deeper): split.
+                     * Cap nsplit to available stack slots so an aggressive
+                     * importance table (e.g. exp(eta)) degrades gracefully
+                     * instead of aborting.  The result remains unbiased:
+                     * weight is divided by the actual nsplit used.
+                     */
+                    int nsplit = (int)ratio;
+                    if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
+                    int avail = MXSTACK - the_stack->np;
+                    if (nsplit > avail) nsplit = avail;
+                    if (nsplit > 1) {
+                        EGS_Float new_wt = the_stack->wt[np] / nsplit;
+                        the_stack->wt[np] = new_wt;
+                        EGS_Float x_=the_stack->x[np], y_=the_stack->y[np],
+                                  z_=the_stack->z[np], u_=the_stack->u[np],
+                                  v_=the_stack->v[np], w_=the_stack->w[np],
+                                  E_=the_stack->E[np], dn=the_stack->dnear[np];
+                        int ir_=the_stack->ir[np], latch_=the_stack->latch[np];
+                        for (int k = 1; k < nsplit; ++k) {
+                            int nn = the_stack->np;
+                            the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
+                            the_stack->z[nn]=z_;  the_stack->u[nn]=u_;
+                            the_stack->v[nn]=v_;  the_stack->w[nn]=w_;
+                            the_stack->E[nn]=E_;  the_stack->wt[nn]=new_wt;
+                            the_stack->iq[nn]=0;  the_stack->ir[nn]=ir_;
+                            the_stack->latch[nn]=latch_; the_stack->dnear[nn]=dn;
+                            the_stack->np++;
+                        }
                     }
                 }
+                else if (ratio < 1.0 - 1e-10) {
+                    /* Backward crossing (outward): Russian roulette */
+                    if (rndm->getUniform() > ratio)
+                        the_epcont->idisc = 1;       // kill
+                    else
+                        the_stack->wt[np] /= ratio;  // survivor: weight × I_old/I_new
+                }
             }
-            else if (ratio < 1.0 - 1e-10) {
-                /* Backward crossing (outward): Russian roulette */
-                if (rndm->getUniform() > ratio)
-                    the_epcont->idisc = 1;       // kill
-                else
-                    the_stack->wt[np] /= ratio;  // survivor: weight × I_old/I_new
-            }
+            /* Track the last region crossed so the next AfterTransport call
+             * computes the ratio relative to the immediately previous region,
+             * not the region where the MFP was originally sampled. */
+            prev_ir_imp = ir;
         }
 
         return 0;

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -339,7 +339,7 @@ public:
                                   z_=the_stack->z[np], u_=the_stack->u[np],
                                   v_=the_stack->v[np], w_=the_stack->w[np],
                                   E_=the_stack->E[np], dn=the_stack->dnear[np];
-                        int ir_=the_stack->ir[np], latch_=the_stack->latch[np];
+                        int ir_=the_stack->ir[np];
                         for (int k = 1; k < nsplit; ++k) {
                             int nn = the_stack->np;
                             the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
@@ -347,7 +347,7 @@ public:
                             the_stack->v[nn]=v_;  the_stack->w[nn]=w_;
                             the_stack->E[nn]=E_;  the_stack->wt[nn]=new_wt;
                             the_stack->iq[nn]=0;  the_stack->ir[nn]=ir_;
-                            the_stack->latch[nn]=latch_; the_stack->dnear[nn]=dn;
+                            the_stack->latch[nn]=latch; the_stack->dnear[nn]=dn;
                             the_stack->np++;
                         }
                     }

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -311,7 +311,8 @@ public:
          * this update, $SELECT-PHOTON-MFP is called only once per MFP (at
          * :PNEWENERGY:), leaving prev_ir_imp stale for crossings 2, 3, ... */
         if (iarg == AfterTransport && !iq && ir >= 0) {
-            if (prev_ir_imp >= 0 && ir != prev_ir_imp
+            int latch = the_stack->latch[np];
+            if (latch && prev_ir_imp >= 0 && ir != prev_ir_imp
                     && ig < (int)region_importance.size()
                     && prev_ir_imp < (int)region_importance[ig].size()
                     && ir          < (int)region_importance[ig].size()) {

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -2309,13 +2309,6 @@ void EGS_KermaApplication::describeSimulation() {
         egsInformation("Calculation geometry: %s\n",
                        geoms[j]->getName().c_str());
         geoms[j]->printInfo();
-        if (fd_geoms[j])
-            egsInformation("---> Scoring using forced detection (FD)\n"
-                           "     for photons aimed at or inside geometry %s\n",
-                           fd_geoms[j]->getName().c_str());
-        else {
-            egsInformation("\n---> Scoring only when photon enters volume\n");
-        }
 
         //"     including those scattered inside the geometry.\n");
         //"     Fluence is equivalent to FLURZ total fluence!\n");

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -2273,6 +2273,27 @@ void EGS_KermaApplication::describeSimulation() {
                    " Variance reduction\n"
                    "===========================================================\n\n");
 
+    bool fd_active = false;
+    for (int j = 0; j < ngeom && !fd_active; j++)
+        if (fd_geoms[j]) fd_active = true;
+
+    if (fd_active) {
+        egsInformation(" Forced detection (FD):        ON\n");
+        for (int j = 0; j < ngeom; j++) {
+            if (fd_geoms[j])
+                egsInformation("   %-30s -> %s\n",
+                               geoms[j]->getName().c_str(),
+                               fd_geoms[j]->getName().c_str());
+            else
+                egsInformation("   %-30s -> (none, track-length only)\n",
+                               geoms[j]->getName().c_str());
+        }
+    }
+    else {
+        egsInformation(" Forced detection (FD):        OFF\n");
+    }
+    egsInformation("\n");
+
     bool imp_active = false;
     for (int j = 0; j < ngeom && !imp_active; j++)
         for (int ir = 0; ir < (int)region_importance[j].size() && !imp_active; ir++)

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -864,41 +864,63 @@ public:
     /*! Output the results of a simulation. */
     void outputResults() {
 
-        egsInformation("\n\n last case = %lld fluence = %g\n\n",
-                       current_case,source->getFluence());
+        EGS_Float F = current_case / getFluence();
 
-        EGS_Float F = current_case/getFluence();
+        /* Compute energy averages in-place before printing. */
+        const bool has_src_ph = Eph_ave  > kermaEpsilon && Nph   > kermaEpsilon;
+        const bool has_src_el = Eel_ave  > kermaEpsilon && Nel   > kermaEpsilon;
+        const bool has_sc     = Eph_sc   > kermaEpsilon && Nsc   > kermaEpsilon;
+        const bool has_sc_p   = Eph_sc_p > kermaEpsilon && Nsc_p > kermaEpsilon;
+        if (has_src_ph) Eph_ave  /= Nph;
+        if (has_src_el) Eel_ave  /= Nel;
+        if (has_sc)     Eph_sc   /= Nsc;
+        if (has_sc_p)   Eph_sc_p /= Nsc_p;
 
-        if (Eph_sc > kermaEpsilon && Nsc > kermaEpsilon) {
-            Eph_sc /= Nsc;
-            // egsInformation(" Mean scoring photon energy <Epsc> = %g MeV  Number of scoring photons = %.10g\n\n",Eph_sc, static_cast<double>(Nsc));
-            egsInformation(" Mean scoring photon energy <Epsc> = %g MeV  Number of scoring photons = %.10g\n\n",Eph_sc, Nsc);
+        egsInformation("===========================================================\n"
+                       " Simulation statistics\n"
+                       "===========================================================\n\n");
+
+        egsInformation(" %-24s %lld\n",
+                       "Histories simulated :", current_case);
+        egsInformation(" %-24s %.6g cm^-2\n\n",
+                       "Source fluence :", source->getFluence());
+
+        if (has_src_ph || has_src_el) {
+            egsInformation(" Source particles\n");
+            if (has_src_ph)
+                egsInformation("   %-22s %8.4f MeV   %.4e particles\n",
+                               "Photons :",   Eph_ave, Nph);
+            if (has_src_el)
+                egsInformation("   %-22s %8.4f MeV   %.4e particles\n",
+                               "Electrons :", Eel_ave, Nel);
+            egsInformation("\n");
         }
-        if (Eph_sc_p > kermaEpsilon && Nsc_p > kermaEpsilon) {
-            Eph_sc_p /= Nsc_p;
-            // egsInformation(" Mean scoring photon energy <Epsc> = %g MeV  Number of scoring photons = %.10g\n\n",Eph_sc, static_cast<double>(Nsc));
-            egsInformation(" Mean scoring primary photon energy <Epsc> = %g MeV  Number of scoring primary photons = %.10g\n\n",Eph_sc_p, Nsc_p);
-        }
 
-        if (Eph_ave > kermaEpsilon && Nph > kermaEpsilon) {
-            Eph_ave /= Nph;
-            egsInformation(" Mean source photon energy <Ep> = %g MeV\n\n",Eph_ave);
-        }
-
-        if (Eel_ave > kermaEpsilon && Nel > kermaEpsilon) {
-            Eel_ave /= Nel;
-            egsInformation(" Mean source electron energy <Ee> = %g MeV\n\n",Eel_ave);
+        if (has_sc || has_sc_p) {
+            egsInformation(" Scoring photons\n");
+            if (has_sc)
+                egsInformation("   %-22s %8.4f MeV   %.4e particles\n",
+                               "All :",       Eph_sc,   Nsc);
+            if (has_sc_p)
+                egsInformation("   %-22s %8.4f MeV   %.4e particles\n",
+                               "Primaries :", Eph_sc_p, Nsc_p);
+            egsInformation("\n");
         }
 
         if (n_split_events > 0) {
-            egsInformation(" IS splitting events: %lld total, %lld capped (%.4g%%)\n",
-                           n_split_events, n_cap_events,
+            egsInformation(" Importance sampling (IS)\n");
+            egsInformation("   %-22s %lld\n",
+                           "Splitting events :", n_split_events);
+            egsInformation("   %-22s %lld   (%.3g%%)\n",
+                           "Capped events :", n_cap_events,
                            100.0 * n_cap_events / n_split_events);
-            if (n_cap_events > 0) {
-                egsInformation(" Stack cap: largest deficit = %d slots"
-                               "  =>  recommend MXSTACK >= %d  (current: %d)\n",
+            if (n_cap_events > 0)
+                egsInformation("   %-22s %d slots  =>  recommend MXSTACK >= %d  (current: %d)\n",
+                               "Max stack deficit :",
                                max_stack_needed - MXSTACK, max_stack_needed, MXSTACK);
-            }
+            else
+                egsInformation("   %-22s none\n",
+                               "Max stack deficit :");
             egsInformation("\n");
         }
 

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -117,7 +117,9 @@ public:
         EGS_AdvancedApplication(argc,argv), ngeom(0),
         kerma(0), kerma_r(0), kerma_p(0), scg(0),
         fd_geom(0), ncg(0), flug(0),flugT(0), verbose(false),
-        score_primaries(false), m_primary(0.0), m_tot(0.0),
+        score_primaries(false),
+        imp_active(false),
+        m_primary(0.0), m_tot(0.0),
         prev_ir_imp(-1),
         n_split_events(0), n_cap_events(0), max_stack_needed(0) {
         Eph_ave = 0.0;
@@ -278,31 +280,21 @@ public:
         }
 
         /********************************************************************
-         * BEWARE: Flagging secondaries by incrementing their latch.
-         *         Other applications might use latch for other purposes!
+         * Flag scattered photons and all interaction products by
+         * incrementing their latch, so that latch=0 always identifies an
+         * unscattered primary.  Required by both IS (latch!=0 guard) and
+         * score_primaries (Kpri/Kscat identification).  Done whenever
+         * either feature is active so the two are fully independent.
          *********************************************************************/
-        // if (score_primaries && !iq) {
-        if (score_primaries) {
-            /***************************************************************
-             FLURZnrc IPRIMARY = 3
-                Flag scattered photons, secondaries, and relaxation
-                particles as secondaries
-            ****************************************************************/
-            if (iarg == EGS_Application::AfterPair    ||
-                iarg == EGS_Application::AfterCompton ||
-                iarg == EGS_Application::AfterPhoto   ||
-                iarg == EGS_Application::AfterRayleigh){
+        if ((score_primaries || imp_active) &&
+            (iarg == EGS_Application::AfterPair    ||
+             iarg == EGS_Application::AfterCompton ||
+             iarg == EGS_Application::AfterPhoto   ||
+             iarg == EGS_Application::AfterRayleigh)) {
 
-                int npold = the_stack->npold-1;
-
-                for (int ip = npold; ip <= np; ip++) {
-                    ++the_stack->latch[ip];
-                }
-
-            }
-        // if (iq && !the_stack->latch[np]){
-        //     egsWarning("-> Primary electron?\n");
-        // }
+            int npold = the_stack->npold-1;
+            for (int ip = npold; ip <= np; ip++)
+                ++the_stack->latch[ip];
         }
 
         /* Geometry importance: splitting and Russian roulette at region crossings.
@@ -1470,6 +1462,7 @@ private:
     /* Geometry importance splitting / Russian roulette */
     vector<vector<EGS_Float>> region_importance; // [ig][ir], default 1.0
     int                       prev_ir_imp;        // region at start of current step
+    bool                      imp_active;         // true when any region importance != 1
 
     /* IS stack-capping diagnostics */
     long long n_split_events;   // total splitting events (nsplit > 1)
@@ -2223,7 +2216,7 @@ int EGS_KermaApplication::initScoring() {
     setAusgabCall(AfterPair, true);
 
     /* Enable AfterTransport only when importance VRT is active */
-    bool imp_active = false;
+    imp_active = false;
     for (int j = 0; j < ngeom && !imp_active; j++)
         for (int ir = 0; ir < (int)region_importance[j].size() && !imp_active; ir++)
             if (fabs(region_importance[j][ir] - 1.0) > 1e-10)

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -117,7 +117,8 @@ public:
         EGS_AdvancedApplication(argc,argv), ngeom(0),
         kerma(0), kerma_r(0), kerma_p(0), scg(0),
         fd_geom(0), ncg(0), flug(0),flugT(0), verbose(false),
-        score_primaries(false), m_primary(0.0), m_tot(0.0) {
+        score_primaries(false), m_primary(0.0), m_tot(0.0),
+        prev_ir_imp(-1) {
         Eph_ave = 0.0;
         Nph = 0.0;
         Eph_sc  = 0.0;
@@ -301,6 +302,52 @@ public:
         // if (iq && !the_stack->latch[np]){
         //     egsWarning("-> Primary electron?\n");
         // }
+        }
+
+        /* Geometry importance: splitting and Russian roulette at region crossings */
+        if (iarg == AfterTransport && !iq && ir >= 0
+                && prev_ir_imp >= 0 && ir != prev_ir_imp
+                && ig < (int)region_importance.size()
+                && prev_ir_imp < (int)region_importance[ig].size()
+                && ir          < (int)region_importance[ig].size()) {
+
+            EGS_Float I_old = region_importance[ig][prev_ir_imp];
+            EGS_Float I_new = region_importance[ig][ir];
+            EGS_Float ratio = I_new / I_old;
+
+            if (ratio > 1.0 + 1e-10) {
+                /* Forward crossing (deeper): split */
+                int nsplit = (int)ratio;
+                if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
+                if (nsplit > 1) {
+                    EGS_Float new_wt = the_stack->wt[np] / nsplit;
+                    the_stack->wt[np] = new_wt;
+                    EGS_Float x_=the_stack->x[np], y_=the_stack->y[np],
+                              z_=the_stack->z[np], u_=the_stack->u[np],
+                              v_=the_stack->v[np], w_=the_stack->w[np],
+                              E_=the_stack->E[np], dn=the_stack->dnear[np];
+                    int ir_=the_stack->ir[np], latch_=the_stack->latch[np];
+                    for (int k = 1; k < nsplit; ++k) {
+                        int nn = the_stack->np;
+                        if (nn >= MXSTACK)
+                            egsFatal("importance splitting: stack overflow\n");
+                        the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
+                        the_stack->z[nn]=z_;  the_stack->u[nn]=u_;
+                        the_stack->v[nn]=v_;  the_stack->w[nn]=w_;
+                        the_stack->E[nn]=E_;  the_stack->wt[nn]=new_wt;
+                        the_stack->iq[nn]=0;  the_stack->ir[nn]=ir_;
+                        the_stack->latch[nn]=latch_; the_stack->dnear[nn]=dn;
+                        the_stack->np++;
+                    }
+                }
+            }
+            else if (ratio < 1.0 - 1e-10) {
+                /* Backward crossing (outward): Russian roulette */
+                if (rndm->getUniform() > ratio)
+                    the_epcont->idisc = 1;       // kill
+                else
+                    the_stack->wt[np] /= ratio;  // survivor: weight × I_old/I_new
+            }
         }
 
         return 0;
@@ -1153,6 +1200,7 @@ public:
         EGS_Vector x(the_stack->x[np],the_stack->y[np],the_stack->z[np]);
         EGS_Vector u(the_stack->u[np],the_stack->v[np],the_stack->w[np]);
         int ireg   = the_stack->ir[np]-2, newmed = geometry->medium(ireg);
+        prev_ir_imp = ireg;  // snapshot for crossing detection in AfterTransport
         EGS_Float tstep = TSTEP_MAX;
         //******************************************************************
         // FD Track-length kerma estimation for photons entering or aimed
@@ -1300,6 +1348,10 @@ private:
     bool      score_primaries,
               verbose;
 
+    /* Geometry importance splitting / Russian roulette */
+    vector<vector<EGS_Float>> region_importance; // [ig][ir], default 1.0
+    int                       prev_ir_imp;        // region at start of current step
+
     static string revision;
 };
 
@@ -1361,6 +1413,7 @@ int EGS_KermaApplication::initScoring() {
         vector<int *>       excluded_regions;
         vector<int>         n_excluded_regions;
         vector<EGS_AffineTransform *> transformations;
+        vector<vector<EGS_Float>>     importance_list;
         EGS_Input *aux;
         EGS_BaseGeometry::setActiveGeometryList(app_index);
         while ((aux = options->takeInputItem("calculation geometry"))) {
@@ -1625,6 +1678,15 @@ int EGS_KermaApplication::initScoring() {
                     }
                     else {
                         geometries.push_back(g);
+                        /* Parse per-region importances (default 1.0) */
+                        vector<EGS_Float> imp_vec(nreg, 1.0);
+                        vector<EGS_Float> imp_input;
+                        if (!aux->getInput("region importances", imp_input)) {
+                            int n = min((int)imp_input.size(), nreg);
+                            for (int i = 0; i < n; i++)
+                                imp_vec[i] = max(imp_input[i], kermaEpsilon);
+                        }
+                        importance_list.push_back(imp_vec);
                         /*Add FD geometry name (can be empty)*/
                         fd_global_gs.push_back(cgname);
                         n_cavity_regions.push_back(ncav);
@@ -1666,6 +1728,7 @@ int EGS_KermaApplication::initScoring() {
             egsWarning("initScoring: no calculation geometries defined\n");
             return 1;
         }
+        region_importance = importance_list;
         geoms        = new EGS_BaseGeometry* [ngeom];
         fd_geoms     = new EGS_BaseGeometry* [ngeom];
         is_sensitive = new bool* [ngeom];

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -2111,26 +2111,8 @@ int EGS_KermaApplication::initScoring() {
             if (fabs(region_importance[j][ir] - 1.0) > 1e-10)
                 imp_active = true;
 
-    if (imp_active) {
+    if (imp_active)
         setAusgabCall(AfterTransport, true);
-        egsInformation("\nGeometry importance sampling: ON\n");
-        for (int j = 0; j < ngeom; j++) {
-            EGS_Float I_min = region_importance[j][0],
-                      I_max = region_importance[j][0];
-            for (int ir = 1; ir < (int)region_importance[j].size(); ir++) {
-                EGS_Float I = region_importance[j][ir];
-                if (I < I_min) I_min = I;
-                if (I > I_max) I_max = I;
-            }
-            egsInformation("  %-30s  %d regions, importances [%.4g, %.4g]\n",
-                           geoms[j]->getName().c_str(),
-                           (int)region_importance[j].size(),
-                           I_min, I_max);
-        }
-    }
-    else {
-        egsInformation("\nGeometry importance sampling: OFF\n");
-    }
 
     return 0;
 }
@@ -2260,6 +2242,37 @@ void EGS_KermaApplication::describeSimulation() {
         }
         egsInformation("\n\n");
     }
+
+    egsInformation("===========================================================\n"
+                   " Variance reduction\n"
+                   "===========================================================\n\n");
+
+    bool imp_active = false;
+    for (int j = 0; j < ngeom && !imp_active; j++)
+        for (int ir = 0; ir < (int)region_importance[j].size() && !imp_active; ir++)
+            if (fabs(region_importance[j][ir] - 1.0) > 1e-10)
+                imp_active = true;
+
+    if (imp_active) {
+        egsInformation(" Geometry importance sampling: ON\n");
+        for (int j = 0; j < ngeom; j++) {
+            EGS_Float I_min = region_importance[j][0],
+                      I_max = region_importance[j][0];
+            for (int ir = 1; ir < (int)region_importance[j].size(); ir++) {
+                EGS_Float I = region_importance[j][ir];
+                if (I < I_min) I_min = I;
+                if (I > I_max) I_max = I;
+            }
+            egsInformation("  %-30s  %d regions, importances [%.4g, %.4g]\n",
+                           geoms[j]->getName().c_str(),
+                           (int)region_importance[j].size(),
+                           I_min, I_max);
+        }
+    }
+    else {
+        egsInformation(" Geometry importance sampling: OFF\n");
+    }
+    egsInformation("\n");
 }
 
 #ifdef BUILD_APP_LIB

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -2058,6 +2058,34 @@ int EGS_KermaApplication::initScoring() {
     setAusgabCall(AfterCompton, true);
     setAusgabCall(AfterPair, true);
 
+    /* Enable AfterTransport only when importance VRT is active */
+    bool imp_active = false;
+    for (int j = 0; j < ngeom && !imp_active; j++)
+        for (int ir = 0; ir < (int)region_importance[j].size() && !imp_active; ir++)
+            if (fabs(region_importance[j][ir] - 1.0) > 1e-10)
+                imp_active = true;
+
+    if (imp_active) {
+        setAusgabCall(AfterTransport, true);
+        egsInformation("\nGeometry importance sampling: ON\n");
+        for (int j = 0; j < ngeom; j++) {
+            EGS_Float I_min = region_importance[j][0],
+                      I_max = region_importance[j][0];
+            for (int ir = 1; ir < (int)region_importance[j].size(); ir++) {
+                EGS_Float I = region_importance[j][ir];
+                if (I < I_min) I_min = I;
+                if (I > I_max) I_max = I;
+            }
+            egsInformation("  %-30s  %d regions, importances [%.4g, %.4g]\n",
+                           geoms[j]->getName().c_str(),
+                           (int)region_importance[j].size(),
+                           I_min, I_max);
+        }
+    }
+    else {
+        egsInformation("\nGeometry importance sampling: OFF\n");
+    }
+
     return 0;
 }
 

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -1678,10 +1678,40 @@ int EGS_KermaApplication::initScoring() {
                     }
                     else {
                         geometries.push_back(g);
-                        /* Parse per-region importances (default 1.0) */
+                        /* Parse per-region importances (default 1.0).
+                         *
+                         * Two input styles (mutually exclusive; ranges take priority):
+                         *
+                         *   importance region ranges = ir_start ir_end I  [ir_start ir_end I ...]
+                         *     Triplets applied in order; later triplets override earlier ones
+                         *     for overlapping ranges.  ir_start and ir_end are inclusive.
+                         *
+                         *   region importances = I_0 I_1 ... I_{nreg-1}
+                         *     Flat per-region list (legacy; truncated or padded with 1.0).
+                         */
                         vector<EGS_Float> imp_vec(nreg, 1.0);
                         vector<EGS_Float> imp_input;
-                        if (!aux->getInput("region importances", imp_input)) {
+                        if (!aux->getInput("importance region ranges", imp_input)) {
+                            if (imp_input.size() % 3 != 0) {
+                                egsFatal("initScoring: 'importance region ranges' must "
+                                         "contain triplets (ir_start ir_end I_value); "
+                                         "got %d values\n", (int)imp_input.size());
+                            }
+                            for (int t = 0; t < (int)imp_input.size(); t += 3) {
+                                int   ir_s = (int)imp_input[t];
+                                int   ir_e = (int)imp_input[t+1];
+                                EGS_Float Ival = imp_input[t+2];
+                                if (ir_s < 0 || ir_e >= nreg || ir_s > ir_e) {
+                                    egsFatal("initScoring: 'importance region ranges' "
+                                             "triplet %d has invalid range [%d,%d] "
+                                             "(geometry has %d regions)\n",
+                                             t/3+1, ir_s, ir_e, nreg);
+                                }
+                                for (int ir = ir_s; ir <= ir_e; ir++)
+                                    imp_vec[ir] = max(Ival, kermaEpsilon);
+                            }
+                        }
+                        else if (!aux->getInput("region importances", imp_input)) {
                             int n = min((int)imp_input.size(), nreg);
                             for (int i = 0; i < n; i++)
                                 imp_vec[i] = max(imp_input[i], kermaEpsilon);

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -323,16 +323,20 @@ public:
 
                 if (ratio > 1.0 + 1e-10) {
                     /* Forward crossing (deeper): split.
-                     * Cap nsplit to available stack slots so an aggressive
-                     * importance table (e.g. exp(eta)) degrades gracefully
-                     * instead of aborting.  The result remains unbiased:
-                     * weight is divided by the actual nsplit used.
-                     */
+                     * nsplit is the intended split factor (from the importance
+                     * ratio); it sets the weight of every particle.  n_actual
+                     * is capped to the available stack space so the simulation
+                     * never aborts.  Crucially, the weight is always divided
+                     * by nsplit (not n_actual): particles that don't fit are
+                     * simply dropped, introducing a small downward bias only
+                     * when the stack is genuinely full, rather than the large
+                     * upward variance spikes that arise from over-weighted
+                     * particles when the weight divisor is capped instead. */
                     int nsplit = (int)ratio;
                     if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
-                    int avail = MXSTACK - the_stack->np;
-                    if (nsplit > avail) nsplit = avail;
-                    if (nsplit > 1) {
+                    int avail   = MXSTACK - the_stack->np;
+                    int n_actual = (nsplit > avail) ? avail : nsplit;
+                    if (n_actual > 1) {
                         EGS_Float new_wt = the_stack->wt[np] / nsplit;
                         the_stack->wt[np] = new_wt;
                         /* Mark the original particle too: EGSnrc's LIFO stack
@@ -346,7 +350,7 @@ public:
                                   v_=the_stack->v[np], w_=the_stack->w[np],
                                   E_=the_stack->E[np], dn=the_stack->dnear[np];
                         int ir_=the_stack->ir[np];
-                        for (int k = 1; k < nsplit; ++k) {
+                        for (int k = 1; k < n_actual; ++k) {
                             int nn = the_stack->np;
                             the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
                             the_stack->z[nn]=z_;  the_stack->u[nn]=u_;

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -347,7 +347,7 @@ public:
                             the_stack->v[nn]=v_;  the_stack->w[nn]=w_;
                             the_stack->E[nn]=E_;  the_stack->wt[nn]=new_wt;
                             the_stack->iq[nn]=0;  the_stack->ir[nn]=ir_;
-                            the_stack->latch[nn]=latch; the_stack->dnear[nn]=dn;
+                            the_stack->latch[nn]=latch|IS_COPY_FLAG; the_stack->dnear[nn]=dn;
                             the_stack->np++;
                         }
                     }
@@ -1217,6 +1217,16 @@ public:
         EGS_Vector u(the_stack->u[np],the_stack->v[np],the_stack->w[np]);
         int ireg   = the_stack->ir[np]-2, newmed = geometry->medium(ireg);
         prev_ir_imp = ireg;  // snapshot for crossing detection in AfterTransport
+
+        /* IS split copies carry IS_COPY_FLAG in latch to suppress the FD score
+         * on their first MFP restart.  The original photon already scored from
+         * its MFP start; letting the copy score again from the split point
+         * would double-count the FD contribution from there onward.  Clear the
+         * flag here so all subsequent MFPs (after physical interactions) score
+         * normally. */
+        bool is_copy = the_stack->latch[np] & IS_COPY_FLAG;
+        if (is_copy) the_stack->latch[np] &= ~IS_COPY_FLAG;
+
         EGS_Float tstep = TSTEP_MAX;
         //******************************************************************
         // FD Track-length kerma estimation for photons entering or aimed
@@ -1225,7 +1235,7 @@ public:
         // killed, and hence not included. Photons inside this geometry or
         // any scoring region are also ray-traced.
         //******************************************************************
-        if (fd_geom &&  // TAKES ALL PHOTONS !!!
+        if (!is_copy && fd_geom &&  // TAKES ALL PHOTONS !!!
                 (is_sensitive[ig][ireg] ||
                  fd_geom->howfar(-1,x,u,tstep,&newmed)>= 0 ||
                  fd_geom->isInside(x))) {
@@ -1367,6 +1377,14 @@ private:
     /* Geometry importance splitting / Russian roulette */
     vector<vector<EGS_Float>> region_importance; // [ig][ir], default 1.0
     int                       prev_ir_imp;        // region at start of current step
+
+    /* Bit flag set on IS split copies to suppress scoreInCV() on their first
+     * MFP restart.  The original photon already scored scoreInCV() from its
+     * MFP start; the copy's restart call would double-count the FD contribution
+     * from the split point onward.  The flag is cleared immediately in
+     * selectPhotonMFP() so all subsequent MFPs (after physical interactions)
+     * score normally.  Bit 30 is used to stay clear of physics latch bits. */
+    static const int IS_COPY_FLAG = 1 << 30;
 
     static string revision;
 };

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -334,16 +334,24 @@ public:
                      * particles when the weight divisor is capped instead. */
                     int nsplit = (int)ratio;
                     if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
-                    int avail   = MXSTACK - the_stack->np;
+                    int avail    = MXSTACK - the_stack->np;
                     int n_actual = (nsplit > avail) ? avail : nsplit;
+                    /* Weight is always divided by nsplit — unconditionally.
+                     * Every surviving particle, including the original when
+                     * the stack is too full for any copies, must carry the
+                     * correct IS-assigned weight w/nsplit.  Copies that do
+                     * not fit are simply dropped (downward bias only when
+                     * the stack is genuinely saturated). */
+                    EGS_Float new_wt = the_stack->wt[np] / nsplit;
+                    the_stack->wt[np] = new_wt;
                     if (n_actual > 1) {
-                        EGS_Float new_wt = the_stack->wt[np] / nsplit;
-                        the_stack->wt[np] = new_wt;
-                        /* Mark the original particle too: EGSnrc's LIFO stack
-                         * will re-enter :PNEWENERGY: for this particle after all
-                         * copies are processed, which would call scoreInCV() again
-                         * from the split boundary — double-counting the FD
-                         * contribution already scored from the MFP start. */
+                        /* IS_COPY_FLAG is only needed when copies exist:
+                         * it prevents the original from calling scoreInCV()
+                         * again when EGSnrc's LIFO stack re-enters
+                         * :PNEWENERGY: after the copies are processed.
+                         * With no copies there is no re-entry, so the flag
+                         * must not be set (it would suppress the next
+                         * legitimate scoreInCV call). */
                         the_stack->latch[np] |= IS_COPY_FLAG;
                         EGS_Float x_=the_stack->x[np], y_=the_stack->y[np],
                                   z_=the_stack->z[np], u_=the_stack->u[np],

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -118,7 +118,8 @@ public:
         kerma(0), kerma_r(0), kerma_p(0), scg(0),
         fd_geom(0), ncg(0), flug(0),flugT(0), verbose(false),
         score_primaries(false), m_primary(0.0), m_tot(0.0),
-        prev_ir_imp(-1) {
+        prev_ir_imp(-1),
+        n_split_events(0), n_cap_events(0), max_stack_needed(0) {
         Eph_ave = 0.0;
         Nph = 0.0;
         Eph_sc  = 0.0;
@@ -336,6 +337,12 @@ public:
                     if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
                     int avail    = MXSTACK - the_stack->np;
                     int n_actual = (nsplit > avail) ? avail : nsplit;
+                    ++n_split_events;
+                    if (n_actual < nsplit) {
+                        ++n_cap_events;
+                        int needed = the_stack->np + nsplit;
+                        if (needed > max_stack_needed) max_stack_needed = needed;
+                    }
                     /* Weight is always divided by nsplit — unconditionally.
                      * Every surviving particle, including the original when
                      * the stack is too full for any copies, must carry the
@@ -682,7 +689,9 @@ public:
         (*data_out) << Eph_ave << " " << Nph << " "
                     << Eel_ave << " " << Nel << " "
                     << Eph_sc  << " " << Nsc << " "
-                    << Eph_sc_p  << " " << Nsc_p << endl;
+                    << Eph_sc_p  << " " << Nsc_p << " "
+                    << n_split_events << " " << n_cap_events << " "
+                    << max_stack_needed << endl;
         if (!data_out->good()) {
             return 1031;
         }
@@ -729,7 +738,8 @@ public:
             }
         }
 
-        (*data_in) >> Eph_ave >> Nph >> Eel_ave >> Nel >> Eph_sc >> Nsc >> Eph_sc_p >> Nsc_p;
+        (*data_in) >> Eph_ave >> Nph >> Eel_ave >> Nel >> Eph_sc >> Nsc >> Eph_sc_p >> Nsc_p
+                   >> n_split_events >> n_cap_events >> max_stack_needed;
         if (!data_in->good()) {
             return 1031;
         }
@@ -769,6 +779,9 @@ public:
         Nph = 0;
         Eel_ave = 0;
         Nel = 0;
+        n_split_events  = 0;
+        n_cap_events    = 0;
+        max_stack_needed = 0;
 
     };
 
@@ -825,7 +838,10 @@ public:
         }
 
         EGS_Float aux_Eph_ave, aux_Nph, aux_Eel_ave, aux_Nel, aux_Eph_sc, aux_Nsc, aux_Eph_sc_p, aux_Nsc_p;
-        data >> aux_Eph_ave >> aux_Nph >> aux_Eel_ave >> aux_Nel >> aux_Eph_sc >> aux_Nsc >> aux_Eph_sc_p >> aux_Nsc_p;
+        long long aux_n_split, aux_n_cap;
+        int aux_max_needed;
+        data >> aux_Eph_ave >> aux_Nph >> aux_Eel_ave >> aux_Nel >> aux_Eph_sc >> aux_Nsc >> aux_Eph_sc_p >> aux_Nsc_p
+             >> aux_n_split >> aux_n_cap >> aux_max_needed;
         if (!data.good()) {
             return 1036;
         }
@@ -838,6 +854,9 @@ public:
         Nph     += aux_Nph;
         Eel_ave += aux_Eel_ave;
         Nel     += aux_Nel;
+        n_split_events  += aux_n_split;
+        n_cap_events    += aux_n_cap;
+        if (aux_max_needed > max_stack_needed) max_stack_needed = aux_max_needed;
 
         return 0;
     };
@@ -869,6 +888,18 @@ public:
         if (Eel_ave > kermaEpsilon && Nel > kermaEpsilon) {
             Eel_ave /= Nel;
             egsInformation(" Mean source electron energy <Ee> = %g MeV\n\n",Eel_ave);
+        }
+
+        if (n_split_events > 0) {
+            egsInformation(" IS splitting events: %lld total, %lld capped (%.4g%%)\n",
+                           n_split_events, n_cap_events,
+                           100.0 * n_cap_events / n_split_events);
+            if (n_cap_events > 0) {
+                egsInformation(" Stack cap: largest deficit = %d slots"
+                               "  =>  recommend MXSTACK >= %d  (current: %d)\n",
+                               max_stack_needed - MXSTACK, max_stack_needed, MXSTACK);
+            }
+            egsInformation("\n");
         }
 
         outputKermaResults(F);
@@ -1395,6 +1426,11 @@ private:
     /* Geometry importance splitting / Russian roulette */
     vector<vector<EGS_Float>> region_importance; // [ig][ir], default 1.0
     int                       prev_ir_imp;        // region at start of current step
+
+    /* IS stack-capping diagnostics */
+    long long n_split_events;   // total splitting events (nsplit > 1)
+    long long n_cap_events;     // events where n_actual < nsplit (stack too full)
+    int       max_stack_needed; // max(np + nsplit) over all capping events
 
     /* Flag set on both the original and all IS copies when a split occurs.
      * EGSnrc's LIFO stack re-enters :PNEWENERGY: for the original particle

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -316,9 +316,16 @@ public:
             EGS_Float ratio = I_new / I_old;
 
             if (ratio > 1.0 + 1e-10) {
-                /* Forward crossing (deeper): split */
+                /* Forward crossing (deeper): split.
+                 * Cap nsplit to available stack slots so an aggressive
+                 * importance table (e.g. exp(eta)) degrades gracefully
+                 * instead of aborting.  The result remains unbiased:
+                 * weight is divided by the actual nsplit used.
+                 */
                 int nsplit = (int)ratio;
                 if (rndm->getUniform() < (ratio - nsplit)) ++nsplit;
+                int avail = MXSTACK - the_stack->np;
+                if (nsplit > avail) nsplit = avail;
                 if (nsplit > 1) {
                     EGS_Float new_wt = the_stack->wt[np] / nsplit;
                     the_stack->wt[np] = new_wt;
@@ -329,8 +336,6 @@ public:
                     int ir_=the_stack->ir[np], latch_=the_stack->latch[np];
                     for (int k = 1; k < nsplit; ++k) {
                         int nn = the_stack->np;
-                        if (nn >= MXSTACK)
-                            egsFatal("importance splitting: stack overflow\n");
                         the_stack->x[nn]=x_;  the_stack->y[nn]=y_;
                         the_stack->z[nn]=z_;  the_stack->u[nn]=u_;
                         the_stack->v[nn]=v_;  the_stack->w[nn]=w_;

--- a/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
+++ b/HEN_HOUSE/user_codes/egs_kerma/egs_kerma.cpp
@@ -585,7 +585,7 @@ public:
                 for (int i = 0; i < n_ir_sc; i++) {
                     //edepCV     = emuen_rho*rho_cv[ig];
                     exp_CV     = exp(-mu_cv*t_sc[i]);
-                    exp_Att    = sigma ? exp_Lambda*(1-exp_CV)/mu_cv : 1.0 ;//Attenuation in scoring region
+                    exp_Att    = sigma ? exp_Lambda*(1-exp_CV)/mu_cv : exp_Lambda*t_sc[i];
                     edepCV     = emuen*exp_Att;
                     weightedEdepCV = wt*edepCV;
                     weightedExpAtt = wt*exp_Att;
@@ -633,7 +633,7 @@ public:
                 //--------------------------------------------
                 //edepCV     = emuen_rho*rho_cv[ig];// Data base contains E_muen/rho values
                 exp_CV     = exp(-mu_cv*t_sc_tot);
-                exp_Att    = sigma ? exp_Lambda_to_CV*(1-exp_CV)/mu_cv : 1.0;
+                exp_Att    = sigma ? exp_Lambda_to_CV*(1-exp_CV)/mu_cv : exp_Lambda_to_CV*t_sc_tot;
                 edepCV     = emuen*exp_Att;
                 kerma->score(ig,wt*edepCV);
                 // Ray-tracing continues


### PR DESCRIPTION
 > **Depends on:** #1434 

  ## Summary

  - Adds geometry-based importance sampling (IS) to `egs_kerma`: forward boundary
    crossings stochastically split photons (⟨N⟩ = I_new/I_old); backward
    crossings apply Russian roulette (p = I_new/I_old).
  - Four correctness fixes committed on top of the initial IS implementation:
    primary photon exclusion (latch==0 → skip IS), `prev_ir_imp` updated
    unconditionally at AfterTransport, IS_COPY_FLAG (bit 30 of latch) on both
    original and copies to suppress FD re-scoring at split boundaries, and
    nsplit/n_actual separation (weight always divided by nsplit; when n_actual=0,
    RR with survival probability 1/nsplit).
  - Tracks IS stack-capping frequency and recommends minimum stack size.
  - Fixes FD vacuum-region scoring: path length through vacuum shells was missing
    from the optical-depth integral, producing ~1.5% bias at shallow depths.
  - Adds BUF iron-sphere input files for IS+FD buildup-factor calculations.

  ## Test plan
  - [x] Build egs_kerma and run `BUF_Fe_1MeV_xoshiro256pp_IS-exp.egsinp`; verify
        converged BUF values are similar to published ANSI/ANS iron-sphere data at shallow depths.
  - [x] Run without IS (comment out importance regions input); confirm same result
        as primary-kerma branch at shallow depths.
  - [x] Run `BUF_Fe_1MeV_xoshiro256pp_IS-x2per5mfp.egsinp`; confirm it fails to
        converge beyond ~25 mfp (known limitation of constant-factor schemes).