### PR TITLE
Improve egs_editor performance, fix egs_editor library names

### DIFF
--- a/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_dose_scoring/egs_dose_scoring.cpp
@@ -820,7 +820,7 @@ extern "C" {
 
         setBaseAusgabObjectInputs();
 
-        ausBlockInput->getSingleInput("library")->setValues({"EGS_Dose_Scoring"});
+        ausBlockInput->getSingleInput("library")->setValues({"egs_dose_scoring"});
 
         // Format: name, isRequired, description, vector string of allowed values
         ausBlockInput->addSingleInput("medium dose", false, "Requests the dose deposited in each medium to be scored, default is no", {"yes", "no"});

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_fluence_scoring/egs_fluence_scoring.cpp
@@ -1833,7 +1833,7 @@ extern "C" {
 
         setBaseAusgabObjectInputs();
 
-        ausBlockInput->getSingleInput("library")->setValues({"EGS_Fluence_Scoring"});
+        ausBlockInput->getSingleInput("library")->setValues({"egs_fluence_scoring"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = ausBlockInput->addSingleInput("type", true, "Whether to score volumetric or planar fluence", {"planar", "volumetric"});

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_phsp_scoring/egs_phsp_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_phsp_scoring/egs_phsp_scoring.cpp
@@ -528,7 +528,7 @@ extern "C" {
 
         setBaseAusgabObjectInputs();
 
-        ausBlockInput->getSingleInput("library")->setValues({"EGS_Phsp_Scoring"});
+        ausBlockInput->getSingleInput("library")->setValues({"egs_phsp_scoring"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto formatPtr = ausBlockInput->addSingleInput("output format", false, "The phase-space format to output. Defaults to EGSnrc", {"EGSnrc", "IAEA"});

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_radiative_splitting/egs_radiative_splitting.cpp
@@ -118,7 +118,7 @@ extern "C" {
 
         setBaseAusgabObjectInputs();
 
-        ausBlockInput->getSingleInput("library")->setValues({"EGS_Radiative_Splitting"});
+        ausBlockInput->getSingleInput("library")->setValues({"egs_radiative_splitting"});
 
         // Format: name, isRequired, description, vector string of allowed values
         ausBlockInput->addSingleInput("splitting", false, "The number of times to split every radiative event");

--- a/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
+++ b/HEN_HOUSE/egs++/ausgab_objects/egs_track_scoring/egs_track_scoring.cpp
@@ -129,7 +129,7 @@ extern "C" {
 
         setBaseAusgabObjectInputs();
 
-        ausBlockInput->getSingleInput("library")->setValues({"EGS_Track_Scoring"});
+        ausBlockInput->getSingleInput("library")->setValues({"egs_track_scoring"});
 
         // Format: name, isRequired, description, vector string of allowed values
         ausBlockInput->addSingleInput("score photons", false, "Score photons? Default is yes.", {"yes", "no"});

--- a/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_autoenvelope/egs_autoenvelope.cpp
@@ -997,7 +997,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_AutoEnvelope"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_autoenvelope"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("type", false, "The type of auto envelope. A switched envelope only provides extra functionality in applications that specifically utilize it.", {"EGS_AEnvelope", "EGS_ASwitchedEnvelope"});

--- a/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_box/egs_box.cpp
@@ -46,7 +46,7 @@ void EGS_Box::printInfo() const {
     egsInformation("=======================================================\n");
 }
 
-static string EGS_BOX_LOCAL typeStr("EGS_Box");
+static string EGS_BOX_LOCAL typeStr("egs_box");
 string EGS_Box::type(typeStr);
 
 static char EGS_BOX_LOCAL ebox_message1[] = "createGeometry(box): %s\n";

--- a/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cd_geometry/egs_cd_geometry.cpp
@@ -48,7 +48,7 @@
     #define S_STREAM std::istringstream
 #endif
 
-static string EGS_CDGEOMETRY_LOCAL typeStr("EGS_CDGeometry");
+static string EGS_CDGEOMETRY_LOCAL typeStr("egs_cdgeometry");
 string EGS_CDGeometry::type(typeStr);
 
 static bool EGS_CDGEOMETRY_LOCAL inputSet = false;

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -255,7 +255,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Cones"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_cones"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of cone.", {"EGS_ConeStack", "EGS_SimpleCone", "EGS_ParallelCones", "EGS_ConeSet"});

--- a/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cones/egs_cones.cpp
@@ -307,7 +307,7 @@ extern "C" {
         apexPtr->addDependency(typePtr, "EGS_ParallelCones");
     }
 
-    EGS_CONES_EXPORT string getExample(string type) {
+    EGS_CONES_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_conez/egs_conez.cpp
@@ -49,7 +49,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Conez"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_conez"});
 
         // Format: name, description, isRequired, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true,"The type of cone", {"EGS_Xconez", "EGS_Yconez", "EGS_Zcones", "EGS_conez"});

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -62,7 +62,7 @@ extern "C" {
         inpPtr->addDependency(typePtr, "EGS_Cylinders");
     }
 
-    EGS_CYLINDERS_EXPORT string getExample(string type) {
+    EGS_CYLINDERS_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_cylinders/egs_cylinders.cpp
@@ -49,7 +49,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Cylinders"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_cylinders"});
 
         // Format: name, isRequired, description, vector string of allowd values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of cylinder.", {"EGS_XCylinders", "EGS_YCylinders", "EGS_ZCylinders", "EGS_Cylinders"});

--- a/HEN_HOUSE/egs++/geometry/egs_dynamic_geometry/egs_dynamic_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_dynamic_geometry/egs_dynamic_geometry.cpp
@@ -79,7 +79,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Dynamic_Geometry"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_dynamic_geometry"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("base geometry", true, "The name of a previously defined geometry");

--- a/HEN_HOUSE/egs++/geometry/egs_dynamic_geometry/egs_dynamic_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_dynamic_geometry/egs_dynamic_geometry.cpp
@@ -87,7 +87,7 @@ extern "C" {
         motionBlock->addSingleInput("control point", true, "Parameters to define motion: timeIndex xtrans ytrans ztrans xrot yrot zrot");
     }
 
-    EGS_DYNAMIC_GEOMETRY_EXPORT string getExample(string type) {
+    EGS_DYNAMIC_GEOMETRY_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_elliptic_cylinders/egs_elliptic_cylinders.cpp
@@ -54,7 +54,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_EllipticCylinders"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_elliptic_cylinders"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of elliptic cylinder", {"EGS_EllipticCylindersXY", "EGS_EllipticCylindersXZ", "EGS_EllipticCylindersYZ", "EGS_EllipticCylinders"});

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -375,7 +375,7 @@ extern "C" {
         geomBlockInput->addSingleInput("inscribed geometries", true, "A list of names of previously defined geometries, must be stictly inside the envelope");
     }
 
-    EGS_ENVELOPEG_EXPORT string getExample(string type) {
+    EGS_ENVELOPEG_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_genvelope/egs_envelope_geometry.cpp
@@ -367,7 +367,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_GEnvelope"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_genvelope"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", false, "The type of envelope", {"EGS_FastEnvelope"});

--- a/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
@@ -66,7 +66,7 @@ extern "C" {
         geomBlockInput->addSingleInput("include file", true, "The path to some geometry.");
     }
 
-    EGS_GLIB_EXPORT string getExample(string type) {
+    EGS_GLIB_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_glib/egs_glib.cpp
@@ -60,7 +60,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Glib"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_glib"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("include file", true, "The path to some geometry.");

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -138,7 +138,7 @@ extern "C" {
         geomBlockInput->addSingleInput("tolerance", false, "A small floating number boundaryTolerance");
     }
 
-    EGS_STACKG_EXPORT string getExample(string type) {
+    EGS_STACKG_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gstack/egs_stack_geometry.cpp
@@ -131,7 +131,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_GStack"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_gstack"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("geometries", true, "A list of names of previously defined geometries");

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -77,7 +77,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_GTransformed"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_gtransformed"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("my geometry", true, "The name of a previously defined geometry");

--- a/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_gtransformed/egs_gtransformed.cpp
@@ -85,7 +85,7 @@ extern "C" {
         addTransformationBlock(geomBlockInput);
     }
 
-    EGS_GTRANSFORMED_EXPORT string getExample(string type) {
+    EGS_GTRANSFORMED_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
@@ -299,7 +299,7 @@ extern "C" {
         firstanglePtr->addDependency(firstangleRadPtr, "", true);
     }
 
-    EGS_IPLANES_EXPORT string getExample(string type) {
+    EGS_IPLANES_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_iplanes/egs_iplanes.cpp
@@ -266,7 +266,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_IPlanes"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_iplanes"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", false, "The type of iplane", {"EGS_RadialRepeater"});

--- a/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
@@ -178,6 +178,7 @@ extern "C" {
         geomBlockInput->addSingleInput("subgeometry", true, "The name of a geometry to place at each lattice position.");
         geomBlockInput->addSingleInput("subgeometry index", true, "The region or list of regions that contain the lattice.");
         geomBlockInput->addSingleInput("spacing", true, "The spacing as defined for Bravais (x, y, z), Cubic (x), or Hexagonal modes (s, close-packed distance). ");
+        geomBlockInput->addSingleInput("type", false, "The type of lattice. Currently just used for hexagonal lattices.", {"hexagonal"});
     }
 
     EGS_LATTICE_EXPORT string getExample(string type) {

--- a/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
@@ -181,7 +181,7 @@ extern "C" {
         geomBlockInput->addSingleInput("type", false, "The type of lattice. Currently just used for hexagonal lattices.", {"hexagonal"});
     }
 
-    EGS_LATTICE_EXPORT string getExample(string type) {
+    EGS_LATTICE_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_lattice/egs_lattice.cpp
@@ -47,6 +47,8 @@
 
 using namespace std;
 
+static bool EGS_LATTICE_LOCAL inputSet = false;
+
 void EGS_Lattice::setMedia(EGS_Input *,int,const int *) {
     egsWarning("EGS_Lattice::setMedia: don't use this method. Use the\n"
                " setMedia() methods of the geometry objects that make up this geometry\n");
@@ -163,6 +165,44 @@ void EGS_Hexagonal_Lattice::printInfo() const {
     egsInformation("=======================================================\n");
 }
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"egs_lattice"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("base geometry", true, "The name of a previously defined geometry, into which the lattice will be enveloped.");
+        geomBlockInput->addSingleInput("subgeometry", true, "The name of a geometry to place at each lattice position.");
+        geomBlockInput->addSingleInput("subgeometry index", true, "The region or list of regions that contain the lattice.");
+        geomBlockInput->addSingleInput("spacing", true, "The spacing as defined for Bravais (x, y, z), Cubic (x), or Hexagonal modes (s, close-packed distance). ");
+    }
+
+    EGS_LATTICE_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Example Bravais lattice with spacings 1, 2 and 3
+    #:start geometry:
+        library           = egs_lattice
+        name              = phantom_w_microcavity
+        base geometry     = phantom
+        subgeometry       = microcavity
+        subgeometry index = 0
+        spacing           = 1 2 3
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_LATTICE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_LATTICE_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         int err = 0;

--- a/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
@@ -78,6 +78,8 @@ EGS_Mesh::~EGS_Mesh() = default;
 EGS_Mesh::EGS_Mesh(EGS_Mesh &&) = default;
 EGS_Mesh &EGS_Mesh::operator=(EGS_Mesh &&) = default;
 
+static bool EGS_MESH_LOCAL inputSet = false;
+
 void EGS_MeshSpec::checkValid() const {
     std::size_t n_max = std::numeric_limits<int>::max();
     if (this->elements.size() >= n_max) {
@@ -1566,6 +1568,42 @@ static EGS_MeshSpec parse_mesh_file(const std::string &mesh_file) {
 }
 
 extern "C" {
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"egs_mesh"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("file", true, "The full filepath to the .msh, .node or .ele file, including the extension.");
+    }
+
+    EGS_MESH_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # Use Gmsh to convert CAD formats to .msh
+    # Define materials by naming "physical volumes" with the medium name
+    #:start geometry:
+        name        = my_mesh
+        library     = egs_mesh
+        # Using the msh4.1 format:
+        file        = model.msh
+        # or, using the TetGen format:
+        # file       = model.node # or model.ele
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_MESH_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
+
     EGS_MESH_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {
             egsWarning("createGeometry(EGS_Mesh): null input\n");

--- a/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
@@ -1580,7 +1580,7 @@ extern "C" {
         geomBlockInput->addSingleInput("scale", false, "Apply a multiplicative scaling factor to positions. E.g. if your model is in mm, scale to cm using scale=0.1.");
     }
 
-    EGS_MESH_EXPORT string getExample(string type) {
+    EGS_MESH_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_mesh/egs_mesh.cpp
@@ -1577,6 +1577,7 @@ extern "C" {
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("file", true, "The full filepath to the .msh, .node or .ele file, including the extension.");
+        geomBlockInput->addSingleInput("scale", false, "Apply a multiplicative scaling factor to positions. E.g. if your model is in mm, scale to cm using scale=0.1.");
     }
 
     EGS_MESH_EXPORT string getExample(string type) {
@@ -1592,6 +1593,7 @@ extern "C" {
         file        = model.msh
         # or, using the TetGen format:
         # file       = model.node # or model.ele
+        scale = 0.1 # scale from mm to cm
     :stop geometry:
 )"};
         return example;

--- a/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_nd_geometry/egs_nd_geometry.cpp
@@ -1267,7 +1267,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_NDGeometry"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_ndgeometry"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", false, "Alternative types of nd_geometry. Neglect this input to use a standard egs_nd_geometry.", {"EGS_XYZGeometry", "EGS_XYZRepeater"});

--- a/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_octree/egs_octree.cpp
@@ -223,7 +223,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Octree"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_octree"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("child geometry", true, "The name of child geometry");

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -126,7 +126,7 @@ extern "C" {
         posPtr->addDependency(numPtr, "", true);
     }
 
-    EGS_PLANES_EXPORT string getExample(string type) {
+    EGS_PLANES_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_planes/egs_planes.cpp
@@ -97,7 +97,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Planes"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_planes"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of plane.", {"EGS_XPlanes", "EGS_YPlanes", "EGS_ZPlanes", "EGS_Planes", "EGS_PlaneCollection"});

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -57,7 +57,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Prism"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_prism"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of prism", {"EGS_PrismX", "EGS_PrismY", "EGS_PrismZ", "EGS_Prism"});

--- a/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_prism/egs_prism.cpp
@@ -66,7 +66,7 @@ extern "C" {
         geomBlockInput->addSingleInput("points", true, "A list of 2D or 3D (for type=EGS_Prism) positions. For 3D points, they must reside on a plane. These create a polygon that define the base of the prism.");
     }
 
-    EGS_PRISM_EXPORT string getExample(string type) {
+    EGS_PRISM_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -104,7 +104,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Pyramid"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_pyramid"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of pyramid", {"EGS_PyramidX", "EGS_PyramidY", "EGS_PyramidZ", "EGS_Pyramid"});

--- a/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_pyramid/egs_pyramid.cpp
@@ -114,7 +114,7 @@ extern "C" {
         geomBlockInput->addSingleInput("closed", false, "0 (open) or 1 (closed). When missing or set to 0, the pyramid is open, otherwise it is closed by the plane in which the pyramid base is defined.", {"0", "1"});
     }
 
-    EGS_PYRAMID_EXPORT string getExample(string type) {
+    EGS_PYRAMID_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
@@ -49,7 +49,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_RoundRect_Cylinders"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_roundrect_cylinders"});
 
         // Format: name, isRequired, description, vector string of allowed inputs
         auto typePtr = geomBlockInput->addSingleInput("type", true, "The type of rounded rectangle cylinder", {"EGS_RoundRectCylinders", "EGS_RoundRectCylindersXY", "EGS_RoundRectCylindersYZ", "EGS_RoundRectCylindersXZ"});

--- a/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_roundrect_cylinders/egs_roundrect_cylinders.cpp
@@ -66,7 +66,7 @@ extern "C" {
         yinpPtr->addDependency(typePtr, "EGS_RoundRectCylinders");
     }
 
-    EGS_ROUNDRECT_CYLINDERS_EXPORT string getExample(string type) {
+    EGS_ROUNDRECT_CYLINDERS_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
@@ -269,7 +269,7 @@ extern "C" {
         slabPtr->addDependency(planePtr, "", true);
     }
 
-    EGS_RZ_EXPORT string getExample(string type) {
+    EGS_RZ_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_rz/egs_rz.cpp
@@ -233,7 +233,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_RZ"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_rz"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto  radPtr = geomBlockInput->addSingleInput("radii", false, "A list of radii, must be in increasing order");

--- a/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_smart_envelope/egs_smart_envelope.cpp
@@ -263,7 +263,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_SmartEnvelope"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_smart_envelope"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("base geometry", true, "The name of a previously defined geometry, that other geometries will be placed strictly inside.");

--- a/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_space/egs_space.cpp
@@ -50,7 +50,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Space"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_space"});
     }
 
     EGS_SPACE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -695,7 +695,7 @@ extern "C" {
         geomBlockInput->addSingleInput("midpoint", false, "The position of the middle of the spheres (x, y, z)");
     }
 
-    EGS_SPHERES_EXPORT string getExample(string type) {
+    EGS_SPHERES_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_spheres/egs_spheres.cpp
@@ -688,7 +688,7 @@ extern "C" {
 
         setBaseGeometryInputs();
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_Spheres"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_spheres"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("radii", true, "A list of sphere radii, in increasing order.");

--- a/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
@@ -40,6 +40,9 @@
 #include <limits>
 
 namespace { // anonymous namespace for low-level geometry routines
+
+static bool EGS_TRIANGLE_MESH_LOCAL inputSet = false;
+
 const EGS_Float eps = 1e-8;
 
 inline EGS_Float dot(const EGS_Vector &x, const EGS_Vector &y) {
@@ -1128,6 +1131,41 @@ int EGS_TriangleMesh::howfar(int ireg, const EGS_Vector &x, const EGS_Vector &u,
 const std::string EGS_TriangleMesh::type = "EGS_TriangleMesh";
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"egs_triangle_mesh"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("file", true, "The full filepath to the .msh, .node or .ele file, including the extension.");
+    }
+
+    EGS_TRIANGLE_MESH_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    #:start geometry:
+        name        = my_surface_mesh
+        library     = egs_triangle_mesh
+        file        = model.stl # Full filepath, including extension
+        :start media input: # Only one medium supported
+            media = water
+        :stop media input:
+        # scale = 0.1 # optional scaling factor. Mesh files are assumed to be in `cm` for scale=1.
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_TRIANGLE_MESH_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_TRIANGLE_MESH_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         if (!input) {

--- a/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
@@ -1144,7 +1144,7 @@ extern "C" {
         geomBlockInput->addSingleInput("scale", false, "Apply a multiplative scaling factor to positions. E.g. if your model is in mm, scale to cm using scale=0.1.");
     }
 
-    EGS_TRIANGLE_MESH_EXPORT string getExample(string type) {
+    EGS_TRIANGLE_MESH_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.cpp
@@ -1135,12 +1135,13 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        setBaseGeometryInputs(false);
+        setBaseGeometryInputs(true);
 
         geomBlockInput->getSingleInput("library")->setValues({"egs_triangle_mesh"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("file", true, "The full filepath to the .msh, .node or .ele file, including the extension.");
+        geomBlockInput->addSingleInput("scale", false, "Apply a multiplative scaling factor to positions. E.g. if your model is in mm, scale to cm using scale=0.1.");
     }
 
     EGS_TRIANGLE_MESH_EXPORT string getExample(string type) {

--- a/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.h
+++ b/HEN_HOUSE/egs++/geometry/egs_triangle_mesh/egs_triangle_mesh.h
@@ -139,11 +139,11 @@ The following file formats are supported:
     :start geometry:
         name        = my_surface_mesh
         library     = egs_triangle_mesh
-        file        = model.stl # your surface mesh here
-        :start media input:
+        file        = model.stl # Full filepath, including extension
+        :start media input: # Only one medium supported
             media = water
         :stop media input:
-        # scale = 0.1 # optional scaling factor. Mesh files are assumed to be in `cm`.
+        # scale = 0.1 # optional scaling factor. Mesh files are assumed to be in `cm` for scale=1.
     :stop geometry:
 
     simulation geometry = my_surface_mesh

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -183,7 +183,7 @@ extern "C" {
         geomBlockInput->addSingleInput("priorities", false, "A list of integers defining the geometry priorities. If neglected, the priority decreases when moving from the first to the last of the geometry list.");
     }
 
-    EGS_UNIONG_EXPORT string getExample(string type) {
+    EGS_UNIONG_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_union/egs_union_geometry.cpp
@@ -176,7 +176,7 @@ extern "C" {
 
         setBaseGeometryInputs(false);
 
-        geomBlockInput->getSingleInput("library")->setValues({"EGS_gunion"});
+        geomBlockInput->getSingleInput("library")->setValues({"egs_gunion"});
 
         // Format: name, isRequired, description, vector string of allowed values
         geomBlockInput->addSingleInput("geometries", true, "A list of names of previously defined geometries");

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -67,6 +67,8 @@
 
 using namespace std;
 
+static bool EGS_VHP_LOCAL inputSet = false;
+
 #ifndef SKIP_DOXYGEN
 EGS_VoxelInfo *EGS_VoxelGeometry::v = 0;
 int            EGS_VoxelGeometry::nv = 0;
@@ -671,6 +673,48 @@ const static EGS_VHP_LOCAL char *vhp_error_msg1 =
     "createGeometry(VHP): wrong/missing %s input for micro_test geometry\n";
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseGeometryInputs(false);
+
+        geomBlockInput->getSingleInput("library")->setValues({"egs_vhp_geometry"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        geomBlockInput->addSingleInput("phantom data", true, "The full filepath to the phantom data file, including the extension.");
+        geomBlockInput->addSingleInput("media data", true, "The full filepath to the media data file, including the extension.");
+        geomBlockInput->addSingleInput("slice range", false, "Two numbers, slice indices (indexed from 0). The first number must be smaller. Used to select a given slice range instead of using the entire phantom.");
+
+        // For bone spongiosa
+        geomBlockInput->addSingleInput("BSC thickness", false, "The thickness of the bone surface cells layer, in cm.");
+        geomBlockInput->addSingleInput("TB medium", false, "The trabecular bone medium name.");
+        geomBlockInput->addSingleInput("TB medium", false, "The bone marrow medium name.");
+        geomBlockInput->addSingleInput("micro matrix", false, "The binary micro matrix filename followed by organ indices (defined in the media data file).");
+    }
+
+    EGS_VHP_EXPORT string getExample(string type) {
+        string example;
+        example = {
+            R"(
+    # For file format definitions and more inputs, see the documentation.
+    #:start geometry:
+        library      = egs_vhp_geometry
+        name         = some_name
+        phantom data = phantom_data_file
+        media data   = media_data_file
+        slice range  = min_slice max_slice
+    :stop geometry:
+)"};
+        return example;
+    }
+
+    EGS_VHP_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return geomBlockInput;
+    }
 
     EGS_VHP_EXPORT EGS_BaseGeometry *createGeometry(EGS_Input *input) {
         string type;

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -693,7 +693,7 @@ extern "C" {
         geomBlockInput->addSingleInput("micro matrix", false, "The binary micro matrix filename followed by organ indices (defined in the media data file).");
     }
 
-    EGS_VHP_EXPORT string getExample(string type) {
+    EGS_VHP_EXPORT string getExample() {
         string example;
         example = {
             R"(

--- a/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
+++ b/HEN_HOUSE/egs++/geometry/egs_vhp_geometry/egs_vhp_geometry.cpp
@@ -689,7 +689,7 @@ extern "C" {
         // For bone spongiosa
         geomBlockInput->addSingleInput("BSC thickness", false, "The thickness of the bone surface cells layer, in cm.");
         geomBlockInput->addSingleInput("TB medium", false, "The trabecular bone medium name.");
-        geomBlockInput->addSingleInput("TB medium", false, "The bone marrow medium name.");
+        geomBlockInput->addSingleInput("BM medium", false, "The bone marrow medium name.");
         geomBlockInput->addSingleInput("micro matrix", false, "The binary micro matrix filename followed by organ indices (defined in the media data file).");
     }
 

--- a/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle/egs_circle.cpp
@@ -38,7 +38,7 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
-static string EGS_CIRCLE_LOCAL typeStr("EGS_Circle");
+static string EGS_CIRCLE_LOCAL typeStr("egs_circle");
 static bool EGS_CIRCLE_LOCAL inputSet = false;
 static shared_ptr<EGS_BlockInput> EGS_CIRCLE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
 

--- a/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_circle_perpendicular/egs_circle_perpendicular.cpp
@@ -38,7 +38,41 @@
 #include "egs_input.h"
 #include "egs_functions.h"
 
+static bool EGS_CIRCLE_PERPENDICULAR_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_CIRCLE_PERPENDICULAR_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setShapeInputs(shapeBlockInput);
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_circle_perpendicular"});
+
+        shapeBlockInput->addSingleInput("radius", false, "The radius of the circle.");
+        shapeBlockInput->addSingleInput("midpoint", false, "The x, y midpoint of the circle, which is in the x-y plane located at z=0. Use an EGS_AffineTransform block to translate or rotate the shape.");
+        shapeBlockInput->addSingleInput("inner radius", false, "The inner radius, to define a ring. Points will only be sampled within the ring between the 'inner radius' and 'radius'.");
+    }
+
+    EGS_CIRCLE_PERPENDICULAR_EXPORT string getExample() {
+        string example {
+            R"(
+        #:start shape:
+            library = egs_circle_perpendicular
+            radius = the circle radius
+            midpoint = Ox, Oy (optional)
+            inner radius = the inner radius (optional)
+        :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_CIRCLE_PERPENDICULAR_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_CIRCLE_PERPENDICULAR_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_conical_shell/egs_conical_shell.cpp
@@ -198,7 +198,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Conical_Shell"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_conical_shell"});
 
         shapeBlockInput->addSingleInput("midpoint", false, "The midpoint of the conical shell, (x, y, z). Defaults to '0 0 0'.");
 

--- a/HEN_HOUSE/egs++/shapes/egs_dynamic_shape/egs_dynamic_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_dynamic_shape/egs_dynamic_shape.cpp
@@ -48,7 +48,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"egs_conical_shell"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_dynamic_shape"});
 
         auto shapePtr = shapeBlockInput->addBlockInput("shape");
         setShapeInputs(shapePtr);

--- a/HEN_HOUSE/egs++/shapes/egs_dynamic_shape/egs_dynamic_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_dynamic_shape/egs_dynamic_shape.cpp
@@ -39,7 +39,53 @@
 #include "egs_functions.h"
 #include <sstream>
 
+static bool EGS_DYNAMIC_SHAPE_LOCAL inputSet = false;
+static shared_ptr<EGS_BlockInput> EGS_DYNAMIC_SHAPE_LOCAL shapeBlockInput = make_shared<EGS_BlockInput>("shape");
+
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setShapeInputs(shapeBlockInput);
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_conical_shell"});
+
+        auto shapePtr = shapeBlockInput->addBlockInput("shape");
+        setShapeInputs(shapePtr);
+
+        shared_ptr<EGS_BlockInput> motionBlock = shapeBlockInput->addBlockInput("motion", true);
+        motionBlock->addSingleInput("control point", true, "Parameters to define motion: timeIndex xtrans ytrans ztrans xrot yrot zrot");
+    }
+
+    EGS_DYNAMIC_SHAPE_EXPORT string getExample() {
+        string example;
+        example = {
+            R"(
+    # Example of egs_dynamic_shape
+    #:start shape:
+        library = egs_dynamic_shape
+        :start shape:
+            definition of the shape to be 'dynamic'
+        :stop shape:
+        :start motion: # units of cm and degrees
+            control point = timeIndex(1) xtrans(1) ytrans(1) ztrans(1) xrot(1) yrot(1) zrot(1)
+            control point = timeIndex(2) xtrans(2) ytrans(2) ztrans(2) xrot(2) yrot(2) zrot(2)
+            .
+            .
+            .
+            control point = timeIndex(N) xtrans(N) ytrans(N) ztrans(N) xrot(N) yrot(N) zrot(N)
+        :stop motion:
+    :stop shape:
+)"};
+        return example;
+    }
+
+    EGS_DYNAMIC_SHAPE_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return shapeBlockInput;
+    }
 
     EGS_DYNAMIC_SHAPE_EXPORT EGS_BaseShape *createShape(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_ellipse/egs_ellipse.cpp
@@ -47,7 +47,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Ellipse"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_ellipse"});
 
         shapeBlockInput->addSingleInput("halfaxis", true, "The two half axis of the ellipse.");
         shapeBlockInput->addSingleInput("midpoint", false, "The midpoint of the ellipse, (x, y). Defaults to '0 0'.");

--- a/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_extended_shape/egs_extended_shape.cpp
@@ -45,7 +45,7 @@ extern "C" {
 
     static void setInputs() {
         inputSet = true;
-        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Extended_Shape"});
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"egs_extended_shape"});
         shapeBlockInput->addSingleInput("extension", true, "Adds delta z to the z-component of the position vector (z1, z2)");
 
         auto shapePtr = shapeBlockInput->addBlockInput("shape");

--- a/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_gaussian_shape/egs_gaussian_shape.cpp
@@ -46,7 +46,7 @@ extern "C" {
     static void setInputs() {
         inputSet = true;
 
-        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Gaussian_Shape"});
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"egs_gaussian_shape"});
         shapeBlockInput->addSingleInput("sigma", true, "1 or 2 or 3 inputs, the sigma for Gaussian spread along x, y and z, respectively.");
 
         auto shapePtr = shapeBlockInput->addBlockInput("shape");
@@ -57,13 +57,14 @@ extern "C" {
         string example;
         example = {
             R"(
-    # Example of egs_gaussiam_shape
+    # Example of egs_gaussian_shape
     #:start shape:
         library = egs_gaussian_shape
         :start shape:
             definition of the shape to be smeared
         :stop shape:
         sigma = 1, 2 or 3 inputs
+    :stop shape:
 )"};
         return example;
     }

--- a/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_line_shape/egs_line_shape.cpp
@@ -70,7 +70,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Line_Shape"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_line_shape"});
 
         shapeBlockInput->addSingleInput("points", true, "A list of 2D positions, at least 2 required. By default these are in the x-y plane at z=0; use a transformation to adjust.");
     }

--- a/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_polygon_shape/egs_polygon_shape.cpp
@@ -149,7 +149,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Polygon_Shape"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_polygon_shape"});
 
         shapeBlockInput->addSingleInput("points", true, "A list of at least 3 2D points (at least 6 floating numbers). By default these are in the x-y plane at z=0; use a transformation to adjust.");
     }

--- a/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_rectangle/egs_rectangle.cpp
@@ -104,7 +104,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Rectangle"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_rectangle"});
 
         shapeBlockInput->addSingleInput("rectangle", true, "Two 2D coordinates to define a rectangle: x1 y1 x2 y2. By default these are in the x-y plane at z=0; use a transformation to adjust.");
         shapeBlockInput->addSingleInput("inner rectangle", false, "Two 2D coordinates to define an inner rectangle, and create a 'rectangular ring': xp1 yp1 xp2 yp2");

--- a/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_shape_collection/egs_shape_collection.cpp
@@ -67,7 +67,7 @@ extern "C" {
 
     static void setInputs() {
         inputSet = true;
-        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"EGS_Shape_Collection"});
+        shapeBlockInput->addSingleInput("library", true, "The type of shape, loaded by shared library in egs++/dso.", {"egs_shape_collection"});
         shapeBlockInput->addSingleInput("probabilities", true, "A list of the relative sampling weight for each of the shapes: p1 p2 ... pn");
 
         auto shapePtr = shapeBlockInput->addBlockInput("shape");

--- a/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_spherical_shell/egs_spherical_shell.cpp
@@ -136,7 +136,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Spherical_Shell"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_spherical_shell"});
 
         shapeBlockInput->addSingleInput("midpoint", false, "The midpoint of the shape, (x y z). Defaults to '0 0 0'.");
         shapeBlockInput->addSingleInput("inner radius", true, "The inner radius");

--- a/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
+++ b/HEN_HOUSE/egs++/shapes/egs_voxelized_shape/egs_voxelized_shape.cpp
@@ -377,7 +377,7 @@ extern "C" {
         inputSet = true;
 
         setShapeInputs(shapeBlockInput);
-        shapeBlockInput->getSingleInput("library")->setValues({"EGS_Voxelized_Shape"});
+        shapeBlockInput->getSingleInput("library")->setValues({"egs_voxelized_shape"});
 
         shapeBlockInput->addSingleInput("file name", true, "The filename for a binary file that contains sampling probabilities for an XYZ voxel grid. See the documentation for file format details.");
     }

--- a/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_angular_spread/egs_angular_spread_source.cpp
@@ -112,7 +112,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Angular_Spread_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_angular_spread_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("source name", true, "The name of a previously defined source.");

--- a/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_beam_source/egs_beam_source.cpp
@@ -367,7 +367,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Beam_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_beam_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("beam code", true, "The name of the BEAMnrc user code. Note that it must be compiled as a shared library, which is not done by default.");

--- a/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_collimated_source/egs_collimated_source.cpp
@@ -129,7 +129,7 @@ extern "C" {
 
         setBaseSourceInputs();
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Collimated_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_collimated_source"});
 
         // Format: name,  isRequired, description, vector string of allowed values
         auto source_shapePtr = srcBlockInput->addBlockInput("source shape");

--- a/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_dynamic_source/egs_dynamic_source.cpp
@@ -215,7 +215,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Dynamic_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_dynamic_source"});
 
         // Format:name, isRequired, description, vector string of allowed
         srcBlockInput->addSingleInput("base source", true, "The name of a previously defined source");

--- a/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_fano_source/egs_fano_source.cpp
@@ -152,7 +152,7 @@ extern "C" {
 
         setBaseSourceInputs();
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Fano_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_fano_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto shapePtr = srcBlockInput->addBlockInput("shape");

--- a/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.cpp
@@ -212,7 +212,7 @@ extern "C" {
         srcBlockInput->addSingleInput("angular spread y", false, "The standard deviation in degrees from the z-axis toward y");
         srcBlockInput->addSingleInput("x translation", false, "An offset from the origin along x");
         srcBlockInput->addSingleInput("y translation", false, "An offset from the origin along y");
-        srcBlockInput->addSingleInput("z translation", false, "An offset from the origin along z");
+        srcBlockInput->addSingleInput("z of rotation", false, "The z position for the point of rotation");
         srcBlockInput->addSingleInput("x rotation", false, "A rotation clockwise when viewed from the +x axis, in degrees");
         srcBlockInput->addSingleInput("y rotation", false, "A rotation clockwise when viewed from the +y axis, in degrees");
     }

--- a/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_focal_spot_source/egs_focal_spot_source.cpp
@@ -38,6 +38,8 @@
 #include "egs_focal_spot_source.h"
 #include "egs_input.h"
 
+static bool EGS_FOCAL_SPOT_LOCAL inputSet = false;
+
 EGS_FocalSpot::EGS_FocalSpot(EGS_Input *input, EGS_ObjectFactory *f) :
     EGS_BaseSimpleSource(input,f), valid(true) {
     // read required inputs
@@ -192,6 +194,64 @@ void EGS_FocalSpot::setUp() {
 
 
 extern "C" {
+
+    static void setInputs() {
+        inputSet = true;
+
+        setBaseSourceInputs();
+
+        srcBlockInput->getSingleInput("library")->setValues({"egs_focal_spot_source"});
+
+        // Format: name, isRequired, description, vector string of allowed values
+        srcBlockInput->addSingleInput("z position", true, "The z position of the source");
+        srcBlockInput->addSingleInput("spatial spread x", true, "The standard deviation of the source along x");
+        srcBlockInput->addSingleInput("spatial spread y", true, "The standard deviation of the source along y");
+        srcBlockInput->addSingleInput("spatial cutoff x", false, "Particles will not be generated outside [x0-cutoff, x0+cutoff]");
+        srcBlockInput->addSingleInput("spatial cutoff y", false, "Particles will not be generated outside [y0-cutoff, y0+cutoff]");
+        srcBlockInput->addSingleInput("angular spread x", false, "The standard deviation in degrees from the z-axis toward x");
+        srcBlockInput->addSingleInput("angular spread y", false, "The standard deviation in degrees from the z-axis toward y");
+        srcBlockInput->addSingleInput("x translation", false, "An offset from the origin along x");
+        srcBlockInput->addSingleInput("y translation", false, "An offset from the origin along y");
+        srcBlockInput->addSingleInput("z translation", false, "An offset from the origin along z");
+        srcBlockInput->addSingleInput("x rotation", false, "A rotation clockwise when viewed from the +x axis, in degrees");
+        srcBlockInput->addSingleInput("y rotation", false, "A rotation clockwise when viewed from the +y axis, in degrees");
+    }
+
+    EGS_FOCAL_SPOT_EXPORT string getExample() {
+        string example;
+        example = {
+            R"(
+    # Example of egs_focal_spot_source
+    #:start source:
+        library              = egs_focal_spot_source
+        name                 = focal_spot_test
+        z position           = 1        # cm
+        spatial spread x     = 0.2      # cm standard deviation always never FWHM
+        spatial spread y     = 0.2      # cm standard deviation always never FWHM
+        spatial cutoff x     = 0.3      # cm particles will not be generated outside [x0-cutoff, x0+cutoff] (optional)
+        spatial cutoff y     = 0.3      # cm particles will not be generated outside [y0-cutoff, y0+cutoff] (optional)
+        angular spread x     = 1.5      # degrees (optional) (standard deviation from z-axis)
+        angular spread y     = 0.9      # degrees (optional) (standard deviation from z-axis)
+        x translation        = 0        # cm (optional)
+        y translation        = 0        # cm (optional)
+        z of rotation        = 0        # cm (optional)
+        x rotation           = 1        # degrees, clockwise when viewed from +x axis
+        y rotation           = 0        # degrees, clockwise when viewed from +y axis
+        :start spectrum:
+            definition of the spectrum
+        :stop spectrum:
+        charge = -1 or 0 or 1 for electrons or photons or positrons
+    :stop source:
+)"};
+        return example;
+    }
+
+    EGS_FOCAL_SPOT_EXPORT shared_ptr<EGS_BlockInput> getInputs() {
+        if(!inputSet) {
+            setInputs();
+        }
+        return srcBlockInput;
+    }
 
     EGS_FOCAL_SPOT_EXPORT EGS_BaseSource *createSource(EGS_Input *input,
             EGS_ObjectFactory *f) {

--- a/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_isotropic_source/egs_isotropic_source.cpp
@@ -43,7 +43,7 @@
 #include "egs_input.h"
 #include "egs_math.h"
 
-static string EGS_ISOTROPIC_SOURCE_LOCAL typeStr("EGS_Isotropic_Source");
+static string EGS_ISOTROPIC_SOURCE_LOCAL typeStr("egs_isotropic_source");
 static bool EGS_ISOTROPIC_SOURCE_LOCAL inputSet = false;
 
 EGS_IsotropicSource::EGS_IsotropicSource(EGS_Input *input,

--- a/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_parallel_beam/egs_parallel_beam.cpp
@@ -117,7 +117,7 @@ extern "C" {
 
         setBaseSourceInputs();
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Parallel_Beam"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_parallel_beam"});
 
         // Format: name, isRequired, description, vector string of allowed values
         auto shapePtr = srcBlockInput->addBlockInput("shape");

--- a/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_phsp_source/egs_phsp_source.cpp
@@ -522,7 +522,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Phsp_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_phsp_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("phase space file", true, "The name of the phase-space file.");

--- a/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_point_source/egs_point_source.cpp
@@ -84,7 +84,7 @@ extern "C" {
 
         setBaseSourceInputs();
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Point_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_point_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("position", true, "The position of the point source: 'x y z'");

--- a/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_radionuclide_source/egs_radionuclide_source.cpp
@@ -535,7 +535,7 @@ extern "C" {
 
         setBaseSourceInputs();
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Radionuclide_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_radionuclide_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("activity", false, "The total activity of mixture, assumed constant.");

--- a/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_source_collection/egs_source_collection.cpp
@@ -162,7 +162,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Source_Collection"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_source_collection"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("source names", true, "A list of names of previously defined sources.");

--- a/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
+++ b/HEN_HOUSE/egs++/sources/egs_transformed_source/egs_transformed_source.cpp
@@ -83,7 +83,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"EGS_Transformed_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"egs_transformed_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("source name", true, "The name of a previously defined source.");

--- a/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
+++ b/HEN_HOUSE/egs++/sources/iaea_phsp_source/iaea_phsp_source.cpp
@@ -558,7 +558,7 @@ extern "C" {
 
         setBaseSourceInputs(false, false);
 
-        srcBlockInput->getSingleInput("library")->setValues({"IAEA_Phsp_Source"});
+        srcBlockInput->getSingleInput("library")->setValues({"iaea_phsp_source"});
 
         // Format: name, isRequired, description, vector string of allowed values
         srcBlockInput->addSingleInput("iaea phase space file", true, "The path to and name of the phase-space file, no extension. Both the .IAEAphsp and .IAEAheader file must be in the same directory.");

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -1,4 +1,3 @@
-
 /*
 ###############################################################################
 #
@@ -103,6 +102,29 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
     connect(this, SIGNAL(cursorPositionChanged()), this, SLOT(autoComplete()));
     connect(popup, SIGNAL(clicked(QModelIndex)), this, SLOT(insertCompletion(QModelIndex)));
     connect(popup, SIGNAL(activated(QModelIndex)), this, SLOT(insertCompletion(QModelIndex)));
+
+    // Debounce timer for viewport-only validation.
+    // Fires 150 ms after the last scroll or block-count change.
+    validationDebounceTimer = new QTimer(this);
+    validationDebounceTimer->setSingleShot(true);
+    validationDebounceTimer->setInterval(150);
+    connect(validationDebounceTimer, &QTimer::timeout,
+            this, &EGS_Editor::validateVisibleLines);
+
+    // Re-validate visible lines after scrolling.
+    connect(this, &QPlainTextEdit::updateRequest,
+            this, [this](const QRect &, int dy) {
+        if (dy != 0) {
+            validationDebounceTimer->start();
+        }
+    });
+
+    // Re-validate after lines are added or removed (e.g. typing a :start/:stop
+    // line changes the block-context for all lines below).
+    connect(this, &QPlainTextEdit::blockCountChanged,
+            this, [this](int) {
+        validationDebounceTimer->start();
+    });
 //
 //         QObject::connect(popup->selectionModel(), SIGNAL(selectionChanged(QItemSelection,QItemSelection)),
 //                         this, SLOT(_q_completionSelected(QItemSelection)));
@@ -207,18 +229,24 @@ int EGS_Editor::countStartingWhitespace(const QString &s) {
     return i;
 }
 
-void EGS_Editor::validateEntireInput() {
-    // This actually validates from the current cursor position,
-    // but we only call this upon loading the file so the cursor is already at the top
-    QTextCursor cursor = textCursor();
-    for (QTextBlock it = cursor.document()->begin(); it != cursor.document()->end(); it = it.next()) {
-        cursor.movePosition(QTextCursor::NextBlock);
-        validateLine(cursor);
-    }
+void EGS_Editor::validateVisibleLines() {
+    // Iterate over only the blocks currently visible in the viewport, mirroring
+    // the approach used by lineNumberAreaPaintEvent.
+    QTextBlock block = firstVisibleBlock();
+    const int viewportBottom = viewport()->height();
 
-#ifdef EDITOR_DEBUG
-    egsInformation("EGS_Editor::validateEntireInput: Done validating input file.\n");
-#endif
+    while (block.isValid()) {
+        const int top = static_cast<int>(
+            blockBoundingGeometry(block).translated(contentOffset()).top());
+        if (top >= viewportBottom) {
+            break;
+        }
+        if (block.isVisible()) {
+            QTextCursor cursor(block);
+            validateLine(cursor);
+        }
+        block = block.next();
+    }
 }
 
 void EGS_Editor::setDarkMode(bool isDark) {
@@ -228,15 +256,16 @@ void EGS_Editor::setDarkMode(bool isDark) {
 void EGS_Editor::validateLine(QTextCursor cursor) {
     QString selectedText = cursor.block().text().simplified();
 
+    // Early-out for blank and comment lines before the expensive context lookup.
+    if (selectedText.isEmpty() || selectedText.startsWith("#")) {
+        return;
+    }
+
     QString blockTitle;
     shared_ptr<EGS_BlockInput> inputBlockTemplate = getBlockInput(blockTitle, cursor);
 
     // If we aren't inside an input block, ignore this line
     if (blockTitle.size() < 1) {
-        return;
-    }
-
-    if (selectedText.startsWith("#")) {
         return;
     }
 
@@ -253,49 +282,41 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
 #endif
 
         // If we found a template for this type of input block,
-        // check that the input tag  (LHS) is valid
+        // check that the input tag (LHS) is valid
         if (inputBlockTemplate) {
 
-            QList<QTextEdit::ExtraSelection> extraSelections = this->extraSelections();
-            QTextEdit::ExtraSelection selection;
-            selection.cursor = cursor;
-            selection.cursor.joinPreviousEditBlock();
+            // Use a scratch cursor for all character-format writes so we don't
+            // disturb the caller's cursor position.
+            QTextCursor fmtCursor = cursor;
+            fmtCursor.joinPreviousEditBlock();
 
-            // Select the whole line
-            selection.cursor.movePosition(QTextCursor::StartOfBlock);
-            selection.cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
-
-            // Reset the format to have no red underline
+            // Select the whole line and clear any previous underline / tooltip.
+            fmtCursor.movePosition(QTextCursor::StartOfBlock);
+            fmtCursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
             QTextCharFormat format;
             format.setUnderlineStyle(QTextCharFormat::NoUnderline);
             format.setToolTip("");
-            selection.cursor.setCharFormat(format);
+            fmtCursor.setCharFormat(format);
 
-            // Check that the input block template contains this type of input
-            // If the input isn't defined, it will return nullptr
+            // Check that the input block template contains this type of input.
+            // If the input isn't defined, it will return nullptr.
             shared_ptr<EGS_SingleInput> inputPtr = inputBlockTemplate->getSingleInput(inputTag.toStdString(), blockTitle.toStdString());
             if (!inputPtr) {
-                // Red underline the input tag
-                // Select the input tag
+                // Red-underline only the input tag (left of "=").
+                fmtCursor.movePosition(QTextCursor::StartOfBlock);
 
-                selection.cursor.movePosition(QTextCursor::StartOfBlock);
-
-                // If whitespace was trimmed from the start of the line,
-                // we account for it so only the input tag is underlined
+                // Account for leading whitespace so only the tag is underlined.
                 int originalEqualsPos = cursor.block().text().indexOf("=");
                 int numWhitespace = countStartingWhitespace(cursor.block().text());
                 if (numWhitespace > 0) {
-                    selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
+                    fmtCursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
                 }
+                fmtCursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, originalEqualsPos - numWhitespace);
 
-                selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, originalEqualsPos - numWhitespace);
-
-                // Set the format to have a red underline
                 format.setUnderlineColor(QColor("red"));
                 format.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
             }
             else {
-
                 // Get the description for this input
                 string desc = inputPtr->getDescription();
 
@@ -326,21 +347,16 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                     }
 
                     if (inputDependencySatisfied(inputPtr, cursor) == false) {
-                        // Red underline the input tag
-                        // Select the input tag
-                        selection.cursor.movePosition(QTextCursor::StartOfBlock);
+                        // Red-underline only the input tag.
+                        fmtCursor.movePosition(QTextCursor::StartOfBlock);
 
-                        // If whitespace was trimmed from the start of the line,
-                        // we account for it so only the input tag is underlined
                         int originalEqualsPos = cursor.block().text().indexOf("=");
                         int numWhitespace = countStartingWhitespace(cursor.block().text());
                         if (numWhitespace > 0) {
-                            selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
+                            fmtCursor.movePosition(QTextCursor::NextCharacter, QTextCursor::MoveAnchor, numWhitespace);
                         }
+                        fmtCursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, originalEqualsPos - numWhitespace);
 
-                        selection.cursor.movePosition(QTextCursor::NextCharacter, QTextCursor::KeepAnchor, originalEqualsPos - numWhitespace);
-
-                        // Set the format to have a red underline
                         format.setUnderlineColor(QColor("red"));
                         format.setUnderlineStyle(QTextCharFormat::SpellCheckUnderline);
                     }
@@ -350,32 +366,21 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
                 format.setToolTip(QString::fromStdString(desc));
             }
 
-            selection.cursor.setCharFormat(format);
-
-            selection.cursor.endEditBlock();
-            extraSelections.append(selection);
-            setExtraSelections(extraSelections);
+            fmtCursor.setCharFormat(format);
+            fmtCursor.endEditBlock();
         }
         cursor.endEditBlock();
     } else {
+        // Non-assignment line inside a known block: clear any stale underline/tooltip.
         cursor.beginEditBlock();
-        QList<QTextEdit::ExtraSelection> extraSelections = this->extraSelections();
-        QTextEdit::ExtraSelection selection;
-        selection.cursor = cursor;
-        selection.cursor.joinPreviousEditBlock();
-
-        // Select the whole line
-        selection.cursor.movePosition(QTextCursor::StartOfBlock);
-        selection.cursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
-
-        // Reset the format to have no red underline
+        QTextCursor fmtCursor = cursor;
+        fmtCursor.joinPreviousEditBlock();
+        fmtCursor.movePosition(QTextCursor::StartOfBlock);
+        fmtCursor.movePosition(QTextCursor::EndOfBlock, QTextCursor::KeepAnchor);
         QTextCharFormat format;
-        //format.setUnderlineStyle(QTextCharFormat::NoUnderline);
         format.setToolTip("");
-        selection.cursor.setCharFormat(format);
-        selection.cursor.endEditBlock();
-        extraSelections.append(selection);
-        setExtraSelections(extraSelections);
+        fmtCursor.setCharFormat(format);
+        fmtCursor.endEditBlock();
         cursor.endEditBlock();
     }
 }
@@ -757,7 +762,7 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
         // so that we're actually starting within the block
         QTextBlock blockEnd;
         blockEnd = cursor.block();
-        int loopGuard = 100000;
+        int loopGuard = document()->blockCount();
         int i = 0;
         while (blockEnd.text().contains(":start ")) {
             blockEnd = getBlockEnd(blockEnd.next());
@@ -947,7 +952,9 @@ QString EGS_Editor::getParentBlockTitle(QTextCursor cursor) {
     return blockTitle;
 }
 
-QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag, bool searchUpstream) {
+QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag, bool searchUpstream, int depth) {
+    static constexpr int maxUpstreamDepth = 20;
+
     QString value;
     vector<QString> innerList;
     bool withinOtherBlock = false;
@@ -1022,9 +1029,9 @@ QString EGS_Editor::getInputValue(QString inp, QTextBlock currentBlock, bool &fo
         }
     }
 
-    if(!foundTag && searchUpstream) {
+    if (!foundTag && searchUpstream && depth < maxUpstreamDepth) {
         QTextBlock upstreamBlock = blockEnd.next().next(); // This might be a :stop of the upstream block
-        value = getInputValue(inp, upstreamBlock, foundTag, searchUpstream);
+        value = getInputValue(inp, upstreamBlock, foundTag, searchUpstream, depth + 1);
     }
 
     return value;

--- a/HEN_HOUSE/egs++/view/egs_editor.cpp
+++ b/HEN_HOUSE/egs++/view/egs_editor.cpp
@@ -113,7 +113,7 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
 
     // Re-validate visible lines after scrolling.
     connect(this, &QPlainTextEdit::updateRequest,
-            this, [this](const QRect &, int dy) {
+    this, [this](const QRect &, int dy) {
         if (dy != 0) {
             validationDebounceTimer->start();
         }
@@ -122,7 +122,7 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
     // Re-validate after lines are added or removed (e.g. typing a :start/:stop
     // line changes the block-context for all lines below).
     connect(this, &QPlainTextEdit::blockCountChanged,
-            this, [this](int) {
+    this, [this](int) {
         validationDebounceTimer->start();
     });
 //
@@ -134,7 +134,7 @@ EGS_Editor::EGS_Editor(QWidget *parent) : QPlainTextEdit(parent) {
 
     // Add shortcuts for find next and previous
     QShortcut *findNextShortcut =
-    new QShortcut(QKeySequence(Qt::Key_F3), this);
+        new QShortcut(QKeySequence(Qt::Key_F3), this);
     connect(findNextShortcut, &QShortcut::activated, this, &EGS_Editor::findNext);
     QShortcut *findPrevShortcut =
         new QShortcut(QKeySequence(Qt::SHIFT | Qt::Key_F3), this);
@@ -210,8 +210,8 @@ void EGS_Editor::highlightCurrentLine() {
         QTextEdit::ExtraSelection selection;
 
         QColor lineColor = isDarkMode
-            ? QColor("#3a3d41")   // subtle dark gray highlight
-            : QColor(Qt::lightGray).lighter(120);
+                           ? QColor("#3a3d41")   // subtle dark gray highlight
+                           : QColor(Qt::lightGray).lighter(120);
 
         selection.format.setBackground(lineColor);
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
@@ -237,7 +237,7 @@ void EGS_Editor::validateVisibleLines() {
 
     while (block.isValid()) {
         const int top = static_cast<int>(
-            blockBoundingGeometry(block).translated(contentOffset()).top());
+                            blockBoundingGeometry(block).translated(contentOffset()).top());
         if (top >= viewportBottom) {
             break;
         }
@@ -370,7 +370,8 @@ void EGS_Editor::validateLine(QTextCursor cursor) {
             fmtCursor.endEditBlock();
         }
         cursor.endEditBlock();
-    } else {
+    }
+    else {
         // Non-assignment line inside a known block: clear any stale underline/tooltip.
         cursor.beginEditBlock();
         QTextCursor fmtCursor = cursor;
@@ -673,7 +674,7 @@ void EGS_Editor::autoComplete() {
         // add 'library =' as an option in the popup
     }
     else if (selectedText.size() == 0 && (egsEquivStr(blockTitle.toStdString(), "geometry") || egsEquivStr(blockTitle.toStdString(), "source")
-    || egsEquivStr(blockTitle.toStdString(), "ausgab object"))) {
+                                          || egsEquivStr(blockTitle.toStdString(), "ausgab object"))) {
 
         // Populate the popup list
         QStringList itemList;
@@ -738,7 +739,7 @@ shared_ptr<EGS_BlockInput> EGS_Editor::getBlockInput(QString &blockTitle, QTextC
     // If the parent block is media definition, then just return pegsless
     if (parentTitle.toStdString() == "media definition") {
         shared_ptr<EGS_BlockInput> medDefBlock = inputStruct->getBlockInput("media definition");
-        if(medDefBlock) {
+        if (medDefBlock) {
             shared_ptr<EGS_BlockInput> inputBlock = medDefBlock->getBlockInput("myMediumName");
             return inputBlock;
         }
@@ -1081,7 +1082,7 @@ QTextBlock EGS_Editor::getBlockEnd(QTextBlock currentBlock) {
 }
 
 template <typename T>
-bool EGS_Editor::inputHasDependency(const shared_ptr<T>& inp) {
+bool EGS_Editor::inputHasDependency(const shared_ptr<T> &inp) {
     static_assert(
         std::is_same<T, EGS_SingleInput>::value ||
         std::is_same<T, EGS_BlockInput>::value,
@@ -1089,11 +1090,11 @@ bool EGS_Editor::inputHasDependency(const shared_ptr<T>& inp) {
     );
 
     return !inp->getDependencyInp().empty()
-        || inp->getDependencyBlock() != nullptr;
+           || inp->getDependencyBlock() != nullptr;
 }
 
 template <typename T>
-bool EGS_Editor::inputDependencySatisfied(const shared_ptr<T>& inp, QTextCursor cursor) {
+bool EGS_Editor::inputDependencySatisfied(const shared_ptr<T> &inp, QTextCursor cursor) {
     static_assert(
         std::is_same<T, EGS_SingleInput>::value ||
         std::is_same<T, EGS_BlockInput>::value,
@@ -1306,8 +1307,7 @@ void EGS_Editor::lineNumberAreaPaintEvent(QPaintEvent *event) {
     }
 }
 
-void EGS_Editor::indentSelection(bool unindent)
-{
+void EGS_Editor::indentSelection(bool unindent) {
     QTextCursor cursor = textCursor();
 
     // No selection means it's a single line to indent
@@ -1319,18 +1319,21 @@ void EGS_Editor::indentSelection(bool unindent)
             QTextCursor lineCursor = cursor;
 
             lineCursor.movePosition(QTextCursor::NextCharacter,
-                                     QTextCursor::KeepAnchor,
-                                     indentWidth);
+                                    QTextCursor::KeepAnchor,
+                                    indentWidth);
             if (lineCursor.selectedText() == QString(indentWidth, ' ')) {
                 lineCursor.removeSelectedText();
-            } else {
+            }
+            else {
                 lineCursor = cursor;
                 lineCursor.movePosition(QTextCursor::NextCharacter,
-                                         QTextCursor::KeepAnchor, 1);
-                if (lineCursor.selectedText() == "\t")
+                                        QTextCursor::KeepAnchor, 1);
+                if (lineCursor.selectedText() == "\t") {
                     lineCursor.removeSelectedText();
+                }
             }
-        } else {
+        }
+        else {
             cursor.insertText(QString(indentWidth, ' '));
         }
         return;
@@ -1349,8 +1352,9 @@ void EGS_Editor::indentSelection(bool unindent)
 
     for (int block = startBlock; block <= endBlock; ++block) {
         QTextBlock textBlock = document()->findBlockByNumber(block);
-        if (!textBlock.isValid())
+        if (!textBlock.isValid()) {
             continue;
+        }
 
         QTextCursor lineCursor(textBlock);
 
@@ -1363,14 +1367,17 @@ void EGS_Editor::indentSelection(bool unindent)
                                       indentWidth);
             if (removeCursor.selectedText() == QString(indentWidth, ' ')) {
                 removeCursor.removeSelectedText();
-            } else {
+            }
+            else {
                 removeCursor = lineCursor;
                 removeCursor.movePosition(QTextCursor::NextCharacter,
                                           QTextCursor::KeepAnchor, 1);
-                if (removeCursor.selectedText() == "\t")
+                if (removeCursor.selectedText() == "\t") {
                     removeCursor.removeSelectedText();
+                }
             }
-        } else {
+        }
+        else {
             lineCursor.insertText(QString(indentWidth, ' '));
         }
     }
@@ -1378,8 +1385,7 @@ void EGS_Editor::indentSelection(bool unindent)
     cursor.endEditBlock();
 }
 
-void EGS_Editor::showFindDialog(bool withReplace)
-{
+void EGS_Editor::showFindDialog(bool withReplace) {
     if (!findDialog) {
         findDialog = new QDialog(this);
         findDialog->setWindowTitle("Find / Replace");
@@ -1460,14 +1466,15 @@ void EGS_Editor::showFindDialog(bool withReplace)
 }
 
 
-void EGS_Editor::findNext()
-{
-    if (!findEdit || findEdit->text().isEmpty())
+void EGS_Editor::findNext() {
+    if (!findEdit || findEdit->text().isEmpty()) {
         return;
+    }
 
     QTextDocument::FindFlags flags;
-    if (caseCheck->isChecked())
+    if (caseCheck->isChecked()) {
         flags |= QTextDocument::FindCaseSensitively;
+    }
 
     bool found = find(findEdit->text(), flags);
 
@@ -1482,8 +1489,9 @@ void EGS_Editor::findNext()
 
 void EGS_Editor::findPrevious() {
     const QString text = findEdit->text();
-    if (text.isEmpty())
+    if (text.isEmpty()) {
         return;
+    }
 
     QTextDocument::FindFlags flags = QTextDocument::FindBackward;
     bool found = find(text, flags);
@@ -1604,12 +1612,14 @@ bool EGS_Editor::eventFilter(QObject *obj, QEvent *event) {
                 popup->QWidget::grabKeyboard();
                 return true;
             }
-        } else if (keyEvent->key() == Qt::Key_F &&
-            (keyEvent->modifiers() & Qt::ControlModifier)) {
+        }
+        else if (keyEvent->key() == Qt::Key_F &&
+                 (keyEvent->modifiers() & Qt::ControlModifier)) {
             showFindDialog(false);
             return true;
-        } else if (keyEvent->key() == Qt::Key_H &&
-            (keyEvent->modifiers() & Qt::ControlModifier)) {
+        }
+        else if (keyEvent->key() == Qt::Key_H &&
+                 (keyEvent->modifiers() & Qt::ControlModifier)) {
             showFindDialog(true);
             return true;
         }

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -59,7 +59,9 @@ public:
     void setInputStruct(shared_ptr<EGS_InputStruct> inp);
     void validateVisibleLines();
     void setDarkMode(bool isDarkMode);
-    void setHighlighter(EGS_Highlighter *h) { syntaxHighlighter = h; }
+    void setHighlighter(EGS_Highlighter *h) {
+        syntaxHighlighter = h;
+    }
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -85,9 +87,9 @@ private:
     QString getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag, bool searchUpstream = false, int depth = 0);
     QTextBlock getBlockEnd(QTextBlock currentBlock);
     template <typename T>
-    bool inputHasDependency(const shared_ptr<T>& inp);
+    bool inputHasDependency(const shared_ptr<T> &inp);
     template <typename T>
-    bool inputDependencySatisfied(const shared_ptr<T>& inp, QTextCursor cursor = QTextCursor());
+    bool inputDependencySatisfied(const shared_ptr<T> &inp, QTextCursor cursor = QTextCursor());
     QTextBlock findSiblingBlock(QString title, QTextBlock currentBlock);
     int countStartingWhitespace(const QString &s);
     void indentSelection(bool unindent);

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -38,7 +38,6 @@
 #include <QtWidgets>
 
 #include "egs_input_struct.h"
-#include "egs_highlighter.h"
 
 class QPaintEvent;
 class QResizeEvent;
@@ -59,9 +58,6 @@ public:
     void setInputStruct(shared_ptr<EGS_InputStruct> inp);
     void validateVisibleLines();
     void setDarkMode(bool isDarkMode);
-    void setHighlighter(EGS_Highlighter *h) {
-        syntaxHighlighter = h;
-    }
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -96,7 +92,6 @@ private:
 
     QWidget *lineNumberArea;
     shared_ptr<EGS_InputStruct> inputStruct;
-    EGS_Highlighter *syntaxHighlighter = nullptr;
     QListView *popup;
     QStringListModel *model;
     bool popupGrabbing;

--- a/HEN_HOUSE/egs++/view/egs_editor.h
+++ b/HEN_HOUSE/egs++/view/egs_editor.h
@@ -38,6 +38,7 @@
 #include <QtWidgets>
 
 #include "egs_input_struct.h"
+#include "egs_highlighter.h"
 
 class QPaintEvent;
 class QResizeEvent;
@@ -56,8 +57,9 @@ public:
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
     void setInputStruct(shared_ptr<EGS_InputStruct> inp);
-    void validateEntireInput();
+    void validateVisibleLines();
     void setDarkMode(bool isDarkMode);
+    void setHighlighter(EGS_Highlighter *h) { syntaxHighlighter = h; }
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -80,7 +82,7 @@ private:
     shared_ptr<EGS_BlockInput> getBlockInput(QString &blockTitle, QTextCursor cursor = QTextCursor());
     QString getBlockTitle(QTextCursor cursor = QTextCursor());
     QString getParentBlockTitle(QTextCursor cursor = QTextCursor());
-    QString getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag, bool searchUpstream = false);
+    QString getInputValue(QString inp, QTextBlock currentBlock, bool &foundTag, bool searchUpstream = false, int depth = 0);
     QTextBlock getBlockEnd(QTextBlock currentBlock);
     template <typename T>
     bool inputHasDependency(const shared_ptr<T>& inp);
@@ -92,11 +94,13 @@ private:
 
     QWidget *lineNumberArea;
     shared_ptr<EGS_InputStruct> inputStruct;
+    EGS_Highlighter *syntaxHighlighter = nullptr;
     QListView *popup;
     QStringListModel *model;
     bool popupGrabbing;
     bool isDarkMode = false;
     static constexpr int indentWidth = 4;
+    QTimer *validationDebounceTimer = nullptr;
 
     QDialog           *findDialog = nullptr;
     QLineEdit         *findEdit   = nullptr;

--- a/HEN_HOUSE/egs++/view/egs_highlighter.cpp
+++ b/HEN_HOUSE/egs++/view/egs_highlighter.cpp
@@ -59,15 +59,17 @@ bool EGS_Highlighter::isDarkMode() const {
         process.start("gsettings", {"get", "org.gnome.desktop.interface", "color-scheme"});
         process.waitForFinished(100);
         QString output = process.readAllStandardOutput();
-        if (output.contains("dark", Qt::CaseInsensitive))
+        if (output.contains("dark", Qt::CaseInsensitive)) {
             return true;
+        }
     }
     // Try KDE
     {
         QSettings kdeSettings(QDir::homePath() + "/.config/kdeglobals", QSettings::IniFormat);
         QString colorScheme = kdeSettings.value("General/ColorScheme", "").toString();
-        if (colorScheme.contains("dark", Qt::CaseInsensitive))
+        if (colorScheme.contains("dark", Qt::CaseInsensitive)) {
             return true;
+        }
     }
     // Fallback heuristic: check app palette brightness
     QColor bg = QApplication::palette().color(QPalette::Base);
@@ -83,8 +85,7 @@ bool EGS_Highlighter::isDarkMode() const {
 }
 
 EGS_Highlighter::EGS_Highlighter(QTextDocument *parent)
-    : QSyntaxHighlighter(parent)
-{
+    : QSyntaxHighlighter(parent) {
     bool dark = isDarkMode();
 
     // ---------- Define color palettes ----------

--- a/HEN_HOUSE/egs++/view/image_window.cpp
+++ b/HEN_HOUSE/egs++/view/image_window.cpp
@@ -632,7 +632,8 @@ void ImageWindow::wheelEvent(QWheelEvent *event) {
     if (stepSize == 0) {
         if (event->angleDelta().y() < 0) {
             stepSize = -1;
-        } else {
+        }
+        else {
             stepSize = 1;
         }
     }
@@ -641,7 +642,8 @@ void ImageWindow::wheelEvent(QWheelEvent *event) {
     if (stepSize == 0) {
         if (event->delta() < 0) {
             stepSize = -1;
-        } else {
+        }
+        else {
             stepSize = 1;
         }
     }

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -535,7 +535,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     egsinpEdit = new EGS_Editor();
     editorLayout->addWidget(egsinpEdit);
     highlighter = new EGS_Highlighter(egsinpEdit->document());
-    egsinpEdit->setHighlighter(highlighter);
     egsinpEdit->setDarkMode(highlighter->isDarkMode());
 
 #ifdef Q_OS_WIN
@@ -1194,6 +1193,11 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     // Defer loading the egsinp file into the editor until the user first opens the editor tab
     editorLoaded = false;
     egsinpEdit->clear();
+
+    // If already on the editor tab, repopulate immediately since currentChanged won't fire
+    if (tabWidget->currentWidget() == tab) {
+        QTimer::singleShot(0, this, &GeometryViewControl::ensureEditorLoaded);
+    }
 
     updateMainWindowTitle("egs_view ("+fileBasename+")");
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -141,6 +141,11 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         if (tabWidget->widget(index) == regionTab && !allowRegionSelection) {
             QTimer::singleShot(0, this, &GeometryViewControl::loadRegions);
         }
+        // On clicking the editor tab, load and validate the file content
+        // (deferred from loadInput to avoid blocking on large files)
+        if (tabWidget->widget(index) == tab && !editorLoaded) {
+            QTimer::singleShot(0, this, &GeometryViewControl::ensureEditorLoaded);
+        }
     });
 
     // Table cell changed
@@ -434,6 +439,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     positronColor = QColor(0,0,255);
     doseTransparency = EGS_Float(this->slider_dose->value()/100.);
     energyScaling = this->energyScalingCheckbox->isChecked();
+    editorLoaded = false;
     initColorSwatches();
 
     // Create gview as child (splitter will manage it)
@@ -529,6 +535,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     egsinpEdit = new EGS_Editor();
     editorLayout->addWidget(egsinpEdit);
     highlighter = new EGS_Highlighter(egsinpEdit->document());
+    egsinpEdit->setHighlighter(highlighter);
     egsinpEdit->setDarkMode(highlighter->isDarkMode());
 
 #ifdef Q_OS_WIN
@@ -761,43 +768,46 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             continue;
         }
 
+        // For each library, call getInputs() once and use the returned block title to determine the library type
+        getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
+        shared_ptr<EGS_BlockInput> inputBlock;
+        if (getInputs) {
+            inputBlock = getInputs();
+        }
+        const string blockTitle = inputBlock ? inputBlock->getTitle() : "";
+
         // Geometries
         createGeomFunction isGeom = (createGeomFunction) egs_lib.resolve("createGeometry");
-        if (isGeom) {
+        if (isGeom && egsEquivStr(blockTitle, "geometry")) {
 #ifdef EDITOR_DEBUG
             egsInformation(" Geometry %s\n",libName.toLatin1().data());
 #endif
+            geomDefPtr->addBlockInput(inputBlock);
 
-            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
-            if (getInputs) {
-
-                shared_ptr<EGS_BlockInput> geom = getInputs();
-                if (geom) {
-                    geomDefPtr->addBlockInput(geom);
-
-                    vector<shared_ptr<EGS_SingleInput>> singleInputs = geom->getSingleInputs();
-                    for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp->getValues();
-//                         egsInformation("  single %s\n", inp->getTag().c_str());
-//                         for (auto&& val : vals) {
-//                             egsInformation("      %s\n", val.c_str());
-//                         }
-                    }
-
-                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = geom->getBlockInputs();
-                    for (auto &block : inputBlocks) {
-                        //egsInformation("  block %s\n", block->getTitle().c_str());
-                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-                        for (auto &inp : singleInputs) {
-                            const vector<string> vals = inp->getValues();
-//                             egsInformation("   single %s\n", inp->getTag().c_str());
-//                             for (auto&& val : vals) {
-//                                 egsInformation("      %s\n", val.c_str());
-//                             }
-                        }
-                    }
+            /*
+            vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
+            for (auto &inp : singleInputs) {
+                const vector<string> vals = inp->getValues();
+                egsInformation("  single %s\n", inp->getTag().c_str());
+                for (auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
                 }
             }
+
+            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
+            for (auto &block : inputBlocks) {
+                egsInformation("  block %s\n", block->getTitle().c_str());
+                vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                for (auto &inp : singleInputs) {
+                    const vector<string> vals = inp->getValues();
+                     egsInformation("   single %s\n", inp->getTag().c_str());
+                     for (auto&& val : vals) {
+                         egsInformation("      %s\n", val.c_str());
+                     }
+                }
+            }
+            */
+
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = geomMenu->addAction(libName);
@@ -808,41 +818,35 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
         // Sources
         createSourceFunction isSource = (createSourceFunction) egs_lib.resolve("createSource");
-        if (isSource) {
+        if (isSource && egsEquivStr(blockTitle, "source")) {
 #ifdef EDITOR_DEBUG
             egsInformation(" Source %s\n",libName.toLatin1().data());
 #endif
+            srcDefPtr->addBlockInput(inputBlock);
 
-            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
-            if (getInputs) {
+            /*
+            vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
+            for (auto &inp : singleInputs) {
+                const vector<string> vals = inp->getValues();
+                egsInformation("  single %s\n", inp->getTag().c_str());
+                for (auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
+                }
+            }
 
-                shared_ptr<EGS_BlockInput> src = getInputs();
-                if (src) {
-                    srcDefPtr->addBlockInput(src);
-
-                    vector<shared_ptr<EGS_SingleInput>> singleInputs = src->getSingleInputs();
-                    for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp->getValues();
-//                         egsInformation("  single %s\n", inp->getTag().c_str());
-//                         for (auto&& val : vals) {
-//                             egsInformation("      %s\n", val.c_str());
-//                         }
-                    }
-
-                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = src->getBlockInputs();
-                    for (auto &block : inputBlocks) {
-                        //egsInformation("  block %s\n", block->getTitle().c_str());
-                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-                        for (auto &inp : singleInputs) {
-                            const vector<string> vals = inp->getValues();
-//                             egsInformation("   single %s\n", inp->getTag().c_str());
-//                             for (auto&& val : vals) {
-//                                 egsInformation("      %s\n", val.c_str());
-//                             }
-                        }
+            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
+            for (auto &block : inputBlocks) {
+                egsInformation("  block %s\n", block->getTitle().c_str());
+                vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                for (auto &inp : singleInputs) {
+                    const vector<string> vals = inp->getValues();
+                    egsInformation("   single %s\n", inp->getTag().c_str());
+                    for (auto&& val : vals) {
+                        egsInformation("      %s\n", val.c_str());
                     }
                 }
             }
+            */
 
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
@@ -854,41 +858,35 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
         // Shapes
         createShapeFunction isShape = (createShapeFunction) egs_lib.resolve("createShape");
-        if (isShape) {
+        if (isShape && egsEquivStr(blockTitle, "shape")) {
 #ifdef EDITOR_DEBUG
             egsInformation(" Shape %s\n",libName.toLatin1().data());
 #endif
+            inputStruct->addBlockInput(inputBlock);
 
-            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
-            if (getInputs) {
+            /*
+            vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
+            for (auto &inp : singleInputs) {
+                const vector<string> vals = inp->getValues();
+                egsInformation("  single %s\n", inp->getTag().c_str());
+                for (auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
+                }
+            }
 
-                shared_ptr<EGS_BlockInput> shape = getInputs();
-                if (shape) {
-                    inputStruct->addBlockInput(shape);
-
-                    vector<shared_ptr<EGS_SingleInput>> singleInputs = shape->getSingleInputs();
-                    for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp->getValues();
-//                         egsInformation("  single %s\n", inp->getTag().c_str());
-//                         for (auto&& val : vals) {
-//                             egsInformation("      %s\n", val.c_str());
-//                         }
-                    }
-
-                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = shape->getBlockInputs();
-                    for (auto &block : inputBlocks) {
-                        //egsInformation("  block %s\n", block->getTitle().c_str());
-                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-                        for (auto &inp : singleInputs) {
-                            const vector<string> vals = inp->getValues();
-//                             egsInformation("   single %s\n", inp->getTag().c_str());
-//                             for (auto&& val : vals) {
-//                                 egsInformation("      %s\n", val.c_str());
-//                             }
-                        }
+            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
+            for (auto &block : inputBlocks) {
+                egsInformation("  block %s\n", block->getTitle().c_str());
+                vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                for (auto &inp : singleInputs) {
+                    const vector<string> vals = inp->getValues();
+                    egsInformation("   single %s\n", inp->getTag().c_str());
+                    for (auto&& val : vals) {
+                        egsInformation("      %s\n", val.c_str());
                     }
                 }
             }
+            */
 
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
@@ -900,41 +898,36 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
         // Ausgab Objects
         createAusgabObjectFunction isAusgabObject = (createAusgabObjectFunction) egs_lib.resolve("createAusgabObject");
-        if (isAusgabObject) {
+        if (isAusgabObject && egsEquivStr(blockTitle, "ausgab object")) {
 #ifdef EDITOR_DEBUG
             egsInformation(" Ausgab %s\n",libName.toLatin1().data());
 #endif
+            ausDefPtr->addBlockInput(inputBlock);
 
-            getInputsFunction getInputs = (getInputsFunction) egs_lib.resolve("getInputs");
-            if (getInputs) {
+            /*
+            vector<shared_ptr<EGS_SingleInput>> singleInputs = inputBlock->getSingleInputs();
+            for (auto &inp : singleInputs) {
+                const vector<string> vals = inp->getValues();
+                egsInformation("   single %s\n", inp->getTag().c_str());
+                for (auto&& val : vals) {
+                    egsInformation("      %s\n", val.c_str());
+                }
+            }
 
-                shared_ptr<EGS_BlockInput> aus = getInputs();
-                if (aus) {
-                    ausDefPtr->addBlockInput(aus);
-
-                    vector<shared_ptr<EGS_SingleInput>> singleInputs = aus->getSingleInputs();
-                    for (auto &inp : singleInputs) {
-                        const vector<string> vals = inp->getValues();
-//                         egsInformation("   single %s\n", inp->getTag().c_str());
-//                         for (auto&& val : vals) {
-//                             egsInformation("      %s\n", val.c_str());
-//                         }
-                    }
-
-                    vector<shared_ptr<EGS_BlockInput>> inputBlocks = aus->getBlockInputs();
-                    for (auto &block : inputBlocks) {
-                        //egsInformation("  block %s\n", block->getTitle().c_str());
-                        vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-                        for (auto &inp : singleInputs) {
-                            const vector<string> vals = inp->getValues();
-//                             egsInformation("   single %s\n", inp->getTag().c_str());
-//                             for (auto&& val : vals) {
-//                                 egsInformation("      %s\n", val.c_str());
-//                             }
-                        }
+            vector<shared_ptr<EGS_BlockInput>> inputBlocks = inputBlock->getBlockInputs();
+            for (auto &block : inputBlocks) {
+                egsInformation("  block %s\n", block->getTitle().c_str());
+                vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                for (auto &inp : singleInputs) {
+                    const vector<string> vals = inp->getValues();
+                    egsInformation("   single %s\n", inp->getTag().c_str());
+                    for (auto&& val : vals) {
+                        egsInformation("      %s\n", val.c_str());
                     }
                 }
             }
+            */
+
             getExampleFunction getExample = (getExampleFunction) egs_lib.resolve("getExample");
             if (getExample) {
                 QAction *action = ausgabMenu->addAction(libName);
@@ -1204,11 +1197,9 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
     // See if any of the dose checkboxes are checked
     doseCheckbox_toggled();
 
-    // Load the egsinp file into the editor
-    if (file.open(QFile::ReadOnly | QFile::Text)) {
-        egsinpEdit->setPlainText(file.readAll());
-        egsinpEdit->validateEntireInput();
-    }
+    // Defer loading the egsinp file into the editor until the user first opens the editor tab
+    editorLoaded = false;
+    egsinpEdit->clear();
 
     updateMainWindowTitle("egs_view ("+fileBasename+")");
 
@@ -1251,6 +1242,19 @@ void GeometryViewControl::reloadInput() {
     if (!loadInput(true)) {
         egsWarning("GeometryViewControl::reloadInput: Error: The geometry is not correctly defined\n");
     }
+}
+
+void GeometryViewControl::ensureEditorLoaded() {
+    if (editorLoaded) {
+        return;
+    }
+
+    QFile file(filename);
+    if (file.open(QFile::ReadOnly | QFile::Text)) {
+        egsinpEdit->setPlainText(file.readAll());
+        egsinpEdit->validateVisibleLines();
+    }
+    editorLoaded = true;
 }
 
 void GeometryViewControl::saveConfig() {
@@ -1928,6 +1932,11 @@ void GeometryViewControl::saveEgsinp() {
 #ifdef VIEW_DEBUG
     egsWarning("In saveEgsinp()\n");
 #endif
+
+    // Make sure the editor has been populated before we read its content.
+    // If the user saves without ever opening the editor tab the text would
+    // otherwise be empty.
+    ensureEditorLoaded();
 
     // Prompt the user for a filename and open the file for writing
     QString newFilename = QFileDialog::getSaveFileName(this, "Save input file as...", filename);
@@ -4374,7 +4383,10 @@ void GeometryViewControl::setApplication() {
 
     selectedApplication = newlySelectedApp;
     egsinpEdit->setInputStruct(inputStruct);
-    egsinpEdit->validateEntireInput();
+    // Only re-validate if the editor has already been loaded; if not, the correct inputStruct will be used when it is lazily loaded later.
+    if (editorLoaded) {
+        egsinpEdit->validateVisibleLines();
+    }
 }
 
 vector<string> findDensityCorrectionInputs(string compound_dir) {

--- a/HEN_HOUSE/egs++/view/viewcontrol.cpp
+++ b/HEN_HOUSE/egs++/view/viewcontrol.cpp
@@ -91,7 +91,7 @@ typedef EGS_AusgabObject *(*createAusgabObjectFunction)();
 typedef shared_ptr<EGS_InputStruct> (*getAppInputsFunction)();
 typedef shared_ptr<EGS_InputStruct> (*getAppSpecificInputsFunction)();
 typedef shared_ptr<EGS_BlockInput> (*getInputsFunction)();
-typedef string (*getExampleFunction)();
+typedef string(*getExampleFunction)();
 
 #ifdef WIN32
     #ifdef CYGWIN
@@ -137,7 +137,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     connect(applyPosition, &QPushButton::clicked, this, &GeometryViewControl::setLookPosition);
 
     // On clicking the region tab, load the list of regions
-    connect(tabWidget, &QTabWidget::currentChanged, this, [this](int index){
+    connect(tabWidget, &QTabWidget::currentChanged, this, [this](int index) {
         if (tabWidget->widget(index) == regionTab && !allowRegionSelection) {
             QTimer::singleShot(0, this, &GeometryViewControl::loadRegions);
         }
@@ -222,7 +222,7 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
     connect(actionOpen_dose, &QAction::triggered,
             this, &GeometryViewControl::loadDose);
 
-    connect(actionOpen_settings, &QAction::triggered, this, [this](){
+    connect(actionOpen_settings, &QAction::triggered, this, [this]() {
         loadConfig();
     });
 
@@ -603,10 +603,6 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
     EGS_Library *existingApp = nullptr;
     for (const auto &lib : binLibraries) {
-#ifdef VIEW_DEBUG
-        egsWarning("GeometryViewControl:: Checking if we can load %s/%s\n", dso_dir.c_str(), lib.toLatin1().data());
-#endif
-
         // Remove the extension
         QString libName = lib.left(lib.lastIndexOf("."));
 
@@ -615,15 +611,14 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
         //egsInformation("Trying %s\n", libName.toLatin1().data());
 
         // Check if the application has the getAppSpecificInputs, and only add it to the drop-down menu if it does
-        EGS_Library* app_lib = new EGS_Library(libName.toLatin1().data(), lib_dir.c_str());
+        EGS_Library *app_lib = new EGS_Library(libName.toLatin1().data(), lib_dir.c_str());
+        if (!existingApp) {
+            existingApp = app_lib;
+        }
         if (app_lib->load()) {
             getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib->resolve("getAppSpecificInputs");
 
             if (getAppInputs) {
-                if(!existingApp) {
-                    existingApp = app_lib;
-                }
-
                 // Adds the button to the menu
                 QAction *action = exampleMenu2->addAction(libName);
                 action->setData(libName);
@@ -638,10 +633,9 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
 
     // ============
     // Application level inputs (but not app specific)
-    if(existingApp) {
+    if (existingApp) {
         getAppInputsFunction getAppInputs = (getAppInputsFunction) existingApp->resolve("getAppInputs");
-
-        if(getAppInputs) {
+        if (getAppInputs) {
 
             // before this was a BlockInput, now it is a InputStruct
             shared_ptr<EGS_InputStruct> app = getAppInputs();
@@ -649,28 +643,28 @@ GeometryViewControl::GeometryViewControl(QWidget *parent, const char *name)
             if (app) {
                 inputStruct->addBlockInputs(app->getBlockInputs());
 
-    //                     vector<shared_ptr<EGS_SingleInput>> singleInputs = app->getSingleInputs();
-    //                     for (auto &inp : singleInputs) {
-    //                         const vector<string> vals = inp->getValues();
-    // //                         egsInformation("  single %s\n", inp->getTag().c_str());
-    // //                         for (auto&& val : vals) {
-    // //                             egsInformation("      %s\n", val.c_str());
-    // //                         }
-    //                     }
+                //                     vector<shared_ptr<EGS_SingleInput>> singleInputs = app->getSingleInputs();
+                //                     for (auto &inp : singleInputs) {
+                //                         const vector<string> vals = inp->getValues();
+                // //                         egsInformation("  single %s\n", inp->getTag().c_str());
+                // //                         for (auto&& val : vals) {
+                // //                             egsInformation("      %s\n", val.c_str());
+                // //                         }
+                //                     }
 
-    //                 vector<shared_ptr<EGS_BlockInput>> inputBlocks = app->getBlockInputs();
-    //                 for (auto &block : inputBlocks) {
-    //                     egsInformation("  block %s\n", block->getTitle().c_str());
-    //                     vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
-    //                     inputStruct->addBlockInput(block);
-    //                     for (auto &inp : singleInputs) {
-    //                         const vector<string> vals = inp->getValues();
-    //                         egsInformation("   single %s\n", inp->getTag().c_str());
-    //                         for (auto&& val : vals) {
-    //                             egsInformation("      %s\n", val.c_str());
-    //                         }
-    //                     }
-    //                 }
+                //                 vector<shared_ptr<EGS_BlockInput>> inputBlocks = app->getBlockInputs();
+                //                 for (auto &block : inputBlocks) {
+                //                     egsInformation("  block %s\n", block->getTitle().c_str());
+                //                     vector<shared_ptr<EGS_SingleInput>> singleInputs = block->getSingleInputs();
+                //                     inputStruct->addBlockInput(block);
+                //                     for (auto &inp : singleInputs) {
+                //                         const vector<string> vals = inp->getValues();
+                //                         egsInformation("   single %s\n", inp->getTag().c_str());
+                //                         for (auto&& val : vals) {
+                //                             egsInformation("      %s\n", val.c_str());
+                //                         }
+                //                     }
+                //                 }
             }
         }
         //     getAppInputs(inputStruct);
@@ -1080,12 +1074,12 @@ bool GeometryViewControl::loadInput(bool reloading, EGS_BaseGeometry *simGeom) {
 
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             QMessageBox::critical(this, "Geometry error",
-                          "The geometry is not correctly defined. Edit the input file and reload.",
-                          QMessageBox::StandardButton::Ok);
+                                  "The geometry is not correctly defined. Edit the input file and reload.",
+                                  QMessageBox::StandardButton::Ok);
 #else
             QMessageBox::critical(this, "Geometry error",
-                          "The geometry is not correctly defined. Edit the input file and reload.",
-                          QMessageBox::Ok, 0, 0);
+                                  "The geometry is not correctly defined. Edit the input file and reload.",
+                                  QMessageBox::Ok, 0, 0);
 #endif
 
             return false;
@@ -1445,12 +1439,12 @@ void GeometryViewControl::loadConfig(QString configFilename) {
         if (input->setContentFromFile(configFilename.toLatin1().data())) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             QMessageBox::critical(this, "Config file read error",
-                          "Failed to open the config file for reading.",
-                          QMessageBox::StandardButton::Ok);
+                                  "Failed to open the config file for reading.",
+                                  QMessageBox::StandardButton::Ok);
 #else
             QMessageBox::critical(this, "Config file read error",
-                          "Failed to open the config file for reading.",
-                          QMessageBox::Ok, 0, 0);
+                                  "Failed to open the config file for reading.",
+                                  QMessageBox::Ok, 0, 0);
 #endif
             delete input;
             return;
@@ -2995,12 +2989,12 @@ int GeometryViewControl::setGeometry(
     if (nmed < 1) {
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
         QMessageBox::critical(this, "Geometry error",
-                          "The geometry defines no media",
-                          QMessageBox::StandardButton::Ok);
+                              "The geometry defines no media",
+                              QMessageBox::StandardButton::Ok);
 #else
         QMessageBox::critical(this, "Geometry error",
-                          "The geometry defines no media",
-                          QMessageBox::Ok, 0, 0);
+                              "The geometry defines no media",
+                              QMessageBox::Ok, 0, 0);
 #endif
         delete [] saveColors;
         delete [] saveName;
@@ -3182,12 +3176,12 @@ int GeometryViewControl::setGeometry(
             qApp->processEvents();
 #if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
             QMessageBox::critical(this, "Geometry error",
-                          "Failed to find a point that is inside the geometry",
-                          QMessageBox::StandardButton::Ok);
+                                  "Failed to find a point that is inside the geometry",
+                                  QMessageBox::StandardButton::Ok);
 #else
             QMessageBox::critical(this, "Geometry error",
-                          "Failed to find a point that is inside the geometry",
-                          QMessageBox::Ok, 0, 0);
+                                  "Failed to find a point that is inside the geometry",
+                                  QMessageBox::Ok, 0, 0);
 #endif
             return 3;
         }
@@ -4332,8 +4326,8 @@ void GeometryViewControl::setApplication() {
         inputStruct->removeBlockInputByApp(selectedApplication);
 
         // Delete the previous application example
-        QList<QAction*> actions = appMenu->actions();
-        for (QAction* action : actions) {
+        QList<QAction *> actions = appMenu->actions();
+        for (QAction *action : actions) {
             //if (action->text() == "egs_current_app") {
             appMenu->removeAction(action);
             delete action;
@@ -4350,7 +4344,8 @@ void GeometryViewControl::setApplication() {
         EGS_Library app_lib(newlySelectedApp.c_str(),lib_dir.c_str());
         if (!app_lib.load()) {
             egsWarning("Failed to load inputs and example for application\n");
-        } else {
+        }
+        else {
             getAppInputsFunction getAppInputs = (getAppInputsFunction) app_lib.resolve("getAppSpecificInputs");
 
             if (getAppInputs) {
@@ -4358,7 +4353,8 @@ void GeometryViewControl::setApplication() {
                 if (app) {
                     inputStruct->addBlockInputs(app->getBlockInputs());
                 }
-            } else {
+            }
+            else {
                 egsInformation("  The selected application doesn't support input autocompletion.\n");
             }
 
@@ -4373,9 +4369,9 @@ void GeometryViewControl::setApplication() {
     }
 
     // Update the "Application: ..." menu bar title
-    QList<QAction*> menuBarActions = editorLayout->menuBar()->actions();
-    for (QAction* action : menuBarActions) {
-        QMenu* retrievedMenu = action->menu();
+    QList<QAction *> menuBarActions = editorLayout->menuBar()->actions();
+    for (QAction *action : menuBarActions) {
+        QMenu *retrievedMenu = action->menu();
         if (retrievedMenu && retrievedMenu->title() == QString::fromStdString("Application (" + selectedApplication) + ") ▸") {
             retrievedMenu->setTitle(QString::fromStdString("Application (" + newlySelectedApp) + ") ▸");
         }
@@ -4414,7 +4410,8 @@ vector<string> findDensityCorrectionInputs(string compound_dir) {
             }
         }
         closedir(dir);
-    } else {
+    }
+    else {
         egsInformation("Failed to open density correction files directory\n");
     }
 

--- a/HEN_HOUSE/egs++/view/viewcontrol.h
+++ b/HEN_HOUSE/egs++/view/viewcontrol.h
@@ -165,6 +165,7 @@ public slots:
 
 private slots:
     void loadRegions();
+    void ensureEditorLoaded();
 
 private:
 
@@ -227,7 +228,8 @@ private:
     bool isPlaying;
     vector<bool> show_regions;
     bool    allowRegionSelection,
-            energyScaling;
+            energyScaling,
+            editorLoaded;
     vector<vector<EGS_Float>> scoreArrays;
     vector<string> geometryNames;
     vector<string> inputExamples;


### PR DESCRIPTION
Fixes performance issues for very large .egsinp files in egs_editor. This solves lag issues in egs_view for such files, by lazy-loading the input file, and only syntax checking on the current view window in the editor.

This also fixes an issue where all shared libraries inserted capitalized library names in egs_editor, which resulted in a crash when actually running the simulation. Now the capitalization of the library names matches the actual shared library files.

Finally, it also adds in egs_editor autocomplete support for some libraries that were not supported yet (anything that was new in the develop branch since egs_editor was added). This looks like changes across a lot of files, but the change is very minor and only impacts egs_view.