### PR TITLE
Fix egs_configure and windows compilation with estar

### DIFF
--- a/HEN_HOUSE/egs++/estar/estar.cpp
+++ b/HEN_HOUSE/egs++/estar/estar.cpp
@@ -49,6 +49,16 @@
 #include "estar_dataTables.h"
 #include "egs_functions.h"
 
+#if defined(WIN32) || defined(_WIN32)
+#  ifdef BUILD_DLL
+#    define ESTAR_EXPORT __declspec(dllexport)
+#  else
+#    define ESTAR_EXPORT __declspec(dllimport)
+#  endif
+#else
+#  define ESTAR_EXPORT
+#endif
+
 /*
     The purpose of this module is to process the arrays and data received from
     pegs4_routine.mortran and then to call the main function (estarCalculation)
@@ -165,7 +175,7 @@ public:
 
 #define egsEstar F77_OBJ_(egs_estar,EGS_ESTAR)
 
-extern __extc__ int egsEstar(char *formulaStr,
+extern __extc__ ESTAR_EXPORT int egsEstar(char *formulaStr,
                              float *massFraction,
                              float *numOfAtoms,
                              float *mediaDensity,
@@ -284,7 +294,7 @@ extern __extc__ int egsEstar(char *formulaStr,
 
 #define egsCompoundsToElements F77_OBJ_(egs_compoundstoelements,EGS_COMPOUNDSTOELEMENTS)
 
-extern __extc__ int egsCompoundsToElements(char *formulaStr,
+extern __extc__ ESTAR_EXPORT int egsCompoundsToElements(char *formulaStr,
         double *massFraction,
         float *mediaDensity,
         char *elementStr,

--- a/HEN_HOUSE/gui/egs_configure/egs_install.h
+++ b/HEN_HOUSE/gui/egs_configure/egs_install.h
@@ -523,6 +523,8 @@ static const char spec_file[]={
 #define NO_IAEA_VARS "IAEA_LIB = \n"\
 "IAEA_PHSP_MACROS = \n"
 
+#define EGSPP_VARS "EGSPP_LIB = $lib_link1 $link2_prefix_egspp$link2_suffix \n"
+
 static const char egspp_spec_file[]={
 "#*************************************************************************\n"\
 "#\n"\

--- a/HEN_HOUSE/gui/egs_configure/egs_install_conf.cpp
+++ b/HEN_HOUSE/gui/egs_configure/egs_install_conf.cpp
@@ -1552,6 +1552,14 @@ void QInstallPage::finalize_cpp(){
 
      append2file(the_iaea.toLatin1(),specFile.toLatin1());
 
+    QString egspp_lib;
+    egspp_lib = QString(EGSPP_VARS);
+    egspp_lib.replace(QString("$lib_link1"), cpp->dsoPath());
+    egspp_lib.replace((QString)"$link2_prefix_", cpp->LinkPrefix() );
+    egspp_lib.replace((QString)"$link2_suffix", cpp->LinkSuffix() );
+
+    append2file(egspp_lib.toLatin1(),specFile.toLatin1());
+
     //configCPPProgressBar->setProgress( configCPPProgressBar->totalSteps() );
     emit cppBuildFinalized();
 }


### PR DESCRIPTION
The ESTAR overhaul in PR https://github.com/nrc-cnrc/EGSnrc/pull/1396 had compilation bugs in egs_configure and on Windows. This resolves those issues.

Merging this in without team review to expedite the 2026 release.
